### PR TITLE
Viite 493 vvh changetable

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/RoadLinkService.scala
@@ -318,9 +318,9 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
     * @return LinksId
     */
 
-    def getLinkIdsFromVVHWithComplementaryByPolygons(polygons: Seq[Polygon]) = {
-      polygons.flatMap(getLinkIdsFromVVHWithComplementaryByPolygon)
-    }
+  def getLinkIdsFromVVHWithComplementaryByPolygons(polygons: Seq[Polygon]) = {
+    polygons.flatMap(getLinkIdsFromVVHWithComplementaryByPolygon)
+  }
 
   /**
     * This method returns "real" and "complementary" link id by polygon.
@@ -674,6 +674,9 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
   def getViiteRoadPartsFromVVH(linkIds: Set[Long], municipalities: Set[Int] = Set()) : Seq[RoadLink] =
     getViiteRoadLinksWithoutChangesFromVVH(linkIds, municipalities)._1
 
+  def getChangeInfoFromVVH(bounds: BoundingRectangle, municipalities: Set[Int]): Seq[ChangeInfo] ={
+    Await.result(vvhClient.roadLinkChangeInfo.fetchByBoundsAndMunicipalitiesF(bounds, municipalities), atMost = Duration.Inf)
+  }
 
   /**
     * Gets road links and change data by municipality from VVH. Used to update cache

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -310,7 +310,7 @@ object RoadAddressLinkBuilder {
         nextSegment.track, discontinuity, startAddrMValue,
         endAddrMValue, nextSegment.startDate, nextSegment.endDate, nextSegment.modifiedBy, nextSegment.lrmPositionId, nextSegment.linkId,
         startMValue, endMValue,
-        nextSegment.sideCode, calibrationPoints, false, combinedGeometry))
+        nextSegment.sideCode, nextSegment.adjustedTimestamp, calibrationPoints, false, combinedGeometry))
 
     } else Seq(nextSegment, previousSegment)
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -105,6 +105,8 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
     val fetchVVHEndTime = System.currentTimeMillis()
     logger.info("End fetch vvh road links in %.3f sec".format((fetchVVHEndTime - fetchVVHStartTime) * 0.001))
 
+    //TODO: In the future when we are dealing with VVHChangeInfo we need to better evaluate when do we switch from bounding box queries to
+    //pure linkId based queries, maybe something related to the zoomLevel we are in map level.
     val fetchMissingRoadAddressStartTime = System.currentTimeMillis()
     val (floatingViiteRoadLinks, addresses, floating) = Await.result(fetchRoadAddressesByBoundingBoxF, Duration.Inf)
     val missingLinkIds = linkIds -- floating.keySet -- addresses.keySet

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -587,6 +587,23 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
     }
   }
 
+  /**
+    * This will annex all the valid ChangeInfo to the corresponding road address object
+    * The criteria for the annexation is the following:
+    *   .The changeInfo vvhTimestamp must be bigger than the RoadAddress vvhTimestamp
+    *   .Either the newId or the oldId from the Changeinfo must be equal to the linkId in the RoadAddress
+    * @param roadAddresses - Sequence of RoadAddresses
+    * @param changes - Sequence of ChangeInfo
+    * @return List of (RoadAddress, List of ChangeInfo)
+    */
+  def matchChangesWithRoadAddresses(roadAddresses: Seq[RoadAddress], changes: Seq[ChangeInfo]) = {
+    roadAddresses.map(ra => {
+      (ra, changes.filter(c => {
+        (c.newId.getOrElse(-1) == ra.linkId || c.oldId.getOrElse(-1) == ra.linkId) && c.vvhTimeStamp > ra.adjustedTimestamp
+      }))
+    })
+  }
+
 }
 
 case class RoadAddressMerge(merged: Set[Long], created: Seq[RoadAddress])

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -143,7 +143,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
   }
 
   ignore("Fetch project links") { // Needs more of mocking because of Futures + transactions disagreeing
-    val roadLinkService = new RoadLinkService(new VVHClient(properties.getProperty("digiroad2.VVHRestApiEndPoint")), mockEventBus, new DummySerializer) {
+  val roadLinkService = new RoadLinkService(new VVHClient(properties.getProperty("digiroad2.VVHRestApiEndPoint")), mockEventBus, new DummySerializer) {
       override def withDynSession[T](f: => T): T = f
       override def withDynTransaction[T](f: => T): T = f
     }
@@ -260,8 +260,8 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     assume(testConnection)
     runWithRollback{
       val project = RoadAddressProject(1,ProjectState.Incomplete,"testiprojekti","Test",DateTime.now(),"Test",DateTime.now(),DateTime.now(),"info",List(ReservedRoadPart(5:Long, 203:Long, 203:Long, 5:Double, Discontinuity.apply("jatkuva"), 8:Long, None:Option[DateTime], None:Option[DateTime])), None)
-           ProjectDAO.createRoadAddressProject(project)
-            sqlu""" insert into road_address_changes(project_id,change_type,new_road_number,new_road_part_number,new_track_code,new_start_addr_m,new_end_addr_m,new_discontinuity,new_road_type,new_ely) Values(1,1,6,1,1,0,10.5,1,1,8) """.execute
+      ProjectDAO.createRoadAddressProject(project)
+      sqlu""" insert into road_address_changes(project_id,change_type,new_road_number,new_road_part_number,new_track_code,new_start_addr_m,new_end_addr_m,new_discontinuity,new_road_type,new_ely) Values(1,1,6,1,1,0,10.5,1,1,8) """.execute
       //Assuming that there is data to show
       val responses = projectService.getRoadAddressChangesAndSendToTR(Set(1))
       responses.projectId should be( 1)
@@ -271,7 +271,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
   test ("update ProjectStatus when TR saved")
   {
     val sent2TRState=ProjectState.apply(2) //notfinnished
-    val savedState=ProjectState.apply(5)
+  val savedState=ProjectState.apply(5)
     val projectId=0
     val addresses = List(ReservedRoadPart(5:Long, 203:Long, 203:Long, 5:Double, Discontinuity.apply("jatkuva"), 8:Long, None:Option[DateTime], None:Option[DateTime]))
     val roadAddressProject = RoadAddressProject(projectId, ProjectState.apply(2), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List(), None)
@@ -299,7 +299,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
   }
 
   test("process roadChange data and expire the roadLinks"){
-      //First Create Mock Project, RoadLinks and
+    //First Create Mock Project, RoadLinks and
 
     runWithRollback{
       var projectId = 0L
@@ -308,7 +308,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       val linkId = 12345L
       //Creation of Test road
       val id = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id, roadNumber, roadPartNumber, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, linkId, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val ra = Seq(RoadAddress(id, roadNumber, roadPartNumber, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, linkId, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       RoadAddressDAO.create(ra)
       val roadsBeforeChanges = RoadAddressDAO.fetchByLinkId(Set(linkId)).head
@@ -355,9 +355,9 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     runWithRollback{
       val id1 = RoadAddressDAO.getNextRoadAddressId
       val id2 = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id1, roadNumber, roadStartPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val ra = Seq(RoadAddress(id1, roadNumber, roadStartPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
-      val rb = Seq(RoadAddress(id2, roadNumber, roadEndPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val rb = Seq(RoadAddress(id2, roadNumber, roadEndPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       val shouldNotExist = projectService.checkRoadAddressNumberAndSEParts(roadNumber, roadStartPart, roadEndPart)
       shouldNotExist.get should be("Tienumeroa ei ole olemassa, tarkista tiedot")
@@ -382,17 +382,73 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean])).thenReturn(Seq(roadlink))
     runWithRollback {
       val id1 = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id1, roadNumber, roadStartPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val ra = Seq(RoadAddress(id1, roadNumber, roadStartPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       val reservation = projectService.checkReservability(roadNumber, roadStartPart, roadEndPart)
+      reservation.right.get.size should be (0)
       RoadAddressDAO.create(ra)
       val id2 = RoadAddressDAO.getNextRoadAddressId
-      val rb = Seq(RoadAddress(id2, roadNumber, roadEndPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val rb = Seq(RoadAddress(id2, roadNumber, roadEndPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
-
-
       RoadAddressDAO.create(rb)
-      reservation
+      val reservationAfterB = projectService.checkReservability(roadNumber, roadStartPart, roadEndPart)
+      reservationAfterB.right.get.size should be (2)
+      reservationAfterB.right.get.map(_.roadNumber).distinct.size should be(1)
+      reservationAfterB.right.get.map(_.roadNumber).distinct.head should be (roadNumber)
     }
+  }
+
+  test("get the road address project") {
+    var count = 0
+    runWithRollback {
+      val countCurrentProjects = projectService.getRoadAddressAllProjects()
+      val id = 0
+      val addresses:List[ReservedRoadPart]= List(ReservedRoadPart(5:Long, 203:Long, 203:Long, 5:Double, Discontinuity.apply("jatkuva"), 8:Long, None:Option[DateTime], None:Option[DateTime]))
+      val roadAddressProject = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", addresses, None)
+      projectService.createRoadLinkProject(roadAddressProject)
+      val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
+      count = countCurrentProjects.size + 1
+      countAfterInsertProjects.size should be (count)
+      val project = projectService.getRoadAddressSingleProject(id)
+      project.size should be(1)
+      project.head.name should be ("TestProject")
+    }
+    runWithRollback {
+      projectService.getRoadAddressAllProjects().size should be (count-1)
+    }
+  }
+
+  test("get the project with it's reserved road parts") {
+    var projectId = 0L
+    val roadNumber = 1943845
+    val roadPartNumber = 1
+    val linkId = 12345L
+
+    runWithRollback{
+
+      //Creation of Test road
+      val id = RoadAddressDAO.getNextRoadAddressId
+      val ra = Seq(RoadAddress(id, roadNumber, roadPartNumber, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, linkId, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+      when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(linkId))).thenReturn(Seq(RoadLink(linkId, ra.head.geom, 9.8, State, 1, TrafficDirection.BothDirections,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(167)))))
+      RoadAddressDAO.create(ra)
+
+      //Creation of test project with test links
+      val project = RoadAddressProject(projectId,ProjectState.Incomplete,"testiprojekti","Test",DateTime.now(),"Test",
+        DateTime.now(),DateTime.now(),"info",
+        List(ReservedRoadPart(0:Long, roadNumber:Long, roadPartNumber:Long, 5:Double, Discontinuity.apply("jatkuva"),
+          8:Long, None:Option[DateTime], None:Option[DateTime])), None)
+      val (proj, projectLink, _, errmsg) = projectService.createRoadLinkProject(project)
+
+      val projectWithReserves = projectService.getProjectsWithReservedRoadParts(proj.id)
+      val returnedProject = projectWithReserves._1
+      val returnedRoadParts = projectWithReserves._2
+
+      returnedProject.name should be("testiprojekti")
+      returnedRoadParts.size should be(1)
+      returnedRoadParts.head.roadNumber should be(roadNumber)
+    }
+
   }
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -224,11 +224,12 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       countAfterInsertProjects.size should be (count)
       sqlu"""UPDATE Project_link set status = 1""".execute
       val terminations = ProjectDeltaCalculator.delta(saved.id).terminations
+      terminations should have size(66)
       val sections = ProjectDeltaCalculator.partition(terminations)
-      sections should have size (2)
+      sections should have size (64)
       sections.exists(_.track == Track.LeftSide) should be (true)
       sections.exists(_.track == Track.RightSide) should be (true)
-      sections.groupBy(_.endMAddr).keySet.size should be (1)
+      sections.groupBy(_.endMAddr).keySet.size should be (59)
     }
     runWithRollback { projectService.getRoadAddressAllProjects() } should have size (count - 1)
   }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
@@ -14,7 +14,7 @@ import org.scalatest.{Assertions, FunSuite, Matchers}
 class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
 
   test("Fuse road address should accept single road address") {
-    val roadAddress = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, None, None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+    val roadAddress = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, None, None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
       Seq(Point(0.0,0.0), Point(0.0,9.8))))
     RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should be (roadAddress)
   }
@@ -23,9 +23,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8,
-          SideCode.TowardsDigitizing, (None, None), true, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4,
-          SideCode.TowardsDigitizing, (None, None), true, Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
+          SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (1)
     }
@@ -34,11 +34,11 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
   test("Fuse road address should not merge consecutive road addresses with differing start dates") {
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
-        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
-        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1902-02-02")), None, Option("tester"),0, 12345L, 9.8, 20.2, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1902-02-02")), None, Option("tester"),0, 12345L, 9.8, 20.2, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 9.8), Point(0.0, 20.2))),
-        RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 20.2, 30.2, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 20.2, 30.2, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 20.2), Point(0.0, 30.2)))
       )
       val fused = RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
@@ -51,9 +51,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
   test("Fuse road address should not merge consecutive road addresses with differing link ids") {
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
-        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
-        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12346L, 0.0, 10.4, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12346L, 0.0, 10.4, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (2)
@@ -65,9 +65,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
   test("Fuse road address should not merge consecutive road addresses if side code differs") {
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
-        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
-        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.AgainstDigitizing, (None, None), false,
+        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.AgainstDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
       )
       intercept[InvalidAddressDataException] {
@@ -79,13 +79,13 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
   test("Fuse road address should merge multiple road addresses with random ordering") {
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
-        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
-        RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 30.0), Point(0.0, 39.8))),
-        RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 20.2), Point(0.0, 30.0))),
-        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.TowardsDigitizing, (None, None), false,
+        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (1)
@@ -97,16 +97,16 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8,
-          SideCode.TowardsDigitizing, (None, Some(CalibrationPoint(12345L, 9.8, 10L))), false, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          SideCode.TowardsDigitizing, 0, (None, Some(CalibrationPoint(12345L, 9.8, 10L))), false, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
 
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4,
-          SideCode.TowardsDigitizing, (Some(CalibrationPoint(12345L, 9.8, 10L)), None), false, Seq(Point(0.0, 9.8), Point(0.0, 20.2))),
+          SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(12345L, 9.8, 10L)), None), false, Seq(Point(0.0, 9.8), Point(0.0, 20.2))),
 
         RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0,
