### PR TITLE
Viite 549 save geometry source to road address

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilder.scala
@@ -310,7 +310,7 @@ object RoadAddressLinkBuilder {
         nextSegment.track, discontinuity, startAddrMValue,
         endAddrMValue, nextSegment.startDate, nextSegment.endDate, nextSegment.modifiedBy, nextSegment.lrmPositionId, nextSegment.linkId,
         startMValue, endMValue,
-        nextSegment.sideCode, nextSegment.adjustedTimestamp, calibrationPoints, false, combinedGeometry))
+        nextSegment.sideCode, nextSegment.adjustedTimestamp, calibrationPoints, false, combinedGeometry, nextSegment.linkGeomSource))
 
     } else Seq(nextSegment, previousSegment)
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -160,7 +160,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
       val (addressesToCreate, unchanged) = newRoadAddresses.values.flatten.toSeq.partition(_.id == NewRoadAddress)
       val savedRoadAddresses = addressesToCreate.map(r =>
           r.copy(geom = GeometryUtils.truncateGeometry3D(roadLinkMap(r.linkId).geometry,
-              r.startMValue, r.endMValue)))
+              r.startMValue, r.endMValue), linkGeomSource = roadLinkMap(r.linkId).linkSource))
 
       val ids = RoadAddressDAO.create(savedRoadAddresses).toSet ++ unchanged.map(_.id).toSet
 
