### PR TITLE
Refactor speedlimit layer

### DIFF
--- a/UI/src/view/SpeedLimitLayer.js
+++ b/UI/src/view/SpeedLimitLayer.js
@@ -20,6 +20,10 @@ window.SpeedLimitLayer = function(params) {
       eventbus.trigger('layer:speedLimit:' + event);
     });
   };
+  this.removeLayerFeatures = function() {
+    vectorLayer.removeAllFeatures();
+    indicatorLayer.clearMarkers();
+  };
   var me = this;
 
   var SpeedLimitCutter = function(vectorLayer, collection) {

--- a/UI/src/view/SpeedLimitLayer.js
+++ b/UI/src/view/SpeedLimitLayer.js
@@ -9,13 +9,22 @@ window.SpeedLimitLayer = function(params) {
       layerName = 'speedLimit';
 
   Layer.call(this, layerName, roadLayer);
-  this.deactivateSelection = function() {};
-  this.activateSelection = function() {};
+  this.activateSelection = function() {
+    updateMassUpdateHandlerState();
+    doubleClickSelectControl.activate();
+  };
+  this.deactivateSelection = function() {
+    updateMassUpdateHandlerState();
+    doubleClickSelectControl.deactivate();
+  };
   this.minZoomForContent = zoomlevels.minZoomForAssets;
+  this.layerStarted = function(eventListener) {
+    bindEvents(eventListener);
+    changeTool(application.getSelectedTool());
+  };
   this.refreshView = function(event) {
     vectorLayer.setVisibility(true);
     adjustStylesByZoomLevel(map.getZoom());
-    start();
     collection.fetch(map.getExtent()).then(function() {
       eventbus.trigger('layer:speedLimit:' + event);
     });
@@ -26,7 +35,7 @@ window.SpeedLimitLayer = function(params) {
   };
   var me = this;
 
-  var SpeedLimitCutter = function(vectorLayer, collection) {
+  var SpeedLimitCutter = function(vectorLayer, collection, eventListener) {
     var scissorFeatures = [];
     var CUT_THRESHOLD = 20;
 
@@ -133,7 +142,6 @@ window.SpeedLimitLayer = function(params) {
     };
   };
 
-  var eventListener = _.extend({running: false}, eventbus);
   var uiState = { zoomLevel: 9 };
 
   var combineFilters = function(filters) {
@@ -276,7 +284,7 @@ window.SpeedLimitLayer = function(params) {
   var indicatorLayer = new OpenLayers.Layer.Boxes('adjacentLinkIndicators');
   map.addLayer(indicatorLayer);
 
-  var speedLimitCutter = new SpeedLimitCutter(vectorLayer, collection);
+  var speedLimitCutter = new SpeedLimitCutter(vectorLayer, collection, me.eventListener);
 
   var highlightMultipleSpeedLimitFeatures = function() {
     var partitioned = _.groupBy(vectorLayer.features, function(feature) {
@@ -345,7 +353,7 @@ window.SpeedLimitLayer = function(params) {
 
     vectorLayer.styleMap = browseStyleMap;
     vectorLayer.redraw();
-    eventListener.stopListening(eventbus, 'map:clicked', displayConfirmMessage);
+    me.eventListener.stopListening(eventbus, 'map:clicked', displayConfirmMessage);
   };
 
   var update = function(zoom, boundingBox) {
@@ -384,23 +392,6 @@ window.SpeedLimitLayer = function(params) {
     }
   };
 
-  var start = function() {
-    if (!eventListener.running) {
-      eventListener.running = true;
-      bindEvents();
-      changeTool(application.getSelectedTool());
-      updateMassUpdateHandlerState();
-    }
-  };
-
-  var stop = function() {
-    doubleClickSelectControl.deactivate();
-    updateMassUpdateHandlerState();
-    speedLimitCutter.deactivate();
-    eventListener.stopListening(eventbus);
-    eventListener.running = false;
-  };
-
   var activateBrowseStyle = function() {
     _.each(vectorLayer.features, function(feature) {
       selectControl.unhighlight(feature);
@@ -416,7 +407,7 @@ window.SpeedLimitLayer = function(params) {
     vectorLayer.redraw();
   };
 
-  var bindEvents = function() {
+  var bindEvents = function(eventListener) {
     eventListener.listenTo(eventbus, 'speedLimits:fetched', redrawSpeedLimits);
     eventListener.listenTo(eventbus, 'tool:changed', changeTool);
     eventListener.listenTo(eventbus, 'speedLimit:selected speedLimit:multiSelected', handleSpeedLimitSelected);
@@ -449,8 +440,8 @@ window.SpeedLimitLayer = function(params) {
 
   var handleSpeedLimitChanged = function(selectedSpeedLimit) {
     doubleClickSelectControl.deactivate();
-    eventListener.stopListening(eventbus, 'map:clicked', displayConfirmMessage);
-    eventListener.listenTo(eventbus, 'map:clicked', displayConfirmMessage);
+    me.eventListener.stopListening(eventbus, 'map:clicked', displayConfirmMessage);
+    me.eventListener.listenTo(eventbus, 'map:clicked', displayConfirmMessage);
     var selectedSpeedLimitFeatures = _.filter(vectorLayer.features, function(feature) { return selectedSpeedLimit.isSelected(feature.attributes); });
     vectorLayer.removeFeatures(selectedSpeedLimitFeatures);
     drawSpeedLimits(selectedSpeedLimit.get());
@@ -458,7 +449,7 @@ window.SpeedLimitLayer = function(params) {
 
   var handleSpeedLimitCancelled = function() {
     doubleClickSelectControl.activate();
-    eventListener.stopListening(eventbus, 'map:clicked', displayConfirmMessage);
+    me.eventListener.stopListening(eventbus, 'map:clicked', displayConfirmMessage);
     redrawSpeedLimits(collection.getAll());
   };
 
@@ -585,9 +576,9 @@ window.SpeedLimitLayer = function(params) {
   };
 
   var reset = function() {
-    stop();
     selectControl.unselectAll();
     vectorLayer.styleMap = browseStyleMap;
+    speedLimitCutter.deactivate();
   };
 
   var show = function(map) {

--- a/UI/src/view/SpeedLimitLayer.js
+++ b/UI/src/view/SpeedLimitLayer.js
@@ -279,6 +279,7 @@ window.SpeedLimitLayer = function(params) {
 
   var vectorLayer = new OpenLayers.Layer.Vector(layerName, { styleMap: browseStyleMap });
   vectorLayer.setOpacity(1);
+  vectorLayer.setVisibility(false);
   map.addLayer(vectorLayer);
 
   var indicatorLayer = new OpenLayers.Layer.Boxes('adjacentLinkIndicators');


### PR DESCRIPTION
Fix the TODO comment to stop listening the map:moved event when layer not selected.

While at it, refactor the speed limit layer to let the base class Layer to control starting, stoping, refreshing etc. by implementing the base class template functions instead of having own overlapping implementation.