### PR TITLE
Viite 413 t intersection doesn't give an error

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -52,4 +52,10 @@ case class Point(x: Double, y: Double, z: Double = 0.0) {
   def +(that: Vector3d): Point = {
     Point(x + that.x, y + that.y, z + that.z)
   }
+
+  override def equals(o: Any) = o match {
+    case that: Point => GeometryUtils.areAdjacent(that, this)
+    case _ => false
+  }
+
 }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -32,6 +32,10 @@ case class Vector3d(x: Double, y: Double, z: Double) {
   def -(that: Vector3d): Vector3d = {
     Vector3d(x - that.x, y - that.y, z - that.z)
   }
+
+  def to2D(): Vector3d = {
+    Vector3d(x, y, 0.0)
+  }
 }
 
 case class Point(x: Double, y: Double, z: Double = 0.0) {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -11,6 +11,9 @@ package object viite {
   val MaxDistanceDiffAllowed = 1.0 /* Temporary restriction from PO: Filler limit on modifications
                                       (LRM adjustments) is limited to 1 meter. If there is a need to fill /
                                       cut more than that then nothing is done to the road address LRM data.
+
+                                      Used also for checking the integrity of the targets of floating road links: no
+                                      three roads may have ending points closer to this in the target geometry
                                    */
 
   val MinAllowedRoadAddressLength = 0.1

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -152,10 +152,15 @@ object DefloatMapper {
       else
         switchSideCode(previousSideCode)
     }
+    def touching(p: Point, points: Seq[Point]) = {
+      points.count(x => (x-p).length() < MaxDistanceDiffAllowed)
+    }
     def hasIntersection(roadLinks: Seq[RoadAddressLink]): Boolean = {
-      val MaxCommunPoints = 2
-      val endPoints = roadLinks.map(rl =>GeometryUtils.geometryEndpoints(rl.geometry)).flatMap( t => Seq(t._1, t._2))
-      endPoints.length - endPoints.distinct.length >= MaxCommunPoints
+      val endPoints = roadLinks.map(rl =>GeometryUtils.geometryEndpoints(rl.geometry))
+      val flattened = endPoints.flatMap(pp => Seq(pp._1, pp._2))
+      !endPoints.forall(ep =>
+        touching(ep._1, flattened) < 3 && touching(ep._2, flattened) < 3
+      )
     }
     def extending(link: RoadAddressLink, ext: RoadAddressLink) = {
       link.roadNumber == ext.roadNumber && link.roadPartNumber == ext.roadPartNumber &&

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -152,7 +152,11 @@ object DefloatMapper {
       else
         switchSideCode(previousSideCode)
     }
-
+    def hasIntersection(roadLinks: Seq[RoadAddressLink]): Boolean = {
+      val MaxCommunPoints = 2
+      val endPoints = roadLinks.map(rl =>GeometryUtils.geometryEndpoints(rl.geometry)).flatMap( t => Seq(t._1, t._2))
+      endPoints.length - endPoints.distinct.length >= MaxCommunPoints
+    }
     def extending(link: RoadAddressLink, ext: RoadAddressLink) = {
       link.roadNumber == ext.roadNumber && link.roadPartNumber == ext.roadPartNumber &&
         link.trackCode == ext.trackCode && link.endAddressM == ext.startAddressM
@@ -197,6 +201,9 @@ object DefloatMapper {
       case SideCode.AgainstDigitizing => orderedSources.head.geometry.last
       case _ => throw new InvalidAddressDataException("Bad sidecode on source")
     }
+
+    if( hasIntersection(targets) )
+      throw new IllegalArgumentException("Non-contiguous road addressing")
 
     val (endingLinks, middleLinks) = targets.partition(t => targets.count(t2 => GeometryUtils.areAdjacent(t.geometry, t2.geometry)) < 3)
     val preSortedTargets = endingLinks.sortBy(l => minDistanceBetweenEndPoints(Seq(startingPoint), l.geometry)) ++ middleLinks

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -153,7 +153,7 @@ object DefloatMapper {
         switchSideCode(previousSideCode)
     }
     def touching(p: Point, points: Seq[Point]) = {
-      points.count(x => (x-p).length() < MaxDistanceDiffAllowed)
+      points.count(x => (x-p).to2D().length() < MaxDistanceDiffAllowed)
     }
     def hasIntersection(roadLinks: Seq[RoadAddressLink]): Boolean = {
       val endPoints = roadLinks.map(rl =>GeometryUtils.geometryEndpoints(rl.geometry))

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
@@ -41,6 +41,20 @@ class DefloatMapperSpec extends FunSuite with Matchers{
     roadAddressTarget.size should be (4)
   }
 
+  test("test order road address link with intersection") {
+    val sources = Seq(
+      createRoadAddressLink(1L, 123L, Seq(Point(422739.942,7228000.062), Point(422654.464, 7228017.876)), 1L, 1L, 0, 100, 107, SideCode.TowardsDigitizing, Anomaly.None),
+      createRoadAddressLink(3L, 125L, Seq(Point(422565.724, 7228023.602), Point(422556.5834168215, 7228025.871885278)), 1L, 1L, 0, 121, 135, SideCode.TowardsDigitizing, Anomaly.None),
+      createRoadAddressLink(2L, 124L, Seq(Point(422654.464, 7228017.876), Point(422565.724,7228023.602)), 1L, 1L, 0, 107, 121, SideCode.AgainstDigitizing, Anomaly.None)
+    )
+    val targets = Seq(
+      createRoadAddressLink(0L, 457L, Seq(Point(422566.54,7228030.756), Point(422557.481, 7228032.199)), 0, 0, 0, 0, 0, SideCode.Unknown, Anomaly.NoAddressGiven),
+      createRoadAddressLink(0L, 456L, Seq(Point(422566.54,7228030.756), Point(422598.206, 7228229.117)), 0, 0, 0, 0, 0, SideCode.Unknown, Anomaly.NoAddressGiven),
+      createRoadAddressLink(0L, 458L, Seq(Point(422739.942,7228000.062), Point(422566.54, 7228030.756)), 0, 0, 0, 0, 0, SideCode.Unknown, Anomaly.NoAddressGiven)
+    )
+    an [IllegalArgumentException] should be thrownBy DefloatMapper.orderRoadAddressLinks(sources, targets)
+  }
+
   test("Order road address link sources and targets") {
     val sources = Seq(
       createRoadAddressLink(1L, 123L, Seq(Point(5.0,5.0), Point(10.0, 10.0)), 1L, 1L, 0, 100, 107, SideCode.TowardsDigitizing, Anomaly.None),

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
@@ -37,7 +37,6 @@ class DefloatMapperSpec extends FunSuite with Matchers{
     val roadAddressSource = sources.map(roadAddressLinkToRoadAddress(true))
     val mapping = DefloatMapper.createAddressMap(sources, targets)
     val roadAddressTarget = roadAddressSource.flatMap(DefloatMapper.mapRoadAddresses(mapping))
-    roadAddressTarget.foreach(println)
     roadAddressTarget.size should be (4)
   }
 


### PR DESCRIPTION
Fixed matching rules to allow non-intersecting but non-connected geometries as valid targets.