@@ -573,7 +573,7 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
   def getRoadAddressesAfterCalculation(sources: Seq[String], targets: Seq[String], user: User): Seq[RoadAddress] = {
     def adjustGeometry(ra: RoadAddress, link: RoadAddressLinkLike): RoadAddress = {
       val geom = GeometryUtils.truncateGeometry3D(link.geometry, ra.startMValue, ra.endMValue)
-      ra.copy(geom = geom)
+      ra.copy(geom = geom, linkGeomSource = link.roadLinkSource)
     }
     val sourceRoadAddressLinks = sources.flatMap(rd => {
       getRoadAddressLink(rd.toLong)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite.dao
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.Point
-import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.masstransitstop.oracle.Sequences
 import fi.liikennevirasto.digiroad2.oracle.MassQuery
 import fi.liikennevirasto.digiroad2.util.Track
@@ -59,7 +59,7 @@ case class ProjectLink(id: Long, roadNumber: Long, roadPartNumber: Long, track: 
                        discontinuity: Discontinuity, startAddrMValue: Long, endAddrMValue: Long, startDate: Option[DateTime] = None,
                        endDate: Option[DateTime] = None, modifiedBy: Option[String] = None, lrmPositionId : Long, linkId: Long, startMValue: Double, endMValue: Double, sideCode: SideCode,
                        calibrationPoints: (Option[CalibrationPoint], Option[CalibrationPoint]) = (None, None), floating: Boolean = false,
-                       geom: Seq[Point], projectId: Long, status: LinkStatus, roadType: RoadType) extends BaseRoadAddress
+                       geom: Seq[Point], projectId: Long, status: LinkStatus, roadType: RoadType, linkGeomSource: LinkGeomSource = LinkGeomSource.NormalLinkInterface) extends BaseRoadAddress
 
 case class ProjectFormLine(startingLinkId: Long, projectId: Long, roadNumber: Long, roadPartNumber: Long, roadLength: Long, ely : Long, discontinuity: String)
 
@@ -73,7 +73,7 @@ object ProjectDAO {
       "calibration_points, status) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
     val ids = sql"""SELECT lrm_position_primary_key_seq.nextval FROM dual connect by level <= ${roadAddresses.size}""".as[Long].list
     roadAddresses.zip(ids).foreach { case ((address), (lrmId)) =>
-      RoadAddressDAO.createLRMPosition(lrmPositionPS, lrmId, address.linkId, address.sideCode.value, address.startMValue, address.endMValue, 0)
+      RoadAddressDAO.createLRMPosition(lrmPositionPS, lrmId, address.linkId, address.sideCode.value, address.startMValue, address.endMValue, 0, address.linkGeomSource.value)
       addressPS.setLong(1, if (address.id == fi.liikennevirasto.viite.NewRoadAddress) {
         Sequences.nextViitePrimaryKeySeqValue
       } else address.id)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -66,7 +66,7 @@ case class ProjectFormLine(startingLinkId: Long, projectId: Long, roadNumber: Lo
 object ProjectDAO {
 
   def create(roadAddresses: Seq[ProjectLink]): Seq[Long] = {
-    val lrmPositionPS = dynamicSession.prepareStatement("insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp) values (?, ?, ?, ?, ?, ?)")
+    val lrmPositionPS = dynamicSession.prepareStatement("insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp, link_source) values (?, ?, ?, ?, ?, ?, ?)")
     val addressPS = dynamicSession.prepareStatement("insert into PROJECT_LINK (id, project_id, lrm_position_id, " +
       "road_number, road_part_number, " +
       "track_code, discontinuity_type, START_ADDR_M, END_ADDR_M, created_by, " +

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -5,7 +5,7 @@ import java.text.DecimalFormat
 
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, BothDirections, TowardsDigitizing, Unknown}
-import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, SideCode}
+import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.masstransitstop.oracle.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.oracle.{MassQuery, OracleDatabase}
 import fi.liikennevirasto.digiroad2.util.Track
@@ -100,7 +100,7 @@ case class RoadAddress(id: Long, roadNumber: Long, roadPartNumber: Long, track: 
                        discontinuity: Discontinuity, startAddrMValue: Long, endAddrMValue: Long, startDate: Option[DateTime] = None,
                        endDate: Option[DateTime] = None, modifiedBy: Option[String] = None, lrmPositionId : Long, linkId: Long, startMValue: Double, endMValue: Double, sideCode: SideCode, adjustedTimestamp: Long,
                        calibrationPoints: (Option[CalibrationPoint], Option[CalibrationPoint]) = (None, None), floating: Boolean = false,
-                       geom: Seq[Point]) extends BaseRoadAddress {
+                       geom: Seq[Point], linkGeomSource: LinkGeomSource) extends BaseRoadAddress {
   val endCalibrationPoint = calibrationPoints._2
   val startCalibrationPoint = calibrationPoints._1
 
@@ -224,11 +224,12 @@ object RoadAddressDAO {
       val y = r.nextDouble()
       val x2 = r.nextDouble()
       val y2 = r.nextDouble()
+      val geomSource = LinkGeomSource.apply(r.nextInt)
 
       RoadAddress(id, roadNumber, roadPartNumber, Track.apply(trackCode), Discontinuity.apply(discontinuity),
         startAddrMValue, endAddrMValue, startDate, endDate, createdBy, lrmPositionId, linkId, startMValue, endMValue,
         SideCode.apply(sideCode), adjustedTimestamp, calibrations(CalibrationCode.apply(calibrationCode), linkId, startMValue, endMValue, startAddrMValue,
-          endAddrMValue, SideCode.apply(sideCode)), floating, Seq(Point(x,y), Point(x2,y2)))
+          endAddrMValue, SideCode.apply(sideCode)), floating, Seq(Point(x,y), Point(x2,y2)), geomSource)
     }
   }
 
@@ -851,7 +852,7 @@ object RoadAddressDAO {
   }
 
   def create(roadAddresses: Seq[RoadAddress], createdBy : Option[String] = None): Seq[Long] = {
-    val lrmPositionPS = dynamicSession.prepareStatement("insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp) values (?, ?, ?, ?, ?, ?)")
+    val lrmPositionPS = dynamicSession.prepareStatement("insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp, link_source) values (?, ?, ?, ?, ?, ?, ?)")
     val addressPS = dynamicSession.prepareStatement("insert into ROAD_ADDRESS (id, lrm_position_id, road_number, road_part_number, " +
       "track_code, discontinuity, START_ADDR_M, END_ADDR_M, start_date, end_date, created_by, " +
       "VALID_FROM, geometry, floating, calibration_points) values (?, ?, ?, ?, ?, ?, ?, ?, TO_DATE(?, 'YYYY-MM-DD'), " +
@@ -859,7 +860,8 @@ object RoadAddressDAO {
       "?,?,0.0,?,?,?,0.0,?)), ?, ?)")
     val ids = sql"""SELECT lrm_position_primary_key_seq.nextval FROM dual connect by level <= ${roadAddresses.size}""".as[Long].list
     val savedIds = roadAddresses.zip(ids).map { case ((address), (lrmId)) =>
-      createLRMPosition(lrmPositionPS, lrmId, address.linkId, address.sideCode.value, address.startMValue, address.endMValue, address.adjustedTimestamp)
+      createLRMPosition(lrmPositionPS, lrmId, address.linkId, address.sideCode.value, address.startMValue,
+        address.endMValue, address.adjustedTimestamp, address.linkGeomSource.value)
       val nextId = if (address.id == fi.liikennevirasto.viite.NewRoadAddress)
         Sequences.nextViitePrimaryKeySeqValue
       else address.id
@@ -900,13 +902,14 @@ object RoadAddressDAO {
   }
 
   def createLRMPosition(lrmPositionPS: PreparedStatement, id: Long, linkId: Long, sideCode: Int,
-                        startM: Double, endM: Double, adjustedTimestamp : Long): Unit = {
+                        startM: Double, endM: Double, adjustedTimestamp : Long, geomSource: Int): Unit = {
     lrmPositionPS.setLong(1, id)
     lrmPositionPS.setLong(2, linkId)
     lrmPositionPS.setLong(3, sideCode)
     lrmPositionPS.setDouble(4, startM)
     lrmPositionPS.setDouble(5, endM)
     lrmPositionPS.setDouble(6, adjustedTimestamp)
+    lrmPositionPS.setInt(7, geomSource)
     lrmPositionPS.addBatch()
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -146,7 +146,8 @@ object RoadAddressDAO {
         (SELECT X FROM TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t WHERE id = 1) as X,
         (SELECT Y FROM TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t WHERE id = 1) as Y,
         (SELECT X FROM TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t WHERE id = 2) as X2,
-        (SELECT Y FROM TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t WHERE id = 2) as Y2
+        (SELECT Y FROM TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t WHERE id = 2) as Y2,
+        link_source
         from road_address ra
         join lrm_position pos on ra.lrm_position_id = pos.id
         where $filter $floatingFilter and
@@ -256,7 +257,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -293,7 +294,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -321,7 +322,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -351,7 +352,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -373,7 +374,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -404,7 +405,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -422,7 +423,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id,pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -742,7 +743,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -770,7 +771,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -802,7 +803,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
@@ -822,7 +823,7 @@ object RoadAddressDAO {
         select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
         ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
         pos.side_code, pos.adjusted_timestamp,
-        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
         from road_address ra cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
         TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -344,7 +344,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       //Creation of Test road
       val id = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id, roadNumber, roadPartNumber, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, linkId, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       RoadAddressDAO.create(ra)
       val roadsBeforeChanges = RoadAddressDAO.fetchByLinkId(Set(linkId)).head
 
@@ -391,9 +391,9 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       val id1 = RoadAddressDAO.getNextRoadAddressId
       val id2 = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id1, roadNumber, roadStartPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val rb = Seq(RoadAddress(id2, roadNumber, roadEndPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val shouldNotExist = projectService.checkRoadAddressNumberAndSEParts(roadNumber, roadStartPart, roadEndPart)
       shouldNotExist.get should be("Tienumeroa ei ole olemassa, tarkista tiedot")
       RoadAddressDAO.create(ra)
@@ -418,13 +418,13 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     runWithRollback {
       val id1 = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id1, roadNumber, roadStartPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val reservation = projectService.checkReservability(roadNumber, roadStartPart, roadEndPart)
       reservation.right.get.size should be (0)
       RoadAddressDAO.create(ra)
       val id2 = RoadAddressDAO.getNextRoadAddressId
       val rb = Seq(RoadAddress(id2, roadNumber, roadEndPart, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       RoadAddressDAO.create(rb)
       val reservationAfterB = projectService.checkReservability(roadNumber, roadStartPart, roadEndPart)
       reservationAfterB.right.get.size should be (2)
@@ -464,7 +464,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       //Creation of Test road
       val id = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id, roadNumber, roadPartNumber, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, linkId, 0.0, 9.8, SideCode.TowardsDigitizing,0 , (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(linkId))).thenReturn(Seq(RoadLink(linkId, ra.head.geom, 9.8, State, 1, TrafficDirection.BothDirections,
         Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(167)))))
       RoadAddressDAO.create(ra)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressLinkBuilderSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
-import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.TowardsDigitizing
 import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.util.Track
@@ -15,7 +15,7 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
 
   test("Fuse road address should accept single road address") {
     val roadAddress = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, None, None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-      Seq(Point(0.0,0.0), Point(0.0,9.8))))
+      Seq(Point(0.0,0.0), Point(0.0,9.8)), LinkGeomSource.NormalLinkInterface))
     RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should be (roadAddress)
   }
 
@@ -23,9 +23,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8,
-          SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4,
-          SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
+          SideCode.TowardsDigitizing, 0, (None, None), true, Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface)
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (1)
     }
@@ -35,11 +35,11 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1902-02-02")), None, Option("tester"),0, 12345L, 9.8, 20.2, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 9.8), Point(0.0, 20.2))),
+          Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 20.2, 30.2, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 20.2), Point(0.0, 30.2)))
+          Seq(Point(0.0, 20.2), Point(0.0, 30.2)), LinkGeomSource.NormalLinkInterface)
       )
       val fused = RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
       fused should have size (3)
@@ -52,9 +52,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12346L, 0.0, 10.4, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
+          Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface)
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (2)
       val ids = roadAddress.map(_.id).toSet
@@ -66,9 +66,9 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.AgainstDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
+          Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface)
       )
       intercept[InvalidAddressDataException] {
         RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
@@ -80,13 +80,13 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 30.0), Point(0.0, 39.8))),
+          Seq(Point(0.0, 30.0), Point(0.0, 39.8)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 20.2), Point(0.0, 30.0))),
+          Seq(Point(0.0, 20.2), Point(0.0, 30.0)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.TowardsDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 9.8), Point(0.0, 20.2)))
+          Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface)
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (1)
     }
