### PR TITLE
Include the link type and functional class for changed speed limit in change api

### DIFF
--- a/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -41,6 +41,8 @@ class ChangeApi extends ScalatraServlet with JacksonJsonSupport with Authenticat
       "value" -> speedLimit.value,
       "linkId" -> speedLimit.linkId,
       "linkGeometry" -> link.geometry,
+      "linkFunctionalClass" -> link.functionalClass,
+      "linkType" -> link.linkType,
       "sideCode" -> speedLimit.sideCode.value,
       "startMeasure" -> speedLimit.startMeasure,
       "endMeasure" -> speedLimit.endMeasure,


### PR DESCRIPTION
Open LR encoding requires the roadlinks:
  -geometry
  -link type
  -functional class

Open LR encoding will be performed outside OTH. The simplest approach is to embed the relevant information into each change info instead of having to request road link information separately.