### PR TITLE
Droth 14 keeping edit mode when jumping objects

### DIFF
--- a/UI/src/model/ApplicationModel.js
+++ b/UI/src/model/ApplicationModel.js
@@ -51,7 +51,6 @@
           var previouslySelectedLayer = selectedLayer;
           selectedLayer = layer;
           eventbus.trigger('layer:selected', layer, previouslySelectedLayer);
-          setReadOnly(true);
         } else {
           eventbus.trigger('layer:' + selectedLayer + ':shown');
         }

--- a/UI/src/model/ApplicationModel.js
+++ b/UI/src/model/ApplicationModel.js
@@ -50,6 +50,7 @@
         if (layer !== selectedLayer) {
           var previouslySelectedLayer = selectedLayer;
           selectedLayer = layer;
+          setSelectedTool('Select');
           eventbus.trigger('layer:selected', layer, previouslySelectedLayer);
         } else {
           eventbus.trigger('layer:' + selectedLayer + ':shown');

--- a/UI/src/view/navigationpanel/ActionPanelBoxes.js
+++ b/UI/src/view/navigationpanel/ActionPanelBoxes.js
@@ -7,7 +7,6 @@
     var className = toolName.toLowerCase();
     var element = $('<div class="action"/>').addClass(className).attr('action', toolName).append(icon).click(function() {
       executeOrShowConfirmDialog(function() {
-        if (selectedMassTransitStopModel) selectedMassTransitStopModel.close();
         applicationModel.setSelectedTool(toolName);
       });
     });

--- a/UI/src/view/navigationpanel/ActionPanelBoxes.js
+++ b/UI/src/view/navigationpanel/ActionPanelBoxes.js
@@ -121,11 +121,11 @@
       .hide();
 
     function show() {
+      editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
     }
 
     function hide() {
-      editModeToggle.reset();
       element.hide();
     }
 

--- a/UI/src/view/navigationpanel/ActionPanelBoxes.js
+++ b/UI/src/view/navigationpanel/ActionPanelBoxes.js
@@ -278,11 +278,11 @@
       .hide();
 
     function show() {
+      editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
     }
 
     function hide() {
-      editModeToggle.reset();
       element.hide();
     }
 

--- a/UI/src/view/navigationpanel/EditModeToggleButton.js
+++ b/UI/src/view/navigationpanel/EditModeToggleButton.js
@@ -30,9 +30,14 @@
       toggleReadOnlyMode(true);
     };
 
+    var toggleEditMode = function(mode) {
+      toggleReadOnlyMode(mode);
+    };
+
     return {
       element: element,
-      reset: reset
+      reset: reset,
+      toggleEditMode: toggleEditMode
     };
   };
 }(this));

--- a/UI/src/view/navigationpanel/LinearAssetBox.js
+++ b/UI/src/view/navigationpanel/LinearAssetBox.js
@@ -45,12 +45,13 @@
     var element = $('<div class="panel-group simple-limit ' + className + 's"/>').append(elements.expanded).hide();
 
     function show() {
+      editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
+
     }
 
     function hide() {
       element.hide();
-      editModeToggle.reset();
     }
 
     return {

--- a/UI/src/view/navigationpanel/LinearAssetBox.js
+++ b/UI/src/view/navigationpanel/LinearAssetBox.js
@@ -47,7 +47,6 @@
     function show() {
       editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
-
     }
 
     function hide() {

--- a/UI/src/view/navigationpanel/ManoeuvreBox.js
+++ b/UI/src/view/navigationpanel/ManoeuvreBox.js
@@ -47,7 +47,6 @@
     function show() {
       editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
-
     }
 
     function hide() {

--- a/UI/src/view/navigationpanel/ManoeuvreBox.js
+++ b/UI/src/view/navigationpanel/ManoeuvreBox.js
@@ -45,11 +45,12 @@
       .hide();
 
     function show() {
+      editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
+
     }
 
     function hide() {
-      editModeToggle.reset();
       element.hide();
     }
 

--- a/UI/src/view/navigationpanel/PointAssetBox.js
+++ b/UI/src/view/navigationpanel/PointAssetBox.js
@@ -39,7 +39,6 @@
     function show() {
       editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
-
     }
 
     function hide() {

--- a/UI/src/view/navigationpanel/PointAssetBox.js
+++ b/UI/src/view/navigationpanel/PointAssetBox.js
@@ -37,12 +37,13 @@
     };
 
     function show() {
+      editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
+
     }
 
     function hide() {
       element.hide();
-      editModeToggle.reset();
     }
   };
 })(this);

--- a/UI/src/view/navigationpanel/RoadLinkBox.js
+++ b/UI/src/view/navigationpanel/RoadLinkBox.js
@@ -151,11 +151,11 @@
     var element = $('<div class="panel-group ' + className + 's"/>').append(elements.expanded).hide();
 
     function show() {
+      editModeToggle.toggleEditMode(applicationModel.isReadOnly());
       element.show();
     }
 
     function hide() {
-      editModeToggle.reset();
       element.hide();
     }
 


### PR DESCRIPTION
The application no longer resets the "Edit Mode" when transitioning between data views.
Changed each entry in the navigation panel to keep the "Edition Tools" visible if the "Edit Mode" is toggled On.