@@ -97,16 +97,16 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8,
-          SideCode.TowardsDigitizing, 0, (None, Some(CalibrationPoint(12345L, 9.8, 10L))), false, Seq(Point(0.0, 0.0), Point(0.0, 9.8))),
+          SideCode.TowardsDigitizing, 0, (None, Some(CalibrationPoint(12345L, 9.8, 10L))), false, Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface),
 
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4,
-          SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(12345L, 9.8, 10L)), None), false, Seq(Point(0.0, 9.8), Point(0.0, 20.2))),
+          SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(12345L, 9.8, 10L)), None), false, Seq(Point(0.0, 9.8), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface),
 
         RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0,
-          SideCode.TowardsDigitizing, 0, (None, None), false, Seq(Point(0.0, 20.2), Point(0.0, 30.0))),
+          SideCode.TowardsDigitizing, 0, (None, None), false, Seq(Point(0.0, 20.2), Point(0.0, 30.0)), LinkGeomSource.NormalLinkInterface),
 
         RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8,
-          SideCode.TowardsDigitizing, 0, (None, None), false, Seq(Point(0.0, 30.0), Point(0.0, 39.8)))
+          SideCode.TowardsDigitizing, 0, (None, None), false, Seq(Point(0.0, 30.0), Point(0.0, 39.8)), LinkGeomSource.NormalLinkInterface)
       )
       //Changed fuseRoadAddress size from 3 to 2 the reasoning behind it is that although we cannot fuse  1 and 2, there is nothing stopping us from fusing 2,3 and 4
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (2)
@@ -117,10 +117,10 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     val geom = Seq(Point(379483.273,6672835.486), Point(379556.289,6673054.073))
     val roadAddress = Seq(
       RoadAddress(3767413, 101, 1, Track.RightSide, Discontinuous, 679L, 701L, Some(DateTime.parse("1991-01-01")), None, Option("tester"),0, 138834, 0.0, 21.0,
-        SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(138834, 0.0, 679L)), None), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0)),
+        SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(138834, 0.0, 679L)), None), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0), LinkGeomSource.NormalLinkInterface),
 
       RoadAddress(3767414, 101, 1, Track.RightSide, Discontinuous, 701L, 923L, Some(DateTime.parse("1991-01-01")), None, Option("tester"),0, 138834, 21.0, 230.776,
-        SideCode.TowardsDigitizing, 0, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776))
+        SideCode.TowardsDigitizing, 0, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776), LinkGeomSource.NormalLinkInterface)
     )
     val fusedList = RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
     fusedList should have size (1)
