### PR TITLE
DROTH-310 (144) Bug: "Bus stop moved" popup missing for bus stops with ELY-keskus as administrative class

### DIFF
--- a/UI/src/view/MassTransitStopLayer.js
+++ b/UI/src/view/MassTransitStopLayer.js
@@ -435,12 +435,19 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
 
   var restrictMovement = function (busStop, currentPoint, angle, nearestLine, coordinates) {
     var movementLimit = 50; //50 meters
+    var popupMessageToShow;
     //The method geometrycalculator.getSquaredDistanceBetweenPoints() will return the distance in Meters so we multiply the result for this
     var distance = Math.sqrt(geometrycalculator.getSquaredDistanceBetweenPoints(busStop, currentPoint));
 
     if (distance > movementLimit && !movementPermission)
     {
-      new GenericConfirmPopup('Pysäkkiä siirretty yli 50 metriä. Haluatko siirtää pysäkin uuteen sijaintiin?',{
+      if (controlledByTR()){
+        popupMessageToShow = 'Pysäkkiä siirretty yli 50 metriä. Siirron yhteydessä vanha pysäkki lakkautetaan ja luodaan uusi pysäkki.';
+      } else {
+        popupMessageToShow = 'Pysäkkiä siirretty yli 50 metriä. Haluatko siirtää pysäkin uuteen sijaintiin?';
+      }
+
+      new GenericConfirmPopup(popupMessageToShow,{
         successCallback: function(){
           doMovement(angle, nearestLine, coordinates, true);
           movementPermission = true;


### PR DESCRIPTION
- Add missing the message "Pysäkkiä siirretty yli 50 metriä. Siirron yhteydessä vanha pysäkki lakkautetaan ja luodaan uusi pysäkki." for cases when the mass transit stop moved more than 50 meters and is managed by ELY-keskus.