### PR TITLE
VIITE-344 - Selection of homogeneous road section doesn't work

### DIFF
--- a/viite-UI/src/model/RoadCollection.js
+++ b/viite-UI/src/model/RoadCollection.js
@@ -143,19 +143,37 @@
     };
 
     this.getGroup = function(id) {
-      return _.find(roadLinkGroups, function(roadLinkGroup) {
+      var group =_.find(roadLinkGroups, function(roadLinkGroup) {
         return _.some(roadLinkGroup, function(roadLink) {
           return roadLink.getId() === id;
         });
       });
+      var road = _.first(group).getData();
+      return processGroupOutput(road, group);
     };
 
     this.getGroupByLinkId = function (linkId) {
-      return _.find(roadLinkGroups, function(roadLinkGroup) {
+      var group = _.find(roadLinkGroups, function(roadLinkGroup) {
         return _.some(roadLinkGroup, function(roadLink) {
           return roadLink.getData().linkId === linkId;
         });
       });
+      var road = _.first(group).getData();
+      return processGroupOutput(road, group);
+    };
+
+    var processGroupOutput = function(road,group){
+      if(roadIsOther(road) || roadIsUnknown(road)){
+        return group;
+      }
+      else {
+        var allGroups = _.filter(roadLinkGroups, function(rlg){
+          return _.some(rlg, function(groupedRoad){
+            return groupedRoad.getData().roadNumber === road.roadNumber && groupedRoad.getData().anomaly === road.anomaly && groupedRoad.getData().roadLinkType === road.roadLinkType && groupedRoad.getData().roadPartNumber === road.roadPartNumber && groupedRoad.getData().trackCode === road.trackCode;
+          });
+        });
+        return _.flatten(allGroups);
+      }
     };
 
     this.getGroupById = function (id) {
@@ -212,5 +230,13 @@
       preMovedRoadAddresses = [];
     };
 
+
+    var roadIsOther = function(road){
+      return  0 === road.roadNumber && 0 === road.anomaly && 0 === road.roadLinkType && 0 === road.roadPartNumber && 99 === road.trackCode;
+    };
+
+    var roadIsUnknown = function(road){
+      return  0 === road.roadNumber && 1 === road.anomaly && 0 === road.roadLinkType && 0 === road.roadPartNumber && 99 === road.trackCode;
+    };
   };
 })(this);


### PR DESCRIPTION
Created a method that will return all the groups that have the same roadNumber ,anomaly ,roadLinkType ,roadPartNumber and trackCode values if the selected group is not a group of Unknown roads or Other (Muu tieverkko) roads.