-          SideCode.TowardsDigitizing, (None, None), false, Seq(Point(0.0, 20.2), Point(0.0, 30.0))),
+          SideCode.TowardsDigitizing, 0, (None, None), false, Seq(Point(0.0, 20.2), Point(0.0, 30.0))),
 
         RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8,
-          SideCode.TowardsDigitizing, (None, None), false, Seq(Point(0.0, 30.0), Point(0.0, 39.8)))
+          SideCode.TowardsDigitizing, 0, (None, None), false, Seq(Point(0.0, 30.0), Point(0.0, 39.8)))
       )
       //Changed fuseRoadAddress size from 3 to 2 the reasoning behind it is that although we cannot fuse  1 and 2, there is nothing stopping us from fusing 2,3 and 4
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (2)
@@ -117,10 +117,10 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     val geom = Seq(Point(379483.273,6672835.486), Point(379556.289,6673054.073))
     val roadAddress = Seq(
       RoadAddress(3767413, 101, 1, Track.RightSide, Discontinuous, 679L, 701L, Some(DateTime.parse("1991-01-01")), None, Option("tester"),0, 138834, 0.0, 21.0,
-        SideCode.TowardsDigitizing, (Some(CalibrationPoint(138834, 0.0, 679L)), None), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0)),
+        SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(138834, 0.0, 679L)), None), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0)),
 
       RoadAddress(3767414, 101, 1, Track.RightSide, Discontinuous, 701L, 923L, Some(DateTime.parse("1991-01-01")), None, Option("tester"),0, 138834, 21.0, 230.776,
-        SideCode.TowardsDigitizing, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776))
+        SideCode.TowardsDigitizing, 0, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776))
     )
     val fusedList = RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
     fusedList should have size (1)
