### PR TITLE
DROTH-312 (144) Bug: Bus stop removal is not implemented according to specification

### DIFF
--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -120,6 +120,7 @@
 
   var assetUpdateFailedMessage = 'Tallennus epäonnistui. Yritä hetken kuluttua uudestaan.';
   var tierekisteriFailedMessage = 'Tietojen tallentaminen/muokkaminen Tierekisterissa epäonnistui. Tehtyjä muutoksia ei tallennettu OTH:ssa';
+  var tierekisteriFailedMessageDelete = 'Tietojen poisto Tierekisterissä epäonnistui. Pysäkkiä ei poistettu OTH:ssa';
 
   var indicatorOverlay = function() {
     jQuery('.container').append('<div class="spinner-overlay modal-overlay"><div class="spinner"></div></div>');
@@ -148,6 +149,11 @@
     eventbus.on('asset:creationTierekisteriFailed asset:updateTierekisteriFailed', function() {
       jQuery('.spinner-overlay').remove();
       alert(tierekisteriFailedMessage);
+    });
+
+    eventbus.on('asset:deleteTierekisteriFailed', function() {
+      jQuery('.spinner-overlay').remove();
+      alert(tierekisteriFailedMessageDelete);
     });
 
     eventbus.on('confirm:show', function() { new Confirm(); });

--- a/UI/src/model/SelectedMassTransitStop.js
+++ b/UI/src/model/SelectedMassTransitStop.js
@@ -317,13 +317,16 @@
       }
     };
 
