### PR TITLE
Filter geometry adjustements from change api

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAsset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAsset.scala
@@ -101,7 +101,3 @@ case class PersistedLinearAsset(id: Long, linkId: Long, sideCode: Int, value: Op
 
 case class NewLinearAsset(linkId: Long, startMeasure: Double, endMeasure: Double, value: Value, sideCode: Int,
                           vvhTimeStamp: Long, geomModifiedDate: Option[DateTime])
-
-object Lol {
-  val vvhGenerated = "vvh_generated"
-}

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAsset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAsset.scala
@@ -101,3 +101,7 @@ case class PersistedLinearAsset(id: Long, linkId: Long, sideCode: Int, value: Op
 
 case class NewLinearAsset(linkId: Long, startMeasure: Double, endMeasure: Double, value: Value, sideCode: Int,
                           vvhTimeStamp: Long, geomModifiedDate: Option[DateTime])
+
+object Lol {
+  val vvhGenerated = "vvh_generated"
+}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/LinearAssetService.scala
@@ -28,7 +28,7 @@ object LinearAssetTypes {
     case ExitNumberAssetTypeId => exitNumberPropertyId
     case _ => numericValuePropertyId
   }
-  val VvhGenereated = "vvh_generated"
+  val VvhGenerated = "vvh_generated"
 }
 
 case class ChangedLinearAsset(linearAsset: PieceWiseLinearAsset, link: RoadLink)
@@ -251,7 +251,7 @@ trait LinearAssetOperations {
     withDynTransaction{
       newLinearAssets.foreach{ linearAsset =>
         val id = dao.createLinearAsset(linearAsset.typeId, linearAsset.linkId, linearAsset.expired, linearAsset.sideCode,
-          linearAsset.startMeasure, linearAsset.endMeasure, linearAsset.createdBy.getOrElse(LinearAssetTypes.VvhGenereated))
+          linearAsset.startMeasure, linearAsset.endMeasure, linearAsset.createdBy.getOrElse(LinearAssetTypes.VvhGenerated))
         linearAsset.value match {
           case Some(NumericValue(intValue)) =>
             dao.insertValue(id, LinearAssetTypes.numericValuePropertyId, intValue)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/LinearAssetService.scala
@@ -28,6 +28,7 @@ object LinearAssetTypes {
     case ExitNumberAssetTypeId => exitNumberPropertyId
     case _ => numericValuePropertyId
   }
+  val VvhGenereated = "vvh_generated"
 }
 
 case class ChangedLinearAsset(linearAsset: PieceWiseLinearAsset, link: RoadLink)
@@ -250,7 +251,7 @@ trait LinearAssetOperations {
     withDynTransaction{
       newLinearAssets.foreach{ linearAsset =>
         val id = dao.createLinearAsset(linearAsset.typeId, linearAsset.linkId, linearAsset.expired, linearAsset.sideCode,
-          linearAsset.startMeasure, linearAsset.endMeasure, linearAsset.createdBy.getOrElse("vvh_generated"))
+          linearAsset.startMeasure, linearAsset.endMeasure, linearAsset.createdBy.getOrElse(LinearAssetTypes.VvhGenereated))
         linearAsset.value match {
           case Some(NumericValue(intValue)) =>
             dao.insertValue(id, LinearAssetTypes.numericValuePropertyId, intValue)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/SpeedLimitService.scala
@@ -232,7 +232,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, vvhClient: VVHClient, roadLi
     withDynTransaction {
       val (newlimits, changedlimits) = limits.partition(_.id <= 0)
       newlimits.foreach { limit =>
-        dao.createSpeedLimit(limit.createdBy.getOrElse("vvh_generated"), limit.linkId, (limit.startMeasure, limit.endMeasure),
+        dao.createSpeedLimit(limit.createdBy.getOrElse(LinearAssetTypes.VvhGenereated), limit.linkId, (limit.startMeasure, limit.endMeasure),
           limit.sideCode, limit.value.get.value, Some(limit.vvhTimeStamp), limit.createdDateTime, limit.modifiedBy,
           limit.modifiedDateTime)
       }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/SpeedLimitService.scala
@@ -232,7 +232,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, vvhClient: VVHClient, roadLi
     withDynTransaction {
       val (newlimits, changedlimits) = limits.partition(_.id <= 0)
       newlimits.foreach { limit =>
-        dao.createSpeedLimit(limit.createdBy.getOrElse(LinearAssetTypes.VvhGenereated), limit.linkId, (limit.startMeasure, limit.endMeasure),
+        dao.createSpeedLimit(limit.createdBy.getOrElse(LinearAssetTypes.VvhGenerated), limit.linkId, (limit.startMeasure, limit.endMeasure),
           limit.sideCode, limit.value.get.value, Some(limit.vvhTimeStamp), limit.createdDateTime, limit.modifiedBy,
           limit.modifiedDateTime)
       }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/oracle/OracleLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/oracle/OracleLinearAssetDao.scala
@@ -421,11 +421,9 @@ class OracleLinearAssetDao(val vvhClient: VVHClient) {
          and (
            (a.valid_to > $sinceDate and a.valid_to <= $untilDate)
            or
-           (a.modified_date > $sinceDate and a.modified_date <= $untilDate)
+           (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> 'vvh_generated')
            or
-           (a.created_date > $sinceDate and a.created_date <= $untilDate)
-           or
-           (pos.modified_date > $sinceDate and pos.modified_date <= $untilDate)
+           (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> 'vvh_generated')
          )
     """.as[(Long, Long, SideCode, Option[Int], Double, Double, Option[String], Option[DateTime], Option[String], Option[DateTime], Long, Option[DateTime], Boolean)].list
 
@@ -449,11 +447,9 @@ class OracleLinearAssetDao(val vvhClient: VVHClient) {
           and (
             (a.valid_to > $sinceDate and a.valid_to <= $untilDate)
             or
-            (a.modified_date > $sinceDate and a.modified_date <= $untilDate)
+            (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> 'vvh_generated')
             or
-            (a.created_date > $sinceDate and a.created_date <= $untilDate)
-            or
-            (pos.modified_date > $sinceDate and pos.modified_date <= $untilDate)
+            (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> 'vvh_generated')
           )
           and a.floating = 0"""
       .as[(Long, Long, Int, Option[Int], Double, Double, Option[String], Option[DateTime], Option[String], Option[DateTime], Boolean, Int, Long, Option[DateTime])].list

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/oracle/OracleLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/oracle/OracleLinearAssetDao.scala
@@ -421,9 +421,9 @@ class OracleLinearAssetDao(val vvhClient: VVHClient) {
          and (
            (a.valid_to > $sinceDate and a.valid_to <= $untilDate)
            or
-           (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> ${LinearAssetTypes.VvhGenereated})
+           (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> ${LinearAssetTypes.VvhGenerated})
            or
-           (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> ${LinearAssetTypes.VvhGenereated})
+           (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> ${LinearAssetTypes.VvhGenerated})
          )
     """.as[(Long, Long, SideCode, Option[Int], Double, Double, Option[String], Option[DateTime], Option[String], Option[DateTime], Long, Option[DateTime], Boolean)].list
 
@@ -447,9 +447,9 @@ class OracleLinearAssetDao(val vvhClient: VVHClient) {
           and (
             (a.valid_to > $sinceDate and a.valid_to <= $untilDate)
             or
-            (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> ${LinearAssetTypes.VvhGenereated})
+            (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> ${LinearAssetTypes.VvhGenerated})
             or
-            (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> ${LinearAssetTypes.VvhGenereated})
+            (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> ${LinearAssetTypes.VvhGenerated})
           )
           and a.floating = 0"""
       .as[(Long, Long, Int, Option[Int], Double, Double, Option[String], Option[DateTime], Option[String], Option[DateTime], Boolean, Int, Long, Option[DateTime])].list

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/oracle/OracleLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/oracle/OracleLinearAssetDao.scala
@@ -421,9 +421,9 @@ class OracleLinearAssetDao(val vvhClient: VVHClient) {
          and (
            (a.valid_to > $sinceDate and a.valid_to <= $untilDate)
            or
-           (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> 'vvh_generated')
+           (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> ${LinearAssetTypes.VvhGenereated})
            or
-           (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> 'vvh_generated')
+           (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> ${LinearAssetTypes.VvhGenereated})
          )
     """.as[(Long, Long, SideCode, Option[Int], Double, Double, Option[String], Option[DateTime], Option[String], Option[DateTime], Long, Option[DateTime], Boolean)].list
 
@@ -447,9 +447,9 @@ class OracleLinearAssetDao(val vvhClient: VVHClient) {
           and (
             (a.valid_to > $sinceDate and a.valid_to <= $untilDate)
             or
-            (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> 'vvh_generated')
+            (a.modified_date > $sinceDate and a.modified_date <= $untilDate and a.modified_by <> ${LinearAssetTypes.VvhGenereated})
             or
-            (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> 'vvh_generated')
+            (a.created_date > $sinceDate and a.created_date <= $untilDate and a.created_by <> ${LinearAssetTypes.VvhGenereated})
           )
           and a.floating = 0"""
       .as[(Long, Long, Int, Option[Int], Double, Double, Option[String], Option[DateTime], Option[String], Option[DateTime], Boolean, Int, Long, Option[DateTime])].list

--- a/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -17,6 +17,12 @@ class ChangeApi extends ScalatraServlet with JacksonJsonSupport with Authenticat
     contentType = formats("json")
   }
 
+
+  // The TN-ITS API is the only client for the change api and it does not care about the changes propagating
+  // from the changes to the VVH roadlinks. Including changes to geometry and link id's.
+  //
+  // Hence all these adjustements are simply filtered out already in the DAO level.
+
   get("/:assetType") {
     contentType = formats("json")
     val since = DateTime.parse(params("since"))

--- a/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -28,7 +28,7 @@ class LinearAssetUpdater(linearAssetService: LinearAssetService) extends Actor {
     linearAssetService.drop(changeSet.droppedAssetIds)
     linearAssetService.persistMValueAdjustments(changeSet.adjustedMValues)
     linearAssetService.persistSideCodeAdjustments(changeSet.adjustedSideCodes)
-    linearAssetService.expire(changeSet.expiredAssetIds.toSeq, LinearAssetTypes.VvhGenereated)
+    linearAssetService.expire(changeSet.expiredAssetIds.toSeq, LinearAssetTypes.VvhGenerated)
   }
 }
 

--- a/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -28,7 +28,7 @@ class LinearAssetUpdater(linearAssetService: LinearAssetService) extends Actor {
     linearAssetService.drop(changeSet.droppedAssetIds)
     linearAssetService.persistMValueAdjustments(changeSet.adjustedMValues)
     linearAssetService.persistSideCodeAdjustments(changeSet.adjustedSideCodes)
-    linearAssetService.expire(changeSet.expiredAssetIds.toSeq, "vvh_generated")
+    linearAssetService.expire(changeSet.expiredAssetIds.toSeq, LinearAssetTypes.VvhGenereated)
   }
 }
 


### PR DESCRIPTION
The TN-ITS API is the only client for the change api and it does not care about the changes propagating from the changes to the VVH roadlinks. Including changes to geometry and link id's.

Hence simply filter out all these adjustements.