@@ -141,10 +141,10 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     val geom = Seq(Point(379483.273,6672835.486), Point(379556.289,6673054.073))
     val roadAddress = Seq(
       RoadAddress(3767413, 101, 1, Track.RightSide, Discontinuous, 679L, 701L, Some(DateTime.parse("1991-01-01")), None, Option("tester"),0, 138834, 0.0, 21.0,
-        SideCode.TowardsDigitizing, (Some(CalibrationPoint(138834, 0.0, 679L)), Some(CalibrationPoint(138834, 21.0, 920L))), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0)),
+        SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(138834, 0.0, 679L)), Some(CalibrationPoint(138834, 21.0, 920L))), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0)),
 
       RoadAddress(3767414, 101, 1, Track.RightSide, Discontinuous, 701L, 923L, Some(DateTime.parse("1991-01-01")), None,  Option("tester"),0, 138834, 21.0, 230.776,
-        SideCode.TowardsDigitizing, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776))
+        SideCode.TowardsDigitizing, 0, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776))
     )
     val fusedList = RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
     fusedList should have size (1)
@@ -165,13 +165,13 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
   test("Fuse road address should fuse against digitization road addresses properly") {
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
-        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.AgainstDigitizing, (None, None), false,
+        RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.AgainstDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 9.8), Point(0.0, 0.0))),
-        RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8, SideCode.AgainstDigitizing, (None, None), false,
+        RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8, SideCode.AgainstDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 39.8), Point(0.0, 30.0))),
-        RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0, SideCode.AgainstDigitizing, (None, None), false,
+        RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0, SideCode.AgainstDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 30.0), Point(0.0, 20.2))),
-        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.AgainstDigitizing, (None, None), false,
+        RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.AgainstDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 20.2), Point(0.0, 9.8)))
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (1)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -368,7 +368,7 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
 
   private def roadAddressLinkToRoadAddress(floating: Boolean)(l: RoadAddressLink) = {
     RoadAddress(l.id, l.roadNumber, l.roadPartNumber, Track.apply(l.trackCode.toInt), Discontinuity.apply(l.discontinuity.toInt),
-      l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode,
+      l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode, 0,
       (l.startCalibrationPoint, l.endCalibrationPoint), floating, l.geometry)
   }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -13,6 +13,7 @@ import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.user.{Configuration, User}
 import fi.liikennevirasto.digiroad2.util.Track