@@ -141,10 +141,10 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     val geom = Seq(Point(379483.273,6672835.486), Point(379556.289,6673054.073))
     val roadAddress = Seq(
       RoadAddress(3767413, 101, 1, Track.RightSide, Discontinuous, 679L, 701L, Some(DateTime.parse("1991-01-01")), None, Option("tester"),0, 138834, 0.0, 21.0,
-        SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(138834, 0.0, 679L)), Some(CalibrationPoint(138834, 21.0, 920L))), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0)),
+        SideCode.TowardsDigitizing, 0, (Some(CalibrationPoint(138834, 0.0, 679L)), Some(CalibrationPoint(138834, 21.0, 920L))), false, GeometryUtils.truncateGeometry3D(geom, 0.0, 21.0), LinkGeomSource.NormalLinkInterface),
 
       RoadAddress(3767414, 101, 1, Track.RightSide, Discontinuous, 701L, 923L, Some(DateTime.parse("1991-01-01")), None,  Option("tester"),0, 138834, 21.0, 230.776,
-        SideCode.TowardsDigitizing, 0, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776))
+        SideCode.TowardsDigitizing, 0, (None, None), false, GeometryUtils.truncateGeometry3D(geom, 21.0, 230.776), LinkGeomSource.NormalLinkInterface)
     )
     val fusedList = RoadAddressLinkBuilder.fuseRoadAddress(roadAddress)
     fusedList should have size (1)
@@ -166,13 +166,13 @@ class RoadAddressLinkBuilderSpec extends FunSuite with Matchers{
     OracleDatabase.withDynSession {
       val roadAddress = Seq(
         RoadAddress(1, 1, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.AgainstDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 9.8), Point(0.0, 0.0))),
+          Seq(Point(0.0, 9.8), Point(0.0, 0.0)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(4, 1, 1, Track.Combined, Discontinuous, 30L, 40L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 30.0, 39.8, SideCode.AgainstDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 39.8), Point(0.0, 30.0))),
+          Seq(Point(0.0, 39.8), Point(0.0, 30.0)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(3, 1, 1, Track.Combined, Discontinuous, 20L, 30L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 10.4, 30.0, SideCode.AgainstDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 30.0), Point(0.0, 20.2))),
+          Seq(Point(0.0, 30.0), Point(0.0, 20.2)), LinkGeomSource.NormalLinkInterface),
         RoadAddress(2, 1, 1, Track.Combined, Discontinuous, 10L, 20L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 10.4, SideCode.AgainstDigitizing, 0, (None, None), false,
-          Seq(Point(0.0, 20.2), Point(0.0, 9.8)))
+          Seq(Point(0.0, 20.2), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface)
       )
       RoadAddressLinkBuilder.fuseRoadAddress(roadAddress) should have size (1)
     }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/RoadAddressServiceSpec.scala
@@ -375,7 +375,7 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
   private def roadAddressLinkToRoadAddress(floating: Boolean)(l: RoadAddressLink) = {
     RoadAddress(l.id, l.roadNumber, l.roadPartNumber, Track.apply(l.trackCode.toInt), Discontinuity.apply(l.discontinuity.toInt),
       l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode, 0,
-      (l.startCalibrationPoint, l.endCalibrationPoint), floating, l.geometry)
+      (l.startCalibrationPoint, l.endCalibrationPoint), floating, l.geometry, LinkGeomSource.NormalLinkInterface)
   }
 
   test("recalculate one track road with single part") {
@@ -428,7 +428,7 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
 
   test("GetFloatingAdjacents road links on road 75 part 2 sourceLinkId 5176142") {
     val roadAddressService = new RoadAddressService(mockRoadLinkService,mockEventBus)
-    val road75FloatingAddresses = RoadAddress(367,75,2,Track.Combined,Discontinuity.Continuous,3532,3598,None,None,Some("tr"),70000389,5176142,0.0,65.259,SideCode.TowardsDigitizing,0,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)))
+    val road75FloatingAddresses = RoadAddress(367,75,2,Track.Combined,Discontinuity.Continuous,3532,3598,None,None,Some("tr"),70000389,5176142,0.0,65.259,SideCode.TowardsDigitizing,0,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)), LinkGeomSource.NormalLinkInterface)
 
     when(mockRoadLinkService.getViiteCurrentAndHistoryRoadLinksFromVVH(any[Set[Long]])).thenReturn(
       (Seq(), Stream()))

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/RoadAddressDAOSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/RoadAddressDAOSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite.dao
 
 import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, SideCode}
