### PR TITLE
Add link geometry to change API

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/SpeedLimitService.scala
@@ -57,7 +57,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, vvhClient: VVHClient, roadLi
     }
   }
 
-  def getChanged(sinceDate: DateTime) = {
+  def getChanged(sinceDate: DateTime): Seq[SpeedLimit] = {
     val persistedSpeedLimits = withDynTransaction {
       dao.getSpeedLimitsChangedSince(sinceDate)
     }

--- a/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -2,11 +2,10 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.Digiroad2Context._
 import fi.liikennevirasto.digiroad2.asset.Asset._
-import fi.liikennevirasto.digiroad2.linearasset.SpeedLimit
 import org.joda.time.DateTime
 import org.json4s.{DefaultFormats, Formats}
+import org.scalatra.ScalatraServlet
 import org.scalatra.json.JacksonJsonSupport
-import org.scalatra.{BadRequest, ScalatraServlet}
 
 
 class ChangeApi extends ScalatraServlet with JacksonJsonSupport with AuthenticationSupport {
@@ -17,48 +16,31 @@ class ChangeApi extends ScalatraServlet with JacksonJsonSupport with Authenticat
     contentType = formats("json")
   }
 
-  /**
-    * Api that fetches changes for municipality after first adjusting to latest geometry from vvh
-    */
-  get("/speedLimits2") {
-    val since = DateTime.parse(params("since"))
-    params.get("municipality").map { municipality =>
-      changesToApi(since, speedLimitService.get(municipality.toInt).filter(speedLimitIsChanged(since)))
-    }.getOrElse {
-      BadRequest("Missing mandatory 'municipality' parameter")
-    }
-  }
-
-  /**
-    * Api that simply fetches all changed speed limits from db
-    */
   get("/speedLimits") {
     val since = DateTime.parse(params("since"))
-    changesToApi(since, speedLimitService.getChanged(since))
+    changedSpeedLimitsToApi(since, speedLimitService.getChanged(since))
   }
 
-  private def speedLimitIsChanged(since: DateTime)(speedLimit: SpeedLimit) = {
-    Seq(speedLimit.createdDateTime, speedLimit.modifiedDateTime)
-      .flatten
-      .exists(_.isAfter(since))
-  }
-
-  private def changesToApi(since: DateTime, speedLimits: Seq[SpeedLimit]) = {
-    val (addedSpeedLimits, updatedSpeedLimits) = speedLimits.partition { speedLimit =>
-      speedLimit.createdDateTime match {
-        case None => false
-        case Some(createdDate) => createdDate.isAfter(since)
+  private def changedSpeedLimitsToApi(since: DateTime, speedLimits: Seq[ChangedSpeedLimit]) = {
+    val (addedSpeedLimits, updatedSpeedLimits) =
+      speedLimits.partition { case ChangedSpeedLimit(speedLimit, link) =>
+        speedLimit.createdDateTime match {
+          case None => false
+          case Some(createdDate) => createdDate.isAfter(since)
+        }
       }
-    }
 
     Map("added" -> addedSpeedLimits.map(speedLimitToApi),
       "updated"  -> updatedSpeedLimits.map(speedLimitToApi))
   }
 
-  private def speedLimitToApi(speedLimit: SpeedLimit) = {
+  private def speedLimitToApi(changedSpeedLimit: ChangedSpeedLimit) = {
+    val ChangedSpeedLimit(speedLimit, link) = changedSpeedLimit
+
     Map("id" -> speedLimit.id,
       "value" -> speedLimit.value,
       "linkId" -> speedLimit.linkId,
+      "linkGeometry" -> link.geometry,
       "sideCode" -> speedLimit.sideCode.value,
       "startMeasure" -> speedLimit.startMeasure,
       "endMeasure" -> speedLimit.endMeasure,


### PR DESCRIPTION
We will need the whole link geometry for changed assets (speed limits at this moment) when we convert to the eventual Rosatte format. Included:

- For each changed asset, include the link geometry where the asset resides to the API response.
- Remove alternative API endpoint.
- Add type annotations where useful.