### PR TITLE
Drvvh 312 creating log of the initial data load

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -154,7 +154,7 @@ class AssetDataImporter {
     warningRows.foreach{
       warning =>
         val row = roads.find(r => r._16 == warning._1).get
-        println("Suppressed row ID %d with reason 1: 'Values of the start and end fields are totally outside of the link geometry' %s".format(warning._1, printRow(row)))
+        println("Suppressed row ID %d with reason 2: 'Values of the start and end fields are totally outside of the link geometry' %s".format(warning._1, printRow(row)))
     }
 
     print(s"${DateTime.now()} - ")

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -143,7 +143,7 @@ class AssetDataImporter {
     print(s"${DateTime.now()} - ")
     println("Read %d road links from vvh".format(linkLengths.size))
 
-    roads.filter(r => linkLengths.get(r._1).isDefined).foreach{
+    roads.filterNot(r => linkLengths.get(r._1).isDefined).foreach{
       row => println("Suppressed row ID %d with reason 1: 'LINK-ID is not found in the VVH Interface' %s".format(row._16, printRow(row)))
     }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -96,6 +96,12 @@ class AssetDataImporter {
   }
 
   def importRoadAddressData(conversionDatabase: DatabaseDef, vvhClient: VVHClient) = {
+    def printRow(r: (Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, String, Option[String], String, String, Long)): Unit ={
+      "linkid: "+r._1+", alku: "+r._2+", loppu: "+r._3+ ", tie: "+r._4+", aosa: "+r._5+", ajr: "+
+        r._6+", ely: "+r._7+", tietyyppi: "+r._8+", jatkuu: "+r._9+", aet: "+r._10+", let: "+
+        r._11+", alkupvm: "+r._12+", loppupvm: "+r._13+", kayttaja: "+r._14+", muutospvm or rekisterointipvm: "+r._15
+
+    }
     def filler(lrmPos: Seq[(Long, Long, Double, Double)], length: Double) = {
       val filled = lrmPos.exists(x => x._4 >= length)
       filled match {
@@ -140,7 +146,7 @@ class AssetDataImporter {
     println("Read %d road links from vvh".format(linkLengths.size))
 
     roads.filter(r => linkLengths.get(r._1).isDefined).foreach{
-      row => logger.warn("ROW ID {} REASON 1: LINK-ID IS NOT FOUND IN THE VVH INTERFACE {}", row._16, row)
+      row => println("Suppressed row ID {} with reason 1: 'LINK-ID is not found in the VVH Interface' {}", row._16, printRow(row))
     }
 
     val (lrmPositions, warningRows) = linkLengths.flatMap {
@@ -149,7 +155,8 @@ class AssetDataImporter {
 
     warningRows.foreach{
       warning =>
-        logger.warn("ROW ID {} REASON 2: VALUES OF THE START AND END FIELDS ARE TOTALLY OUTSIDE OF THE LINK GEOMETRY {}", warning._1, warning)
+        val row = roads.find(r => r._16 == warning._1).get
+        println("Suppressed row ID {} with reason 1: 'Values of the start and end fields are totally outside of the link geometry' {}", warning._1, printRow(row))
     }
 
     print(s"${DateTime.now()} - ")

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -139,9 +139,18 @@ class AssetDataImporter {
     print(s"${DateTime.now()} - ")
     println("Read %d road links from vvh".format(linkLengths.size))
 
-    val lrmPositions = linkLengths.flatMap {
+    roads.filter(r => linkLengths.get(r._1).isDefined).foreach{
+      row => logger.warn("REASON 1: LINK-ID IS NOT FOUND IN THE VVH INTERFACE", row)
+    }
+
+    val (lrmPositions, warningRows) = linkLengths.flatMap {
       case (linkId, length) => cutter(filler(lrmList.getOrElse(linkId, List()), length), length)
-    }.filterNot(x => x._3 == x._4)
+    }.partition(x => x._3 == x._4)
+
+    warningRows.foreach{
+      warning =>
+        logger.warn("REASON 2: VALUES OF THE START AND END FIELDS ARE TOTALLY OUTSIDE OF THE LINK GEOMETRY ", warning)
+    }
 
     print(s"${DateTime.now()} - ")
     println("%d zero length segments removed".format(lrmList.size - lrmPositions.size))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -96,11 +96,9 @@ class AssetDataImporter {
   }
 
   def importRoadAddressData(conversionDatabase: DatabaseDef, vvhClient: VVHClient) = {
-    def printRow(r: (Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, String, Option[String], String, String, Long)): Unit ={
-      "linkid: "+r._1+", alku: "+r._2+", loppu: "+r._3+ ", tie: "+r._4+", aosa: "+r._5+", ajr: "+
-        r._6+", ely: "+r._7+", tietyyppi: "+r._8+", jatkuu: "+r._9+", aet: "+r._10+", let: "+
-        r._11+", alkupvm: "+r._12+", loppupvm: "+r._13+", kayttaja: "+r._14+", muutospvm or rekisterointipvm: "+r._15
-
+    def printRow(r: (Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, Long, String, Option[String], String, String, Long)): String ={
+      s"""linkid: %d, alku: %d, loppu: %d, tie: %d, aosa: %d, ajr: %d, ely: %d, tietyyppi: %d, jatkuu: %d, aet: %d, let: %d, alkupvm: %s, loppupvm: %s, kayttaja: %s, muutospvm or rekisterointipvm: %s""".
+        format(r._1, r._2, r._3, r._4, r._5, r._6, r._7, r._8, r._9, r._10, r._11, r._12, r._13, r._14, r._15)
     }
     def filler(lrmPos: Seq[(Long, Long, Double, Double)], length: Double) = {
       val filled = lrmPos.exists(x => x._4 >= length)
@@ -146,7 +144,7 @@ class AssetDataImporter {
     println("Read %d road links from vvh".format(linkLengths.size))
 
     roads.filter(r => linkLengths.get(r._1).isDefined).foreach{
-      row => println("Suppressed row ID {} with reason 1: 'LINK-ID is not found in the VVH Interface' {}", row._16, printRow(row))
+      row => println("Suppressed row ID %d with reason 1: 'LINK-ID is not found in the VVH Interface' %s".format(row._16, printRow(row)))
     }
 
     val (lrmPositions, warningRows) = linkLengths.flatMap {
@@ -156,7 +154,7 @@ class AssetDataImporter {
     warningRows.foreach{
       warning =>
         val row = roads.find(r => r._16 == warning._1).get
-        println("Suppressed row ID {} with reason 1: 'Values of the start and end fields are totally outside of the link geometry' {}", warning._1, printRow(row))
+        println("Suppressed row ID %d with reason 1: 'Values of the start and end fields are totally outside of the link geometry' %s".format(warning._1, printRow(row)))
     }
 
     print(s"${DateTime.now()} - ")

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -149,7 +149,7 @@ class AssetDataImporter {
 
     val (lrmPositions, warningRows) = linkLengths.flatMap {
       case (linkId, length) => cutter(filler(lrmList.getOrElse(linkId, List()), length), length)
-    }.partition(x => x._3 == x._4)
+    }.partition(x => x._3 != x._4)
 
     warningRows.foreach{
       warning =>

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/AssetDataImporter.scala
@@ -140,7 +140,7 @@ class AssetDataImporter {
     println("Read %d road links from vvh".format(linkLengths.size))
 
     roads.filter(r => linkLengths.get(r._1).isDefined).foreach{
-      row => logger.warn("REASON 1: LINK-ID IS NOT FOUND IN THE VVH INTERFACE", row)
+      row => logger.warn("ROW ID {} REASON 1: LINK-ID IS NOT FOUND IN THE VVH INTERFACE {}", row._16, row)
     }
 
     val (lrmPositions, warningRows) = linkLengths.flatMap {
@@ -149,7 +149,7 @@ class AssetDataImporter {
 
     warningRows.foreach{
       warning =>
-        logger.warn("REASON 2: VALUES OF THE START AND END FIELDS ARE TOTALLY OUTSIDE OF THE LINK GEOMETRY ", warning)
+        logger.warn("ROW ID {} REASON 2: VALUES OF THE START AND END FIELDS ARE TOTALLY OUTSIDE OF THE LINK GEOMETRY {}", warning._1, warning)
     }
 
     print(s"${DateTime.now()} - ")


### PR DESCRIPTION
A log needs to be created of all the rows that cannot be saved to Viite during the initial data load. All attribute data needs to be picked up. Reason codes used:
1 = Link-ID is not found in the VVH interface
2 = Values of the start and end fields are totally outside of the link geometry 
3 = Another reason
These are for example cases where the link-ID is not found in the VVH interface and values of the start and end fields of a road address segment are totally outside of the link geometry (for example the length of the link is 10, road address start is 12 and end 18).
