### PR TITLE
Viite 515 crash on floating transfer

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -223,6 +223,17 @@ object RoadAddressLinkBuilder {
     latestDateString
   }
 
+  def prettyPrint(l: RoadAddress): String = {
+
+    s"""${if (l.id == -1000) { "NEW!" } else { l.id }} link: ${l.linkId} ${setPrecision(l.startMValue)}-${setPrecision(l.endMValue)} road address: ${l.roadNumber}/${l.roadPartNumber}/${l.track.value}/${l.startAddrMValue}-${l.endAddrMValue} length: ${setPrecision(l.endMValue - l.startMValue)} dir: ${l.sideCode}
+       |${if (l.startCalibrationPoint.nonEmpty) { " <- " + l.startCalibrationPoint.get.addressMValue + " "} else ""}
+       |${if (l.endCalibrationPoint.nonEmpty) { " " + l.endCalibrationPoint.get.addressMValue + " ->"} else ""}
+     """.stripMargin.replace("\n", "")
+  }
+
+  private def setPrecision(d: Double) = {
+    BigDecimal(d).setScale(3, BigDecimal.RoundingMode.HALF_UP).toDouble
+  }
   /**
     * Fuse recursively
     *
@@ -231,6 +242,11 @@ object RoadAddressLinkBuilder {
     * @return road addresses fused in reverse order
     */
   private def fuseRoadAddressInGroup(unprocessed: Seq[RoadAddress], ready: Seq[RoadAddress] = Nil): Seq[RoadAddress] = {
+    println("ready:")
+    ready.map(prettyPrint).foreach(println)
+    println("unprocessed:")
+    unprocessed.map(prettyPrint).foreach(println)
+
     if (ready.isEmpty)
       fuseRoadAddressInGroup(unprocessed.tail, Seq(unprocessed.head))
     else if (unprocessed.isEmpty)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -223,17 +223,6 @@ object RoadAddressLinkBuilder {
     latestDateString
   }
 
-  def prettyPrint(l: RoadAddress): String = {
-
-    s"""${if (l.id == -1000) { "NEW!" } else { l.id }} link: ${l.linkId} ${setPrecision(l.startMValue)}-${setPrecision(l.endMValue)} road address: ${l.roadNumber}/${l.roadPartNumber}/${l.track.value}/${l.startAddrMValue}-${l.endAddrMValue} length: ${setPrecision(l.endMValue - l.startMValue)} dir: ${l.sideCode}
-       |${if (l.startCalibrationPoint.nonEmpty) { " <- " + l.startCalibrationPoint.get.addressMValue + " "} else ""}
-       |${if (l.endCalibrationPoint.nonEmpty) { " " + l.endCalibrationPoint.get.addressMValue + " ->"} else ""}
-     """.stripMargin.replace("\n", "")
-  }
-
-  private def setPrecision(d: Double) = {
-    BigDecimal(d).setScale(3, BigDecimal.RoundingMode.HALF_UP).toDouble
-  }
   /**
     * Fuse recursively
     *
@@ -242,11 +231,6 @@ object RoadAddressLinkBuilder {
     * @return road addresses fused in reverse order
     */
   private def fuseRoadAddressInGroup(unprocessed: Seq[RoadAddress], ready: Seq[RoadAddress] = Nil): Seq[RoadAddress] = {
-    println("ready:")
-    ready.map(prettyPrint).foreach(println)
-    println("unprocessed:")
-    unprocessed.map(prettyPrint).foreach(println)
-
     if (ready.isEmpty)
       fuseRoadAddressInGroup(unprocessed.tail, Seq(unprocessed.head))
     else if (unprocessed.isEmpty)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -811,7 +811,7 @@ object RoadAddressDAO {
         case None => ""
       })
       addressPS.setString(11, createdBy.getOrElse(address.modifiedBy.getOrElse("-")))
-    val (p1, p2) = (address.geom.head, address.geom.last)
+      val (p1, p2) = (address.geom.head, address.geom.last)
       addressPS.setDouble(12, p1.x)
       addressPS.setDouble(13, p1.y)
       addressPS.setDouble(14, address.startAddrMValue)
@@ -830,7 +830,7 @@ object RoadAddressDAO {
   }
 
   def createLRMPosition(lrmPositionPS: PreparedStatement, id: Long, linkId: Long, sideCode: Int,
-                                startM: Double, endM: Double): Unit = {
+                        startM: Double, endM: Double): Unit = {
     lrmPositionPS.setLong(1, id)
     lrmPositionPS.setLong(2, linkId)
     lrmPositionPS.setLong(3, sideCode)
@@ -885,6 +885,6 @@ object RoadAddressDAO {
              on r.START_ADDR_M=ra.lol
              WHERE r.road_number=$roadNumber AND r.road_part_number=$roadPart AND
              (r.valid_from is null or r.valid_from <= sysdate) AND (r.valid_to is null or r.valid_to > sysdate) AND track_code in (0,1)"""
-     Q.queryNA[(Long,Long,Double,Long, DateTime, DateTime)](query).firstOption
-    }
+    Q.queryNA[(Long,Long,Double,Long, DateTime, DateTime)](query).firstOption
+  }
 }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -154,8 +154,8 @@ object RoadAddressDAO {
                            startAddrMValue: Long, endAddrMValue: Long, sideCode: SideCode): (Option[CalibrationPoint], Option[CalibrationPoint]) = {
     sideCode match {
       case BothDirections => (None, None) // Invalid choice
-      case TowardsDigitizing => calibrations(calibrationCode, linkId, 0.0, endMValue-startMValue, startAddrMValue, endAddrMValue)
-      case AgainstDigitizing => calibrations(calibrationCode, linkId, endMValue-startMValue, 0.0, startAddrMValue, endAddrMValue)
+      case TowardsDigitizing => calibrations(calibrationCode, linkId, 0.0, Math.max(startMValue, endMValue), startAddrMValue, endAddrMValue)
+      case AgainstDigitizing => calibrations(calibrationCode, linkId, Math.max(startMValue, endMValue), 0.0, startAddrMValue, endAddrMValue)
       case Unknown => (None, None)  // Invalid choice
     }
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -74,6 +74,10 @@ object DefloatMapper {
       GeometryUtils.truncateGeometry3D(geometry, Math.min(d1, d2), Math.max(d1, d2))
     }
     def adjust(mapping: RoadAddressMapping, startM: Double, endM: Double) = {
+
+
+//
+      // THE BUG IS HERE
       if (mapping.sourceLinkId != mapping.targetLinkId)
         mapping
       else {
@@ -112,6 +116,7 @@ object DefloatMapper {
         case Some(cp) => if (cp.addressMValue == endAddrM) Some(cp.copy(linkId = adjMap.targetLinkId,
           segmentMValue = if (sideCode == SideCode.TowardsDigitizing) Math.max(startM, endM) else 0.0)) else None
       }
+      println(s"mapped ${ra.linkId} ${ra.startAddrMValue}-${ra.endAddrMValue} to ${startCP.map(_.addressMValue).getOrElse(startAddrM)}-${endCP.map(_.addressMValue).getOrElse(endAddrM)}")
       ra.copy(id = NewRoadAddress, linkId = adjMap.targetLinkId, startAddrMValue = startCP.map(_.addressMValue).getOrElse(startAddrM),
         endAddrMValue = endCP.map(_.addressMValue).getOrElse(endAddrM), floating = false,
         sideCode = sideCode, startMValue = startM, endMValue = endM, geom = mappedGeom, calibrationPoints = (startCP, endCP))
@@ -127,6 +132,7 @@ object DefloatMapper {
     val (startM, endM) = (mapping.sourceStartM, mapping.sourceEndM)
     // The lengths may not be exactly equal: coefficient is to adjust that
     val coefficient = (roadAddress.endAddrMValue - roadAddress.startAddrMValue) / (roadAddress.endMValue - roadAddress.startMValue)
+    println(coefficient, s"${roadAddress.startAddrMValue}-${roadAddress.endAddrMValue} / ${(roadAddress.endMValue - roadAddress.startMValue)} with ${startM} ${endM}")
     roadAddress.sideCode match {
       case SideCode.AgainstDigitizing =>
         (roadAddress.endAddrMValue - Math.round(endM*coefficient), roadAddress.endAddrMValue - Math.round(startM*coefficient))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -94,8 +94,6 @@ object DefloatMapper {
     }
     roadAddressMapping.filter(_.matches(ra)).map(mapping => {
       val adjMap = adjust(mapping, ra.startMValue, ra.endMValue)
-      println("ra: " + ra.startAddrMValue + " - " + ra.endAddrMValue + s" (${ra.startMValue}-${ra.endMValue})")
-      println(adjMap)
       val (mappedStartM, mappedEndM) = (adjMap.targetStartM, adjMap.targetEndM)
       val (sideCode, mappedGeom, (mappedStartAddrM, mappedEndAddrM)) =
         if (isDirectionMatch(adjMap))

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -94,7 +94,7 @@ object DefloatMapper {
     }
     roadAddressMapping.filter(_.matches(ra)).map(mapping => {
       val adjMap = adjust(mapping, ra.startMValue, ra.endMValue)
-      println("ra: " + ra.startAddrMValue + " - " + ra.endAddrMValue)
+      println("ra: " + ra.startAddrMValue + " - " + ra.endAddrMValue + s" (${ra.startMValue}-${ra.endMValue})")
       println(adjMap)
       val (mappedStartM, mappedEndM) = (adjMap.targetStartM, adjMap.targetEndM)
       val (sideCode, mappedGeom, (mappedStartAddrM, mappedEndAddrM)) =

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/DefloatMapper.scala
@@ -71,28 +71,31 @@ object DefloatMapper {
 
   def mapRoadAddresses(roadAddressMapping: Seq[RoadAddressMapping])(ra: RoadAddress): Seq[RoadAddress] = {
     def truncate(geometry: Seq[Point], d1: Double, d2: Double) = {
-      GeometryUtils.truncateGeometry3D(geometry, Math.min(d1, d2), Math.max(d1, d2))
+      val startM = Math.max(Math.min(d1, d2), 0.0)
+      val endM = Math.min(Math.max(d1, d2), GeometryUtils.geometryLength(geometry))
+      GeometryUtils.truncateGeometry3D(geometry,
+        startM, endM)
     }
     def adjust(mapping: RoadAddressMapping, startM: Double, endM: Double) = {
-
-
-//
-      // THE BUG IS HERE
-      if (mapping.sourceLinkId != mapping.targetLinkId)
+      if (withinTolerance(mapping.sourceStartM, startM) && withinTolerance(mapping.sourceEndM, endM))
         mapping
       else {
         val (newStartM, newEndM) =
-          (if (startM < mapping.sourceStartM + MaxDistanceDiffAllowed) mapping.sourceStartM else startM,
-            if (endM > mapping.sourceEndM - MaxDistanceDiffAllowed) mapping.sourceEndM else endM)
-        val (newTargetStartM, newTargetEndM) = (newStartM * mapping.coefficient, newEndM * mapping.coefficient)
+          (if (withinTolerance(startM, mapping.sourceStartM) || startM < mapping.sourceStartM) mapping.sourceStartM else startM,
+            if (withinTolerance(endM, mapping.sourceEndM) || endM > mapping.sourceEndM) mapping.sourceEndM else endM)
+        val (newTargetStartM, newTargetEndM) = (mapping.interpolate(newStartM), mapping.interpolate(newEndM))
+        val geomStartM = Math.min(mapping.sourceStartM, mapping.sourceEndM)
+        val geomTargetStartM = Math.min(mapping.interpolate(mapping.sourceStartM), mapping.interpolate(mapping.sourceEndM))
         mapping.copy(sourceStartM = newStartM, sourceEndM = newEndM, sourceGeom =
-          truncate(mapping.sourceGeom, newStartM, newEndM),
+          truncate(mapping.sourceGeom, newStartM - geomStartM, newEndM - geomStartM),
           targetStartM = newTargetStartM, targetEndM = newTargetEndM, targetGeom =
-            truncate(mapping.targetGeom, newTargetStartM, newTargetEndM))
+            truncate(mapping.targetGeom, newTargetStartM - geomTargetStartM, newTargetEndM - geomTargetStartM))
       }
     }
     roadAddressMapping.filter(_.matches(ra)).map(mapping => {
       val adjMap = adjust(mapping, ra.startMValue, ra.endMValue)
+      println("ra: " + ra.startAddrMValue + " - " + ra.endAddrMValue)
+      println(adjMap)
       val (mappedStartM, mappedEndM) = (adjMap.targetStartM, adjMap.targetEndM)
       val (sideCode, mappedGeom, (mappedStartAddrM, mappedEndAddrM)) =
         if (isDirectionMatch(adjMap))
@@ -116,7 +119,6 @@ object DefloatMapper {
         case Some(cp) => if (cp.addressMValue == endAddrM) Some(cp.copy(linkId = adjMap.targetLinkId,
           segmentMValue = if (sideCode == SideCode.TowardsDigitizing) Math.max(startM, endM) else 0.0)) else None
       }
-      println(s"mapped ${ra.linkId} ${ra.startAddrMValue}-${ra.endAddrMValue} to ${startCP.map(_.addressMValue).getOrElse(startAddrM)}-${endCP.map(_.addressMValue).getOrElse(endAddrM)}")
       ra.copy(id = NewRoadAddress, linkId = adjMap.targetLinkId, startAddrMValue = startCP.map(_.addressMValue).getOrElse(startAddrM),
         endAddrMValue = endCP.map(_.addressMValue).getOrElse(endAddrM), floating = false,
         sideCode = sideCode, startMValue = startM, endMValue = endM, geom = mappedGeom, calibrationPoints = (startCP, endCP))
@@ -128,17 +130,19 @@ object DefloatMapper {
   }
 
   private def splitRoadAddressValues(roadAddress: RoadAddress, mapping: RoadAddressMapping): (Long, Long) = {
-    // Check if the road address covers the whole mapping area
-    val (startM, endM) = (mapping.sourceStartM, mapping.sourceEndM)
-    // The lengths may not be exactly equal: coefficient is to adjust that
-    val coefficient = (roadAddress.endAddrMValue - roadAddress.startAddrMValue) / (roadAddress.endMValue - roadAddress.startMValue)
-    println(coefficient, s"${roadAddress.startAddrMValue}-${roadAddress.endAddrMValue} / ${(roadAddress.endMValue - roadAddress.startMValue)} with ${startM} ${endM}")
-    roadAddress.sideCode match {
-      case SideCode.AgainstDigitizing =>
-        (roadAddress.endAddrMValue - Math.round(endM*coefficient), roadAddress.endAddrMValue - Math.round(startM*coefficient))
-      case SideCode.TowardsDigitizing =>
-        (roadAddress.startAddrMValue + Math.round(startM*coefficient), roadAddress.startAddrMValue + Math.round(endM*coefficient))
-      case _ => throw new InvalidAddressDataException(s"Bad sidecode ${roadAddress.sideCode} on road address $roadAddress")
+    if (withinTolerance(roadAddress.startMValue, mapping.sourceStartM) && withinTolerance(roadAddress.endMValue, mapping.sourceEndM))
+      (roadAddress.startAddrMValue, roadAddress.endAddrMValue)
+    else {
+      val (startM, endM) = (mapping.sourceStartM, mapping.sourceEndM)
+      // The lengths may not be exactly equal: coefficient is to adjust that
+      val coefficient = (roadAddress.endAddrMValue - roadAddress.startAddrMValue) / (roadAddress.endMValue - roadAddress.startMValue)
+      roadAddress.sideCode match {
+        case SideCode.AgainstDigitizing =>
+          (roadAddress.endAddrMValue - Math.round(endM * coefficient), roadAddress.endAddrMValue - Math.round(startM * coefficient))
+        case SideCode.TowardsDigitizing =>
+          (roadAddress.startAddrMValue + Math.round(startM * coefficient), roadAddress.startAddrMValue + Math.round(endM * coefficient))
+        case _ => throw new InvalidAddressDataException(s"Bad sidecode ${roadAddress.sideCode} on road address $roadAddress")
+      }
     }
   }
 
@@ -305,6 +309,9 @@ object DefloatMapper {
   private def isDirectionMatch(r: RoadAddressMapping): Boolean = {
     ((r.sourceStartM - r.sourceEndM) * (r.targetStartM - r.targetEndM)) > 0
   }
+  private def withinTolerance(mValue1: Double, mValue2: Double) = {
+    Math.abs(mValue1 - mValue2) < MinAllowedRoadAddressLength
+  }
 
   def postTransferChecks(seq: Seq[RoadAddress]): Unit = {
     if (seq.count(_.startCalibrationPoint.nonEmpty) > 1)
@@ -398,7 +405,29 @@ case class RoadAddressMapping(sourceLinkId: Long, targetLinkId: Long, sourceStar
       GeometryUtils.overlapAmount((roadAddress.startMValue, roadAddress.endMValue), (sourceStartM, sourceEndM)) > 0.999
   }
 
-  val sourceLen: Double = Math.abs(sourceEndM - sourceStartM)
-  val targetLen: Double = Math.abs(targetEndM - targetStartM)
-  val coefficient: Double = targetLen/sourceLen
+  val sourceDelta = sourceEndM - sourceStartM
+  val targetDelta = targetEndM - targetStartM
+  val sourceLen: Double = Math.abs(sourceDelta)
+  val targetLen: Double = Math.abs(targetDelta)
+  val coefficient: Double = targetDelta/sourceDelta
+  /**
+    * interpolate location mValue on starting measure to target location
+    * @param mValue Source M value to map
+    */
+  def interpolate(mValue: Double): Double = {
+    if (withinTolerance(mValue, sourceStartM))
+      targetStartM
+    else if (withinTolerance(mValue, sourceEndM))
+      targetEndM
+    else {
+      // Affine transformation: y = ax + b
+      val a = coefficient
+      val b = targetStartM - sourceStartM
+      a * mValue + b
+    }
+  }
+
+  private def withinTolerance(mValue1: Double, mValue2: Double) = {
+    Math.abs(mValue1 - mValue2) < MinAllowedRoadAddressLength
+  }
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -712,7 +712,6 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
       RoadAddressDAO.create(roadAddressSeq)
       // pre-checks
       RoadAddressDAO.fetchByLinkId(Set(1392315L, 1392326L), true) should have size (3)
-      RoadAddressDAO.fetchByLinkId(Set(1392315L, 1392326L), true).foreach(println)
       val mapping = DefloatMapper.createAddressMap(sourceLinks, targetLinks)
       mapping should have size (2)
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
@@ -52,7 +52,6 @@ class DefloatMapperSpec extends FunSuite with Matchers{
     )
     val roadAddressTarget = roadAddressSource.flatMap(DefloatMapper.mapRoadAddresses(mapping))
     roadAddressTarget.size should be (4)
-    roadAddressTarget.map(prettyPrint).foreach(println)
     roadAddressTarget.find(r => r.linkId == 1021200L)
       .map(r => r.startMValue).getOrElse(Double.NaN) should be (0.0 +- .00001)
     roadAddressTarget.find(r => r.linkId == 1021200L)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
@@ -47,15 +47,16 @@ class DefloatMapperSpec extends FunSuite with Matchers{
     val mapping = Seq(
       RoadAddressMapping(1021200L, 1021217L, 0.0, 10.0, 2.214, 5.0, Seq(Point(0.0, 0.0), Point(0.0,10.0)), Seq(Point(0.0, 0.0), Point(0.0,10.0))),
       RoadAddressMapping(1021200L, 1021200L, 10.0, 40.0, 40.0, 0.0, Seq(Point(0.0, 10.0), Point(0.0,40.0)), Seq(Point(0.0, 40.0), Point(0.0,0.0))),
-      RoadAddressMapping(1021200L, 1021217L, 40.0, 82.345, 5.0, 17.215, Seq(Point(0.0, 40.0), Point(0.0,143.345)), Seq(Point(0.0, 5.0), Point(0.0,17.215))),
+      RoadAddressMapping(1021200L, 1021217L, 40.0, 82.925, 5.0, 17.215, Seq(Point(0.0, 40.0), Point(0.0,143.345)), Seq(Point(0.0, 5.0), Point(0.0,17.215))),
       RoadAddressMapping(1021217L, 1021217L, 0.0, 40.345, 0.0, 2.214/17.215*40.345, Seq(Point(0.0, 40.0), Point(0.0,143.345)), Seq(Point(0.0, 5.0), Point(0.0,17.215)))
     )
     val roadAddressTarget = roadAddressSource.flatMap(DefloatMapper.mapRoadAddresses(mapping))
     roadAddressTarget.size should be (4)
+    roadAddressTarget.map(prettyPrint).foreach(println)
     roadAddressTarget.find(r => r.linkId == 1021200L)
-      .map(r => r.startMValue).getOrElse(Double.NaN) should be (13.333 +- .001)
+      .map(r => r.startMValue).getOrElse(Double.NaN) should be (0.0 +- .00001)
     roadAddressTarget.find(r => r.linkId == 1021200L)
-      .map(r => r.endMValue).getOrElse(Double.NaN) should be (53.333 +- .001)
+      .map(r => r.endMValue).getOrElse(Double.NaN) should be (40.0 +- .001)
     roadAddressTarget.find(r => r.linkId == 1021217L && r.startMValue == 0.0)
       .map(r => r.endMValue).getOrElse(Double.NaN) should be (2.214 +- .001)
     roadAddressTarget.find(r => r.linkId == 1021217L && r.startMValue >= 2.213 && r.startMValue <= 2.215)


### PR DESCRIPTION
Fix crash on two links and three segments to single link mapping. Adjust road address geometries after transfer to match properly the target geometry and not just approximate geometry.