-    var deleteMassTransitStop = function (poistaSelected){
-      if (poistaSelected){
+    var deleteMassTransitStop = function (poistaSelected) {
+      if (poistaSelected) {
         var currAsset = this.getCurrentAsset();
-        backend.deleteAllMassTransitStopData(currAsset.id,function() {
+        backend.deleteAllMassTransitStopData(currAsset.id, function () {
           eventbus.trigger('massTransitStopDeleted', currAsset);
-        }, function(){
+        }, function (errorObject) {
           cancel();
+          if (errorObject.status == 555) {
+            eventbus.trigger('asset:deleteTierekisteriFailed');
+          }
         });
       }
     };

--- a/UI/src/view/MassTransitStopForm.js
+++ b/UI/src/view/MassTransitStopForm.js
@@ -50,11 +50,15 @@
   };
 
   var SaveButton = function() {
-    var element = $('<button />').addClass('save btn btn-primary').text('Tallenna').click(function() {
-      element.prop('disabled', true);
-      if(poistaSelected){
-        selectedMassTransitStopModel.deleteMassTransitStop(poistaSelected);
-      }else {
+    var element = $('<button />').addClass('save btn btn-primary').text('Tallenna').click(function () {
+      if (poistaSelected) {
+        new GenericConfirmPopup('Haluatko varmasti poistaa pysäkin? Kyllä/Ei', {
+          successCallback: function () {
+            element.prop('disabled', true);
+            selectedMassTransitStopModel.deleteMassTransitStop(poistaSelected);
+          }
+        });
+      } else {
         selectedMassTransitStopModel.save();
       }
     });

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/MassTransitStopService.scala
@@ -515,6 +515,8 @@ trait MassTransitStopService extends PointAssetOperations {
       val persistedStop = fetchPointAssets(withId(assetId)).headOption
       val relevantToTR = isStoredInTierekisteri(Some(persistedStop.get))
 
+      massTransitStopDao.deleteAllMassTransitStopData(assetId)
+
       if ((relevantToTR) && (tierekisteriClient.isTREnabled)) {
         val liviIdOption = persistedStop.get.propertyData.find(propertyData =>
           propertyData.publicId.equals(LiViIdentifierPublicId)).flatMap(propertyData => propertyData.values.headOption).map(_.propertyValue).headOption
@@ -523,7 +525,6 @@ trait MassTransitStopService extends PointAssetOperations {
           case Some(liviId) => tierekisteriClient.deleteMassTransitStop(liviId)
           case _ => throw new RuntimeException(s"bus stop relevant to Tierekisteri doesn't have 'yllapitajan koodi' property")
         }
-        massTransitStopDao.deleteAllMassTransitStopData(assetId)
       }
     }
   }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/MassTransitStopServiceSpec.scala
@@ -623,6 +623,7 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers {
     runWithRollback {
       val eventbus = MockitoSugar.mock[DigiroadEventBus]
       val service = new TestMassTransitStopServiceWithTierekisteri(eventbus)
+      when(mockTierekisteriClient.isTREnabled).thenReturn(true)
       val stop = service.getMassTransitStopByNationalId(85755, Int => Unit).get
       service.deleteAllMassTransitStopData(stop.id)
       verify(mockTierekisteriClient).deleteMassTransitStop("OTHJ85755")
@@ -636,6 +637,7 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers {
     val stop = service.getMassTransitStopByNationalId(85755, Int => Unit).get
     when(mockTierekisteriClient.deleteMassTransitStop(any[String])).thenThrow(new TierekisteriClientException("foo"))
     intercept[TierekisteriClientException] {
+      when(mockTierekisteriClient.isTREnabled).thenReturn(true)
       service.deleteAllMassTransitStopData(stop.id)
     }
     service.getMassTransitStopByNationalId(85755, Int => Unit).isEmpty should be(false)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/MassTransitStopServiceSpec.scala
@@ -76,8 +76,8 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers {
   }
 
   class TestMassTransitStopServiceWithDynTransaction(val eventbus: DigiroadEventBus) extends MassTransitStopService {
-    override def withDynSession[T](f: => T): T = f
-    override def withDynTransaction[T](f: => T): T = OracleDatabase.withDynTransaction(f)
+    override def withDynSession[T](f: => T): T = TestTransactions.withDynSession()(f)
+    override def withDynTransaction[T](f: => T): T = TestTransactions.withDynTransaction()(f)
     override def vvhClient: VVHClient = mockVVHClient
     override val tierekisteriClient: TierekisteriClient = mockTierekisteriClient
     override val massTransitStopDao: MassTransitStopDao = new MassTransitStopDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/MassTransitStopServiceSpec.scala
@@ -5,6 +5,7 @@ import java.util.Date
 
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.masstransitstop.oracle.MassTransitStopDao
+import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.user.{Configuration, User}
 import fi.liikennevirasto.digiroad2.util._
 import org.joda.time.DateTime
@@ -67,6 +68,16 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers {
   class TestMassTransitStopServiceWithTierekisteri(val eventbus: DigiroadEventBus) extends MassTransitStopService {
     override def withDynSession[T](f: => T): T = f
     override def withDynTransaction[T](f: => T): T = f
+    override def vvhClient: VVHClient = mockVVHClient
+    override val tierekisteriClient: TierekisteriClient = mockTierekisteriClient
+    override val massTransitStopDao: MassTransitStopDao = new MassTransitStopDao
+    override val tierekisteriEnabled = true
+    override val geometryTransform: GeometryTransform = mockGeometryTransform
+  }
+
+  class TestMassTransitStopServiceWithDynTransaction(val eventbus: DigiroadEventBus) extends MassTransitStopService {
+    override def withDynSession[T](f: => T): T = f
+    override def withDynTransaction[T](f: => T): T = OracleDatabase.withDynTransaction(f)
     override def vvhClient: VVHClient = mockVVHClient
     override val tierekisteriClient: TierekisteriClient = mockTierekisteriClient
     override val massTransitStopDao: MassTransitStopDao = new MassTransitStopDao
@@ -606,5 +617,27 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers {
       dateFormatter.format(trStop.operatingFrom.get) should be (opFrom.get)
       dateFormatter.format(trStop.operatingTo.get) should be (opTo.get)
     }
+  }
+
+  test("delete a TR kept mass transit stop") {
+    runWithRollback {
+      val eventbus = MockitoSugar.mock[DigiroadEventBus]
+      val service = new TestMassTransitStopServiceWithTierekisteri(eventbus)
+      val stop = service.getMassTransitStopByNationalId(85755, Int => Unit).get
+      service.deleteAllMassTransitStopData(stop.id)
+      verify(mockTierekisteriClient).deleteMassTransitStop("OTHJ85755")
+      service.getMassTransitStopByNationalId(85755, Int => Unit).isEmpty should be(true)
+    }
+  }
+
+  test("delete fails if a TR kept mass transit stop is not found") {
+    val eventbus = MockitoSugar.mock[DigiroadEventBus]
+    val service = new TestMassTransitStopServiceWithDynTransaction(eventbus)
+    val stop = service.getMassTransitStopByNationalId(85755, Int => Unit).get
+    when(mockTierekisteriClient.deleteMassTransitStop(any[String])).thenThrow(new TierekisteriClientException("foo"))
+    intercept[TierekisteriClientException] {
+      service.deleteAllMassTransitStopData(stop.id)
+    }
+    service.getMassTransitStopByNationalId(85755, Int => Unit).isEmpty should be(false)
   }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TestTransactions.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TestTransactions.scala
@@ -13,4 +13,14 @@ object TestTransactions {
       dynamicSession.rollback()
     }
   }
+  def withDynTransaction[T](ds: DataSource = OracleDatabase.ds)(f: => T): T = {
+    Database.forDataSource(ds).withDynTransaction {
+      f
+    }
+  }
+  def withDynSession[T](ds: DataSource = OracleDatabase.ds)(f: => T): T = {
+    Database.forDataSource(ds).withDynSession {
+      f
+    }
+  }
 }


### PR DESCRIPTION
These features are missing from bus stop removal implementation (DROTH-273):
- There should be a confirmation popup for user when Poista checkbox is checked and user clicks Tallenna. See DROTH-273 for message text.
- The bus stop should be first removed from Tierekisteri and if that is successful, it can be removed from OTH
- If removal from Tierekisteri fails, user should be shown a popup message. See DROTH-273 for message text.