### PR TITLE
DROTH-568 If a bus stop (maintainer ELY) status is moved from anything to virtual (type = 5) stop needs to be removed from Tierekisteri

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/MassTransitStopService.scala
@@ -423,12 +423,13 @@ trait MassTransitStopService extends PointAssetOperations {
 
       val id = asset.id
       massTransitStopDao.updateAssetLastModified(id, username)
+      val isVirtualBusStop = MassTransitStopOperations.isVirtualBusStop(properties)
       val oldLiviIdProperty = MassTransitStopOperations.liviIdValueOption(asset.propertyData)
       val newLiviIdProperty = if (properties.nonEmpty) {
         val administrationProperty = properties.find(_.publicId == MassTransitStopOperations.AdministratorInfoPublicId)
         val elyAdministrated = administrationProperty.exists(_.values.headOption.exists(_.propertyValue == MassTransitStopOperations.CentralELYPropertyValue))
         val hslAdministrated = administrationProperty.exists(_.values.headOption.exists(_.propertyValue == MassTransitStopOperations.HSLPropertyValue))
-        if  (!(elyAdministrated || hslAdministrated) && MassTransitStopOperations.liviIdValueOption(asset.propertyData).exists(_.propertyValue != "")) {
+        if  ( (!(elyAdministrated || hslAdministrated) || isVirtualBusStop) && MassTransitStopOperations.liviIdValueOption(asset.propertyData).exists(_.propertyValue != "")) {
           updatePropertiesForAsset(id, properties.toSeq, roadLink.get.administrativeClass, asset.nationalId, None)
         } else {
           updatePropertiesForAsset(id, properties.toSeq, roadLink.get.administrativeClass, asset.nationalId, MassTransitStopOperations.liviIdValueOption(asset.propertyData))
@@ -458,11 +459,12 @@ trait MassTransitStopService extends PointAssetOperations {
       val wasStoredInTierekisteri = MassTransitStopOperations.isStoredInTierekisteri(persistedStop)
       val shouldBeInTierekisteri = MassTransitStopOperations.isStoredInTierekisteri(mergedProperties)
 
-      val operation = (wasStoredInTierekisteri, shouldBeInTierekisteri) match {
-        case (true, true) => Operation.Update
-        case (true, false) => Operation.Expire
-        case (false, true) => Operation.Create
-        case (false, false) => Operation.Noop
+      val operation = (wasStoredInTierekisteri, shouldBeInTierekisteri, isVirtualBusStop) match {
+        case (true, true, _) => Operation.Update
+        case (true, false, false) => Operation.Expire
+        case (true, false, true) => Operation.Remove
+        case (false, true, _) => Operation.Create
+        case (false, false, _) => Operation.Noop
       }
 
       if(optionalPosition.isDefined && operation == Operation.Update) {
@@ -519,7 +521,7 @@ trait MassTransitStopService extends PointAssetOperations {
     }
     val tierekisteriLiviId = MassTransitStopOperations.liviIdValueOption(persistedStop.propertyData).map(_.propertyValue) // Using the saved LiviId if any
     val modifiedAsset = fetchPointAssets(withId(id)).headOption // Reload from database
-    if(tierekisteriOperation == Operation.Expire){
+    if(tierekisteriOperation == Operation.Expire || tierekisteriOperation == Operation.Remove){
       executeTierekisteriOperation(tierekisteriOperation, modifiedAsset.get, { _ => Some(roadLink) }, tierekisteriLiviId, Some(username))
       convertPersistedStopWithPropertiesAndPublishEvent(modifiedAsset, { _ => Some(roadLink) }, Operation.Noop, tierekisteriLiviId, Some(username))
     } else {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/masstransitstop/MassTransitStopOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/masstransitstop/MassTransitStopOperations.scala
@@ -118,6 +118,10 @@ object MassTransitStopOperations {
     !isVirtualStop && (elyAdministrated || (isHSLAdministrated && isAdminClassState))
   }
 
+  def isVirtualBusStop(properties: Set[SimpleProperty]): Boolean = {
+    properties.find(pro => pro.publicId == MassTransitStopTypePublicId).exists(_.values.exists(_.propertyValue == VirtualBusStopPropertyValue))
+  }
+
   def getAdministrationClass(properties: Seq[AbstractProperty]): Option[AdministrativeClass] = {
     val propertyValueOption = properties.find(_.publicId == MassTransitStopAdminClassPublicId)
       .map(_.values).getOrElse(Seq()).headOption


### PR DESCRIPTION
- Create method to verified if BusStop was modified to Virtual;
- Join the previous validation created to remove the LiVi_ID in OTH in case bus stop (maintainer ELY) status was moved from anything to virtual;
- Add the Remove Operation type in the Operation match.