+import fi.liikennevirasto.viite.dao.Discontinuity.Discontinuous
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.model.{Anomaly, RoadAddressLink, RoadAddressLinkPartitioner}
 import fi.liikennevirasto.viite.process.RoadAddressFiller.LRMValueAdjustment
@@ -686,4 +687,44 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
 
   }
 
+
+  test("verify the correct annexation of changeInfos to roadAddresses"){
+    val linkId1 = 12345L
+    val linkId2 = 67890L
+    val linkId3 = 98765L
+    val defaultVVTimestamp = 1459452603000L
+    val roadAddress = Seq(
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, linkId1, 0.0, 9.8,
+        SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, linkId2, 0.0, 10.4,
+        SideCode.TowardsDigitizing, defaultVVTimestamp, (None, None), true, Seq(Point(0.0, 9.8), Point(0.0, 20.2))),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, linkId3, 0.0, 10.4,
+        SideCode.TowardsDigitizing, defaultVVTimestamp, (None, None), true, Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
+    )
+
+    val changeInfo =
+      Seq(
+        ChangeInfo(Option(602156), Option(linkId2), 6798918, 1, Option(10.52131863), Option(106.62158114), Option(0.0), Option(96.166451179999996), defaultVVTimestamp+5L) ,
+        ChangeInfo(Option(linkId2), Option(602156), 6798918, 2, Option(10.52131863), Option(106.62158114), Option(0.0), Option(96.166451179999996), defaultVVTimestamp+5L) ,
+        ChangeInfo(Option(linkId2), Option(602156), 6798918, 3, Option(10.52131863), Option(106.62158114), Option(0.0), Option(96.166451179999996), defaultVVTimestamp) ,
+        ChangeInfo(Option(602156), Option(602156), 6798918, 4, Option(10.52131863), Option(106.62158114), Option(0.0), Option(96.166451179999996), defaultVVTimestamp) ,
+        ChangeInfo(Option(602156), Option(linkId1), 6798918, 5, Option(10.52131863), Option(106.62158114), Option(0.0), Option(96.166451179999996), defaultVVTimestamp+5L)
+      )
+    val matchedResults = roadAddressService.matchChangesWithRoadAddresses(roadAddress, changeInfo)
+
+    matchedResults.size should be(3)
+    val firstMatch = matchedResults.find(_._1.linkId == linkId1).get
+    val secondMatch = matchedResults.find(_._1.linkId == linkId2).get
+    val thirdMatch = matchedResults.find(_._1.linkId == linkId3).get
+
+    firstMatch._2.size should be (1)
+    firstMatch._2.head.changeType should be (5)
+    secondMatch._2.size should be (2)
+    secondMatch._2(0).changeType should be (1)
+    secondMatch._2(1).changeType should be (2)
+    thirdMatch._2.size should be (0)
+
+    matchedResults.flatMap(_._2).find(_.changeType == 3).isEmpty should be (true)
+
+  }
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/RoadAddressDAOSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/RoadAddressDAOSpec.scala
@@ -89,7 +89,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
   test("Create Road Address") {
     runWithRollback {
       val id = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       val currentSize = RoadAddressDAO.fetchByRoadPart(ra.head.roadNumber, ra.head.roadPartNumber).size
       val returning = RoadAddressDAO.create(ra)
@@ -104,7 +104,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
     runWithRollback {
       val username = "testUser"
       val id = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       val currentSize = RoadAddressDAO.fetchByRoadPart(ra.head.roadNumber, ra.head.roadPartNumber).size
       val returning = RoadAddressDAO.create(ra, Some(username))
@@ -120,7 +120,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
   test("Create Road Address With Calibration Point") {
     runWithRollback {
       val id = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,
+      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0,
         (Some(CalibrationPoint(12345L, 0.0, 0L)), None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       val returning = RoadAddressDAO.create(ra)
@@ -131,7 +131,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
     }
     runWithRollback {
       val id = RoadAddressDAO.getNextRoadAddressId
-      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,
+      val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0,
         (Some(CalibrationPoint(12345L, 0.0, 0L)), Some(CalibrationPoint(12345L, 9.8, 10L))), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       val returning = RoadAddressDAO.create(ra)
@@ -157,7 +157,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
     val localRoadAddressService = new RoadAddressService(localMockRoadLinkService,localMockEventBus)
     runWithRollback {
       val id = RoadAddressDAO.getNextRoadAddressId
-      val toBeMergedRoadAddresses = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 6556558L, 0.0, 9.8, SideCode.TowardsDigitizing, (None, None), false,
+      val toBeMergedRoadAddresses = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 6556558L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
         Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
       localRoadAddressService.mergeRoadAddressInTX(RoadAddressMerge(Set(1L), toBeMergedRoadAddresses))
     }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
@@ -99,7 +99,7 @@ class DefloatMapperSpec extends FunSuite with Matchers{
 
   private def roadAddressLinkToRoadAddress(floating: Boolean)(l: RoadAddressLink) = {
     RoadAddress(l.id, l.roadNumber, l.roadPartNumber, Track.apply(l.trackCode.toInt), Discontinuity.apply(l.discontinuity.toInt),
-      l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode,
+      l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode, l.attributes.get("ADJUSTED_TIMESTAMP").getOrElse(0L).asInstanceOf[Long],
       (l.startCalibrationPoint, l.endCalibrationPoint), floating, l.geometry)
   }
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/LinkRoadAddressCalculatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/LinkRoadAddressCalculatorSpec.scala
@@ -13,9 +13,9 @@ import org.scalatest.{FunSuite, Matchers}
 class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate one track road with single part") {
-    val addresses = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"), 0,123L, 0.0, 98.3, SideCode.Unknown, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 33.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 48.1, SideCode.Unknown, (None, Some(CalibrationPoint(125L, 48.1, 180))), false, Seq()))
+    val addresses = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"), 0,123L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 33.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 48.1, 180))), false, Seq()))
     val returnval = LinkRoadAddressCalculator.recalculate(addresses)
     returnval.last.endAddrMValue should be (180)
     returnval.last.endMValue should be (48.1)
@@ -25,12 +25,12 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate one track road with single parts") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.LeftSide, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.LeftSide, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.LeftSide, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, (None, Some(CalibrationPoint(125L, 48.1, 180))),false, Seq()),
-      RoadAddress(4, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(5, 1, 1, Track.RightSide, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 33.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq())
+      RoadAddress(1, 1, 1, Track.LeftSide, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(2, 1, 1, Track.LeftSide, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(3, 1, 1, Track.LeftSide, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 48.1, 180))),false, Seq()),
+      RoadAddress(4, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(5, 1, 1, Track.RightSide, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 33.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq())
     )
     val (left, right) = LinkRoadAddressCalculator.recalculate(addresses).partition(_.track == Track.LeftSide)
     left.last.endAddrMValue should be (180)
@@ -43,15 +43,15 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate one track road with multiple parts together") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq()),
-      RoadAddress(4, 1, 2, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(5, 1, 2, Track.Combined, Discontinuity.Continuous, 100, 108, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(6, 1, 2, Track.Combined, Discontinuity.Continuous, 108, 116, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(7, 1, 2, Track.Combined, Discontinuity.Continuous, 116, 124, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(8, 1, 2, Track.Combined, Discontinuity.Continuous, 124, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 9.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(9, 1, 2, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq())
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq()),
+      RoadAddress(4, 1, 2, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(5, 1, 2, Track.Combined, Discontinuity.Continuous, 100, 108, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(6, 1, 2, Track.Combined, Discontinuity.Continuous, 108, 116, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(7, 1, 2, Track.Combined, Discontinuity.Continuous, 116, 124, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(8, 1, 2, Track.Combined, Discontinuity.Continuous, 124, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 9.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(9, 1, 2, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq())
     )
     val (one, two) = LinkRoadAddressCalculator.recalculate(addresses).partition(_.roadPartNumber == 1)
     one.last.endAddrMValue should be (180)
@@ -64,15 +64,15 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate multiple track road with single part") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq()),
-      RoadAddress(4, 1, 1, Track.LeftSide, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,223L, 0.0, 44.3, SideCode.Unknown, (Some(CalibrationPoint(223L, 0.0, 180)), None), false, Seq()),
-      RoadAddress(5, 1, 1, Track.LeftSide, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,224L, 0.0, 33.2, SideCode.Unknown, (None, Some(CalibrationPoint(225L, 33.2, 265))), false, Seq()),
-      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 180, 230, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, (Some(CalibrationPoint(225L, 0.0, 180)), None), false, Seq()),
-      RoadAddress(7, 1, 1, Track.RightSide, Discontinuity.Continuous, 230, 265, Some(DateTime.now), None, Option("tester"),0, 323L, 0.0, 38.3, SideCode.Unknown, (None, Some(CalibrationPoint(323L, 38.3, 265))), false, Seq()),
-      RoadAddress(8, 1, 1, Track.Combined, Discontinuity.Continuous, 265, 300, Some(DateTime.now), None, Option("tester"),0, 324L, 0.0, 33.2, SideCode.Unknown, (Some(CalibrationPoint(323L, 0.0, 265)), None), false, Seq()),
-      RoadAddress(9, 1, 1, Track.Combined, Discontinuity.EndOfRoad, 300, 350, Some(DateTime.now), None, Option("tester"),0, 325L, 0.0, 48.1, SideCode.Unknown, (None, Some(CalibrationPoint(225L, 48.1, 350))), false, Seq())
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq()),
+      RoadAddress(4, 1, 1, Track.LeftSide, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,223L, 0.0, 44.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 180)), None), false, Seq()),
+      RoadAddress(5, 1, 1, Track.LeftSide, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,224L, 0.0, 33.2, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 33.2, 265))), false, Seq()),
+      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 180, 230, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (Some(CalibrationPoint(225L, 0.0, 180)), None), false, Seq()),
+      RoadAddress(7, 1, 1, Track.RightSide, Discontinuity.Continuous, 230, 265, Some(DateTime.now), None, Option("tester"),0, 323L, 0.0, 38.3, SideCode.Unknown, 0, (None, Some(CalibrationPoint(323L, 38.3, 265))), false, Seq()),
+      RoadAddress(8, 1, 1, Track.Combined, Discontinuity.Continuous, 265, 300, Some(DateTime.now), None, Option("tester"),0, 324L, 0.0, 33.2, SideCode.Unknown, 0, (Some(CalibrationPoint(323L, 0.0, 265)), None), false, Seq()),
+      RoadAddress(9, 1, 1, Track.Combined, Discontinuity.EndOfRoad, 300, 350, Some(DateTime.now), None, Option("tester"),0, 325L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 350))), false, Seq())
     )
     val results = LinkRoadAddressCalculator.recalculate(addresses).toList.sortBy(_.endAddrMValue)
     results.last.endAddrMValue should be (350)
@@ -82,11 +82,11 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("calibration point in the middle of the link must not break calculation") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 123L, 108.3, 135.2, SideCode.Unknown, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"), 0,123L, 135.2, 180.1, SideCode.Unknown, (None, Some(CalibrationPoint(123L, 180.1, 180))), false, Seq()),
-      RoadAddress(4, 1, 1, Track.Combined, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,123L, 180.1, 224.3, SideCode.Unknown, (Some(CalibrationPoint(123L, 180.1, 180)), None), false, Seq()),
-      RoadAddress(5, 1, 1, Track.Combined, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,123L, 224.3, 265.2, SideCode.Unknown, (None, Some(CalibrationPoint(225L, 265.2, 265))), false, Seq()))
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 123L, 108.3, 135.2, SideCode.Unknown, 0, (None, None), false, Seq()),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"), 0,123L, 135.2, 180.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(123L, 180.1, 180))), false, Seq()),
+      RoadAddress(4, 1, 1, Track.Combined, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,123L, 180.1, 224.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 180.1, 180)), None), false, Seq()),
+      RoadAddress(5, 1, 1, Track.Combined, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,123L, 224.3, 265.2, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 265.2, 265))), false, Seq()))
     val results = LinkRoadAddressCalculator.recalculate(addresses).toList.sortBy(_.endAddrMValue)
     results.foreach(println)
     results.last.endAddrMValue should be (265)


### PR DESCRIPTION
Changed the RoadAddress in order to include the adjusted_timestamp~from LRM_POSITION; ground work for Viite-82.

Added a test for the getChangeInfoFromVVH method on the RoadLinkService.

Added a small helper method that when supplied with both with a sequence of RoadAddresses and ChangeInfos it will return what un-applied changeInfos match said roadAddress.

Added a TODO as a reminder of future changes to the vvhChangeInfo queries.