### PR TITLE
VIITE-546 batch job to update current LRM link source values

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressDAO.scala
@@ -417,6 +417,29 @@ object RoadAddressDAO {
     queryList(query)
   }
 
+  def fetchByRoad(roadNumber: Long, includeFloating: Boolean = false) = {
+    val floating = if (!includeFloating)
+      "floating='0' AND"
+    else
+      ""
+    // valid_to > sysdate because we may expire and query the data again in same transaction
+    val query =
+      s"""
+        select ra.id, ra.road_number, ra.road_part_number, ra.track_code,
+        ra.discontinuity, ra.start_addr_m, ra.end_addr_m, ra.lrm_position_id, pos.link_id, pos.start_measure, pos.end_measure,
+        pos.side_code, pos.adjusted_timestamp,
+        ra.start_date, ra.end_date, ra.created_by, ra.valid_from, ra.CALIBRATION_POINTS, ra.floating, t.X, t.Y, t2.X, t2.Y, link_source
+        from road_address ra cross join
+        TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t cross join
+        TABLE(SDO_UTIL.GETVERTICES(ra.geometry)) t2
+        join lrm_position pos on ra.lrm_position_id = pos.id
+        where $floating road_number = $roadNumber AND t.id < t2.id AND
+        (valid_to IS NULL OR valid_to > sysdate) AND (valid_from IS NULL OR valid_from <= sysdate)
+        ORDER BY road_number, road_part_number, track_code, start_addr_m
+      """
+    queryList(query)
+  }
+
   def fetchMultiSegmentLinkIds(roadNumber: Long) = {
     val query =
       s"""
@@ -712,6 +735,12 @@ object RoadAddressDAO {
     }
   }
 
+  def updateLRM(id: Long, geometrySource: LinkGeomSource): Boolean = {
+    sqlu"""
+           UPDATE LRM_POSITION SET link_source = ${geometrySource.value} WHERE id = $id
+      """.execute
+    true
+  }
   /**
     * Create the value for geometry field, using the updateSQL above.
     *

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/DataFixture.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.viite.util
 
 import java.util.Properties
 
-import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
+import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource}
 import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.util.SqlScriptRunner
 import fi.liikennevirasto.digiroad2._
@@ -172,7 +172,7 @@ object DataFixture {
       }
 
     //For each municipality get all VVH Roadlinks
-    municipalities.sorted.foreach { municipality =>
+    municipalities.par.foreach { municipality =>
       println("Start processing municipality %d".format(municipality))
 
       //Obtain all RoadLink by municipality and change info from VVH
@@ -203,6 +203,39 @@ object DataFixture {
 
   }
 
+  private def updateRoadAddressGeometrySource(): Unit = {
+    val roadLinkService = new RoadLinkService(vvhClient, new DummyEventBus, new DummySerializer)
+
+    //Get All Roads
+    val roads: Seq[Long] =
+      OracleDatabase.withDynTransaction {
+        RoadAddressDAO.getCurrentValidRoadNumbers()
+      }
+
+    //For each municipality get all VVH Roadlinks
+    roads.par.foreach { road =>
+      println("%d: Fetch road addresses for road #%d".format(road, road))
+      OracleDatabase.withDynTransaction {
+        val roadAddressSeq = RoadAddressDAO.fetchByRoad(road)
+        // Floating addresses are ignored
+        val linkIds = roadAddressSeq.map(_.linkId).toSet
+        println("%d: %d address rows fetched on %d links".format(road, roadAddressSeq.size, linkIds.size))
+        val cacLinks = roadLinkService.getCurrentAndComplementaryVVHRoadLinks(linkIds)
+          .map(rl => rl.linkId -> rl.linkSource).toMap
+        // If not present in current and complementary, check the historic links, too
+        val vvhHistoryLinks = roadLinkService.getViiteRoadLinksHistoryFromVVH(linkIds -- cacLinks.keySet)
+          .map(rl => rl.linkId -> LinkGeomSource.HistoryLinkInterface).toMap
+        val vvhLinks = cacLinks ++ vvhHistoryLinks
+        val updated = roadAddressSeq
+          .filterNot(ra => vvhLinks.getOrElse(ra.linkId, ra.linkGeomSource) == ra.linkGeomSource)
+          .count(ra =>
+            RoadAddressDAO.updateLRM(ra.lrmPositionId, vvhLinks(ra.linkId))
+          )
+        println("%d: %d addresses updated".format(road, updated))
+      }
+    }
+
+  }
   def main(args:Array[String]) : Unit = {
     import scala.util.control.Breaks._
     val username = properties.getProperty("bonecp.username")
@@ -241,9 +274,12 @@ object DataFixture {
         importRoadAddressChangeTestData()
       case Some ("apply_change_information_to_road_address_links") =>
         applyChangeInformationToRoadAddressLinks()
+      case Some ("update_road_address_link_source") =>
+        updateRoadAddressGeometrySource()
       case _ => println("Usage: DataFixture import_road_addresses | recalculate_addresses | update_missing | " +
         "find_floating_road_addresses | import_complementary_road_address | fuse_multi_segment_road_addresses " +
-        "| update_road_addresses_geometry_no_complementary | update_road_addresses_geometry | import_road_address_change_test_data")
+        "| update_road_addresses_geometry_no_complementary | update_road_addresses_geometry | import_road_address_change_test_data "+
+        "| apply_change_information_to_road_address_links | update_road_address_link_source")
     }
   }
 }


### PR DESCRIPTION
Batch job updates road address LRM link source to current, complementary or historic source depending on which one matches. Historic only for completely removed links.