### PR TITLE
VIITE-405 reset roadcollection before fetching new road links 

### DIFF
--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -570,6 +570,7 @@
 
     this.refreshView = function() {
       //Generalize the zoom levels as the resolutions and zoom levels differ between map tile sources
+      roadCollection.reset();
       roadCollection.fetch(map.getView().calculateExtent(map.getSize()), map.getView().getZoom());
       roadLayer.layer.changed();
     };


### PR DESCRIPTION
Force refreshing to get new road link address values for the whole road.