+import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.masstransitstop.oracle.Sequences
 import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.util.Track
@@ -90,7 +90,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
     runWithRollback {
       val id = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val currentSize = RoadAddressDAO.fetchByRoadPart(ra.head.roadNumber, ra.head.roadPartNumber).size
       val returning = RoadAddressDAO.create(ra)
       returning.nonEmpty should be (true)
@@ -105,7 +105,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
       val username = "testUser"
       val id = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val currentSize = RoadAddressDAO.fetchByRoadPart(ra.head.roadNumber, ra.head.roadPartNumber).size
       val returning = RoadAddressDAO.create(ra, Some(username))
       returning.nonEmpty should be (true)
@@ -122,7 +122,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
       val id = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0,
         (Some(CalibrationPoint(12345L, 0.0, 0L)), None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val returning = RoadAddressDAO.create(ra)
       returning.nonEmpty should be (true)
       returning.head should be (id)
@@ -133,7 +133,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
       val id = RoadAddressDAO.getNextRoadAddressId
       val ra = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0,
         (Some(CalibrationPoint(12345L, 0.0, 0L)), Some(CalibrationPoint(12345L, 9.8, 10L))), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       val returning = RoadAddressDAO.create(ra)
       returning.nonEmpty should be (true)
       returning.head should be (id)
@@ -158,7 +158,7 @@ class RoadAddressDAOSpec extends FunSuite with Matchers {
     runWithRollback {
       val id = RoadAddressDAO.getNextRoadAddressId
       val toBeMergedRoadAddresses = Seq(RoadAddress(id, 1943845, 1, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), None, Option("tester"),0, 6556558L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
-        Seq(Point(0.0, 0.0), Point(0.0, 9.8))))
+        Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       localRoadAddressService.mergeRoadAddressInTX(RoadAddressMerge(Set(1L), toBeMergedRoadAddresses))
     }
   }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/DefloatMapperSpec.scala
@@ -5,7 +5,7 @@ import java.util.Date
 import fi.liikennevirasto.digiroad2.RoadLinkType.NormalRoadLinkType
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
-import fi.liikennevirasto.digiroad2.asset.{ConstructionType, LinkType, SideCode, State}
+import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.viite.RoadType
 import fi.liikennevirasto.viite.dao.{CalibrationPoint, Discontinuity, RoadAddress}
@@ -176,7 +176,7 @@ class DefloatMapperSpec extends FunSuite with Matchers{
 
   private def roadAddressLinkToRoadAddress(floating: Boolean)(l: RoadAddressLink) = {
     RoadAddress(l.id, l.roadNumber, l.roadPartNumber, Track.apply(l.trackCode.toInt), Discontinuity.apply(l.discontinuity.toInt),
-      l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode, l.attributes.get("ADJUSTED_TIMESTAMP").getOrElse(0L).asInstanceOf[Long],
-      (l.startCalibrationPoint, l.endCalibrationPoint), floating, l.geometry)
+      l.startAddressM, l.endAddressM, Option(new DateTime(new Date())), None, None, 0, l.linkId, l.startMValue, l.endMValue, l.sideCode, l.attributes.getOrElse("ADJUSTED_TIMESTAMP", 0L).asInstanceOf[Long],
+      (l.startCalibrationPoint, l.endCalibrationPoint), floating, l.geometry, l.roadLinkSource)
   }
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/FloatingCheckerSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/FloatingCheckerSpec.scala
@@ -17,9 +17,9 @@ class FloatingCheckerSpec  extends FunSuite with Matchers{
     val geometry = Seq(Point(0.0, 0.0), Point(60.0, 0.0), Point(60.0, 9.844))
     val roadAddressSeq = Seq(
       RoadAddress(1L, 12L, 1, Track.RightSide, Discontinuity.Continuous, 5L, 60L, None, None, None, 1L, 123, 0.0, 54.948,
-        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 0.0, 54.948)),
+        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 0.0, 54.948), LinkGeomSource.NormalLinkInterface),
       RoadAddress(2L, 12L, 1, Track.RightSide, Discontinuity.Continuous, 60L, 75L, None, None, None, 1L, 123, 54.948, 69.844,
-        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 54.948, 69.844))
+        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 54.948, 69.844), LinkGeomSource.NormalLinkInterface)
     )
     val link = RoadLink(12L, geometry, 69.844, State, 1, TrafficDirection.TowardsDigitizing, Motorway, None, None,
       Map(), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
@@ -37,9 +37,9 @@ class FloatingCheckerSpec  extends FunSuite with Matchers{
     val geometry = Seq(Point(0.0, 0.0), Point(60.0, 0.0), Point(60.0, 9.844))
     val roadAddressSeq = Seq(
       RoadAddress(1L, 12L, 1, Track.RightSide, Discontinuity.Continuous, 5L, 60L, None, None, None, 1L, 123, 0.0, 54.948,
-        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 0.0, 54.948)),
+        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 0.0, 54.948), LinkGeomSource.NormalLinkInterface),
       RoadAddress(2L, 12L, 1, Track.RightSide, Discontinuity.Continuous, 60L, 75L, None, None, None, 1L, 123, 54.948, 69.844,
-        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 54.948, 69.844))
+        SideCode.TowardsDigitizing, 0L, (None, None), false, GeometryUtils.truncateGeometry2D(geometry, 54.948, 69.844), LinkGeomSource.NormalLinkInterface)
     )
     val link = RoadLink(12L, geometry, 69.844, State, 1, TrafficDirection.TowardsDigitizing, Motorway, None, None,
       Map(), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/LinkRoadAddressCalculatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/LinkRoadAddressCalculatorSpec.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.viite.process
 
-import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.viite.RoadType
 import fi.liikennevirasto.viite.dao.{CalibrationPoint, Discontinuity, RoadAddress}
@@ -13,9 +13,9 @@ import org.scalatest.{FunSuite, Matchers}
 class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate one track road with single part") {
-    val addresses = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"), 0,123L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 33.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 48.1, 180))), false, Seq()))
+    val addresses = Seq(RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"), 0,123L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 33.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 48.1, 180))), false, Seq(), LinkGeomSource.NormalLinkInterface))
     val returnval = LinkRoadAddressCalculator.recalculate(addresses)
     returnval.last.endAddrMValue should be (180)
     returnval.last.endMValue should be (48.1)
@@ -25,12 +25,12 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate one track road with single parts") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.LeftSide, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.LeftSide, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.LeftSide, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 48.1, 180))),false, Seq()),
-      RoadAddress(4, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(5, 1, 1, Track.RightSide, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 33.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq())
+      RoadAddress(1, 1, 1, Track.LeftSide, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(2, 1, 1, Track.LeftSide, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(3, 1, 1, Track.LeftSide, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 48.1, 180))),false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(4, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(5, 1, 1, Track.RightSide, Discontinuity.Continuous, 100, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 33.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq(), LinkGeomSource.NormalLinkInterface)
     )
     val (left, right) = LinkRoadAddressCalculator.recalculate(addresses).partition(_.track == Track.LeftSide)
     left.last.endAddrMValue should be (180)
@@ -43,15 +43,15 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate one track road with multiple parts together") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq()),
-      RoadAddress(4, 1, 2, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(5, 1, 2, Track.Combined, Discontinuity.Continuous, 100, 108, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(6, 1, 2, Track.Combined, Discontinuity.Continuous, 108, 116, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(7, 1, 2, Track.Combined, Discontinuity.Continuous, 116, 124, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(8, 1, 2, Track.Combined, Discontinuity.Continuous, 124, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 9.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(9, 1, 2, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq())
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(4, 1, 2, Track.Combined, Discontinuity.Continuous, 0, 100, Some(DateTime.now), None, Option("tester"),0, 223L, 0.0, 98.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(5, 1, 2, Track.Combined, Discontinuity.Continuous, 100, 108, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(6, 1, 2, Track.Combined, Discontinuity.Continuous, 108, 116, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(7, 1, 2, Track.Combined, Discontinuity.Continuous, 116, 124, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 8.0, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(8, 1, 2, Track.Combined, Discontinuity.Continuous, 124, 130, Some(DateTime.now), None, Option("tester"),0, 224L, 0.0, 9.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(9, 1, 2, Track.Combined, Discontinuity.Continuous, 130, 180, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 180))), false, Seq(), LinkGeomSource.NormalLinkInterface)
     )
     val (one, two) = LinkRoadAddressCalculator.recalculate(addresses).partition(_.roadPartNumber == 1)
     one.last.endAddrMValue should be (180)
@@ -64,15 +64,15 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("testRecalculate multiple track road with single part") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq()),
-      RoadAddress(4, 1, 1, Track.LeftSide, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,223L, 0.0, 44.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 180)), None), false, Seq()),
-      RoadAddress(5, 1, 1, Track.LeftSide, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,224L, 0.0, 33.2, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 33.2, 265))), false, Seq()),
-      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 180, 230, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (Some(CalibrationPoint(225L, 0.0, 180)), None), false, Seq()),
-      RoadAddress(7, 1, 1, Track.RightSide, Discontinuity.Continuous, 230, 265, Some(DateTime.now), None, Option("tester"),0, 323L, 0.0, 38.3, SideCode.Unknown, 0, (None, Some(CalibrationPoint(323L, 38.3, 265))), false, Seq()),
-      RoadAddress(8, 1, 1, Track.Combined, Discontinuity.Continuous, 265, 300, Some(DateTime.now), None, Option("tester"),0, 324L, 0.0, 33.2, SideCode.Unknown, 0, (Some(CalibrationPoint(323L, 0.0, 265)), None), false, Seq()),
-      RoadAddress(9, 1, 1, Track.Combined, Discontinuity.EndOfRoad, 300, 350, Some(DateTime.now), None, Option("tester"),0, 325L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 350))), false, Seq())
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 124L, 0.0, 25.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"),0, 125L, 0.0, 58.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(125L, 58.1, 180))), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(4, 1, 1, Track.LeftSide, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,223L, 0.0, 44.3, SideCode.Unknown, 0, (Some(CalibrationPoint(223L, 0.0, 180)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(5, 1, 1, Track.LeftSide, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,224L, 0.0, 33.2, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 33.2, 265))), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(6, 1, 1, Track.RightSide, Discontinuity.Continuous, 180, 230, Some(DateTime.now), None, Option("tester"),0, 225L, 0.0, 48.1, SideCode.Unknown, 0, (Some(CalibrationPoint(225L, 0.0, 180)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(7, 1, 1, Track.RightSide, Discontinuity.Continuous, 230, 265, Some(DateTime.now), None, Option("tester"),0, 323L, 0.0, 38.3, SideCode.Unknown, 0, (None, Some(CalibrationPoint(323L, 38.3, 265))), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(8, 1, 1, Track.Combined, Discontinuity.Continuous, 265, 300, Some(DateTime.now), None, Option("tester"),0, 324L, 0.0, 33.2, SideCode.Unknown, 0, (Some(CalibrationPoint(323L, 0.0, 265)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(9, 1, 1, Track.Combined, Discontinuity.EndOfRoad, 300, 350, Some(DateTime.now), None, Option("tester"),0, 325L, 0.0, 48.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 48.1, 350))), false, Seq(), LinkGeomSource.NormalLinkInterface)
     )
     val results = LinkRoadAddressCalculator.recalculate(addresses).toList.sortBy(_.endAddrMValue)
     results.last.endAddrMValue should be (350)
