### PR TITLE
Fix for not parsing actual error message

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ViiteTierekisteriClient.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ViiteTierekisteriClient.scala
@@ -193,7 +193,6 @@ object ViiteTierekisteriClient {
       val statusCode = response.getStatusLine.getStatusCode
       if (statusCode>=400 && statusCode<500)
       errorMessage = parse(StreamInput(response.getEntity.getContent)).extract[TRErrorResponse] // would be nice if we didn't need case class for parsing of one attribute
-      val reason = response.getStatusLine.getReasonPhrase
       ProjectChangeStatus(trProject.id, statusCode, errorMessage.error_message)
     } catch {
       case NonFatal(e) => ProjectChangeStatus(trProject.id, ProjectState.Incomplete.value, "Lähetys tierekisteriin epäonnistui") // sending project to tierekisteri failed


### PR DESCRIPTION
When tierekisteri did not accept project, user  always got "Bad request" message to UI after pressing publish. Now we parse error message when we are expecting one (with html error codes 400-499)