@@ -82,11 +82,11 @@ class LinkRoadAddressCalculatorSpec extends FunSuite with Matchers{
 
   test("calibration point in the middle of the link must not break calculation") {
     val addresses = Seq(
-      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq()),
-      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 123L, 108.3, 135.2, SideCode.Unknown, 0, (None, None), false, Seq()),
-      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"), 0,123L, 135.2, 180.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(123L, 180.1, 180))), false, Seq()),
-      RoadAddress(4, 1, 1, Track.Combined, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,123L, 180.1, 224.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 180.1, 180)), None), false, Seq()),
-      RoadAddress(5, 1, 1, Track.Combined, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,123L, 224.3, 265.2, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 265.2, 265))), false, Seq()))
+      RoadAddress(1, 1, 1, Track.Combined, Discontinuity.Continuous, 0, 110, Some(DateTime.now), None, Option("tester"),0, 123L, 0.0, 108.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 0.0, 0)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(2, 1, 1, Track.Combined, Discontinuity.Continuous, 110, 135, Some(DateTime.now), None, Option("tester"),0, 123L, 108.3, 135.2, SideCode.Unknown, 0, (None, None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(3, 1, 1, Track.Combined, Discontinuity.Continuous, 135, 180, Some(DateTime.now), None, Option("tester"), 0,123L, 135.2, 180.1, SideCode.Unknown, 0, (None, Some(CalibrationPoint(123L, 180.1, 180))), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(4, 1, 1, Track.Combined, Discontinuity.Continuous, 180, 225, Some(DateTime.now), None, Option("tester"), 0,123L, 180.1, 224.3, SideCode.Unknown, 0, (Some(CalibrationPoint(123L, 180.1, 180)), None), false, Seq(), LinkGeomSource.NormalLinkInterface),
+      RoadAddress(5, 1, 1, Track.Combined, Discontinuity.Continuous, 225, 265, Some(DateTime.now), None, Option("tester"), 0,123L, 224.3, 265.2, SideCode.Unknown, 0, (None, Some(CalibrationPoint(225L, 265.2, 265))), false, Seq(), LinkGeomSource.NormalLinkInterface))
     val results = LinkRoadAddressCalculator.recalculate(addresses).toList.sortBy(_.endAddrMValue)
     results.foreach(println)
     results.last.endAddrMValue should be (265)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/RoadAddressChangeInfoMapperSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/RoadAddressChangeInfoMapperSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.viite.process
 
 import fi.liikennevirasto.digiroad2.{ChangeInfo, Point}
-import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.asset.{LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.viite.NewRoadAddress
 import fi.liikennevirasto.viite.dao.{Discontinuity, RoadAddress}
@@ -13,9 +13,9 @@ import org.scalatest.{FunSuite, Matchers}
 class RoadAddressChangeInfoMapperSpec extends FunSuite with Matchers {
   test("resolve simple case") {
     val roadAddress = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 1000, Some(DateTime.now), None,
-      None, 0L, 123L, 0.0, 1000.234, SideCode.AgainstDigitizing, 86400L, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)))
+      None, 0L, 123L, 0.0, 1000.234, SideCode.AgainstDigitizing, 86400L, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)), LinkGeomSource.NormalLinkInterface)
     val roadAddress2 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 1000, 1400, Some(DateTime.now), None,
-      None, 0L, 124L, 0.0, 399.648, SideCode.AgainstDigitizing, 86400L, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)))
+      None, 0L, 124L, 0.0, 399.648, SideCode.AgainstDigitizing, 86400L, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)), LinkGeomSource.NormalLinkInterface)
     val map = Seq(roadAddress, roadAddress2).groupBy(_.linkId)
     val changes = Seq(
       ChangeInfo(Some(123), Some(124), 123L, 2, Some(0.0), Some(1000.234), Some(399.648), Some(1399.882), 96400L),
@@ -40,11 +40,11 @@ class RoadAddressChangeInfoMapperSpec extends FunSuite with Matchers {
     val changesVVHTimestamp = 96400L
 
     val roadAddress1 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 1000, Some(DateTime.now), None,
-      None, 0L, roadLinkId1, 0.0, 1000.234, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)))
+      None, 0L, roadLinkId1, 0.0, 1000.234, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)), LinkGeomSource.NormalLinkInterface)
     val roadAddress2 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 1000, 1400, Some(DateTime.now), None,
-      None, 0L, roadLinkId2, 0.0, 399.648, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)))
+      None, 0L, roadLinkId2, 0.0, 399.648, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)), LinkGeomSource.NormalLinkInterface)
     val roadAddress3 = RoadAddress(367,75,2,Track.Combined,Discontinuity.Continuous,3532,3598,None,None,
-      Some("tr"),70000389,roadLinkId3,0.0,65.259,SideCode.TowardsDigitizing,roadAdjustedTimestamp,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)))
+      Some("tr"),70000389,roadLinkId3,0.0,65.259,SideCode.TowardsDigitizing,roadAdjustedTimestamp,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)), LinkGeomSource.NormalLinkInterface)
     val map = Seq(roadAddress1, roadAddress2, roadAddress3).groupBy(_.linkId)
     val changes = Seq(
       ChangeInfo(Some(roadLinkId1), Some(roadLinkId2), 123L, 2, Some(0.0), Some(1000.234), Some(399.648), Some(1399.882), changesVVHTimestamp),
@@ -77,11 +77,14 @@ class RoadAddressChangeInfoMapperSpec extends FunSuite with Matchers {
     val changesVVHTimestamp = 96400L
 
     val roadAddress1 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 1000, Some(DateTime.now), None,
-      None, 0L, roadLinkId1, 0.0, 1000.234, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)))
+      None, 0L, roadLinkId1, 0.0, 1000.234, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false,
+      Seq(Point(0.0, 0.0), Point(1000.234, 0.0)), LinkGeomSource.NormalLinkInterface)
     val roadAddress2 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 1000, 1400, Some(DateTime.now), None,
-      None, 0L, roadLinkId2, 0.0, 399.648, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)))
+      None, 0L, roadLinkId2, 0.0, 399.648, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false,
+      Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)), LinkGeomSource.NormalLinkInterface)
     val roadAddress3 = RoadAddress(367,75,2,Track.Combined,Discontinuity.Continuous,3532,3598,None,None,
-      Some("tr"),70000389,roadLinkId3,0.0,65.259,SideCode.TowardsDigitizing,roadAdjustedTimestamp,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)))
+      Some("tr"),70000389,roadLinkId3,0.0,65.259,SideCode.TowardsDigitizing,roadAdjustedTimestamp,(None,None),true,
+      List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)), LinkGeomSource.NormalLinkInterface)
     val map = Seq(roadAddress1, roadAddress2, roadAddress3).groupBy(_.linkId)
     val changes = Seq(
       ChangeInfo(Some(roadLinkId1), Some(roadLinkId2), 123L, 2, Some(0.0), Some(1000.234), Some(399.648), Some(1399.882), changesVVHTimestamp),
@@ -112,11 +115,11 @@ class RoadAddressChangeInfoMapperSpec extends FunSuite with Matchers {
     val changesVVHTimestamp = 96400L
 
     val roadAddress1 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 400, 1400, Some(DateTime.now), None,
-      None, 0L, roadLinkId1, 0.0, 1000.234, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)))
+      None, 0L, roadLinkId1, 0.0, 1000.234, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(0.0, 0.0), Point(1000.234, 0.0)), LinkGeomSource.NormalLinkInterface)
     val roadAddress2 = RoadAddress(1, 1, 1, Track.RightSide, Discontinuity.Continuous, 0, 400, Some(DateTime.now), None,
-      None, 0L, roadLinkId2, 0.0, 399.648, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)))
+      None, 0L, roadLinkId2, 0.0, 399.648, SideCode.AgainstDigitizing, roadAdjustedTimestamp, (None, None), false, Seq(Point(1000.234, 0.0), Point(1000.234, 399.648)), LinkGeomSource.NormalLinkInterface)
     val roadAddress3 = RoadAddress(367,75,2,Track.Combined,Discontinuity.Continuous,1400,1465,None,None,
-      Some("tr"),70000389,roadLinkId3,0.0,65.259,SideCode.TowardsDigitizing,roadAdjustedTimestamp,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)))
+      Some("tr"),70000389,roadLinkId3,0.0,65.259,SideCode.TowardsDigitizing,roadAdjustedTimestamp,(None,None),true,List(Point(538889.668,6999800.979,0.0), Point(538912.266,6999862.199,0.0)), LinkGeomSource.NormalLinkInterface)
     val map = Seq(roadAddress1, roadAddress2, roadAddress3).groupBy(_.linkId)
     val changes = Seq(
       //Modifications


### PR DESCRIPTION
Road address objects (and project links) are saved and fetched with the geometry source information.