### PR TITLE
Viite 449 determining the growth direction for non ramps

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -29,7 +29,7 @@ case class NewAddressDataExtracted(sourceIds: Set[Long], targetIds: Set[Long])
 
 case class RoadAddressProjectExtractor(id: Long, status: Long, name: String, startDate: String, additionalInfo: String,roadPartList: List[ReservedRoadPart])
 
-case class RoadAddressProjectLinkUpdate(linkIds: Seq[Long], projectId: Long, newStatus: Int)
+case class RoadAddressProjectLinkUpdate(linkIds: Seq[Long], projectId: Long, newStatus: Int, operation: String)
 class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
                val roadAddressService: RoadAddressService,
                val projectService: ProjectService,
@@ -288,7 +288,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
 
     val modification = parsedBody.extract[RoadAddressProjectLinkUpdate]
     val updated = projectService.updateProjectLinkStatus(modification.projectId, modification.linkIds.toSet,
-      LinkStatus.apply(modification.newStatus), user.username)
+      LinkStatus.apply(modification.newStatus), user.username, modification.operation)
     Map("projectId" -> modification.projectId, "publishable" -> (updated &&
       projectService.projectLinkPublishable(modification.projectId)))
   }

--- a/digiroad2-oracle/sql/insert_road_address_project_data.sql
+++ b/digiroad2-oracle/sql/insert_road_address_project_data.sql
@@ -1,0 +1,10 @@
+alter session set nls_language = 'american' NLS_NUMERIC_CHARACTERS = ', ';
+
+--Creation of Projects
+Insert into PROJECT (ID,STATE,NAME,ELY,CREATED_BY,CREATED_DATE,MODIFIED_BY,MODIFIED_DATE,ADD_INFO,START_DATE,STATUS_INFO,CHECK_COUNTER) values (VIITE_PROJECT_SEQ.nextval,'1','Test01','8','silari',to_date('17.07.12','RR.MM.DD'),'-',to_date('17.07.12','RR.MM.DD'),null,to_date('17.07.12','RR.MM.DD'),null,'0');
+
+--Creation of LRM_Positions
+Insert into LRM_POSITION (ID,LANE_CODE,SIDE_CODE,START_MEASURE,END_MEASURE,MML_ID,LINK_ID,ADJUSTED_TIMESTAMP,MODIFIED_DATE,LINK_SOURCE) values (lrm_position_primary_key_seq.nextval,null,'2','0','492,902',null,'2227748','0',to_timestamp('17.07.12 17:23:32,131636000','RR.MM.DD HH24:MI:SSXFF'),'1');
+
+--Creation of Project_Link's
+Insert into PROJECT_LINK (ID,PROJECT_ID,TRACK_CODE,DISCONTINUITY_TYPE,ROAD_NUMBER,ROAD_PART_NUMBER,START_ADDR_M,END_ADDR_M,LRM_POSITION_ID,CREATED_BY,MODIFIED_BY,CREATED_DATE,MODIFIED_DATE,STATUS,CALIBRATION_POINTS,ROAD_TYPE) values (viite_general_seq.nextval,VIITE_PROJECT_SEQ.currval,'2','5','5','201','2007','2503',lrm_position_primary_key_seq.currval,'silari',null,to_date('17.07.12','RR.MM.DD'),null,'0','0','99');

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -155,7 +155,8 @@ object DataFixture {
 //      "siilinjarvi_speed_limits.sql",
 //      "siilinjarvi_linear_assets.sql",
       "insert_road_address_data.sql",
-      "insert_floating_road_addresses.sql"
+      "insert_floating_road_addresses.sql",
+      "insert_road_address_project_data.sql"
     ))
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -340,7 +340,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       val changed = projectLinks.filter(pl => linkIds.contains(pl.linkId)).map(_.id).toSet
       ProjectDAO.updateProjectLinkStatus(changed, linkStatus, userName)
       if(operation == "uusi"){
-        ProjectDAO.updateProjectLinkSideCode(changed, userName)
+        ProjectDAO.updateProjectLinkSideCode(changed)
       }
       try {
         val delta = ProjectDeltaCalculator.delta(projectId)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -221,14 +221,10 @@ object ProjectDAO {
     }
   }
 
-  def updateProjectLinkSideCode(projectLinkIds: Set[Long], userName: String): Unit = {
-    val user = userName.replaceAll("[^A-Za-z0-9\\-]+", "")
+  def updateProjectLinkSideCode(projectLinkIds: Set[Long]): Unit = {
     val randomSideCode = allowedSideCodes(new Random(System.currentTimeMillis()).nextInt(allowedSideCodes.length))
-        MassQuery.withIds(projectLinkIds) {
-          s: String =>
-            val sql = s"UPDATE LRM_POSITION SET SIDE_CODE = ${randomSideCode.value}, MODIFIED_BY='$user' WHERE ID IN (SELECT LRM_POSITION_ID FROM PROJECT_LINK WHERE ID IN (SELECT ID FROM $s))"
-            Q.updateNA(sql).execute
-        }
+              val sql = s"UPDATE LRM_POSITION SET SIDE_CODE = ${randomSideCode.value}, MODIFIED_DATE=sysdate WHERE LINK_ID IN (${projectLinkIds.mkString(",")})"
+              Q.updateNA(sql).execute
   }
 
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -227,7 +227,6 @@ object ProjectDAO {
               Q.updateNA(sql).execute
   }
 
-
   def updateProjectStatus(projectID:Long,state:ProjectState,errorMessage:String) {
     val projectstate=state.value
     sqlu""" update project set state=$projectstate, status_info=$errorMessage  WHERE id=$projectID""".execute

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -285,7 +285,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       countAfterInsertProjects.size should be (count)
       projectService.projectLinkPublishable(saved.id) should be (false)
       val linkIds = ProjectDAO.getProjectLinks(saved.id).map(_.linkId).toSet
-      projectService.updateProjectLinkStatus(saved.id, linkIds, LinkStatus.Terminated, "-")
+      projectService.updateProjectLinkStatus(saved.id, linkIds, LinkStatus.Terminated, "-", "defaultOperation")
       projectService.projectLinkPublishable(saved.id) should be (true)
     }
     runWithRollback { projectService.getRoadAddressAllProjects() } should have size (count - 1)
@@ -510,12 +510,12 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       val linkIds205 = projectLinks._1.map(_.linkId).toSet
       val linkIds206 = projectLinks._2.map(_.linkId).toSet
 
-      projectService.updateProjectLinkStatus(saved.id, linkIds205, LinkStatus.Terminated, "-")
+      projectService.updateProjectLinkStatus(saved.id, linkIds205, LinkStatus.Terminated, "-", "defaultOperation")
       projectService.projectLinkPublishable(saved.id) should be (false)
 
       projectService.getChangeProject(saved.id).map(_.changeInfoSeq).getOrElse(Seq()) should have size (0)
 
-      projectService.updateProjectLinkStatus(saved.id, linkIds206, LinkStatus.Terminated, "-")
+      projectService.updateProjectLinkStatus(saved.id, linkIds206, LinkStatus.Terminated, "-", "defaultOperation")
       projectService.projectLinkPublishable(saved.id) should be (true)
 
       val changeProjectOpt = projectService.getChangeProject(saved.id)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -445,8 +445,8 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be (count)
       val project = projectService.getRoadAddressSingleProject(id)
-      project.size should be(1)
-      project.head.name should be ("TestProject")
+      project.size should be(2)
+      project.map(_.name) should contain ("TestProject")
     }
     runWithRollback {
       projectService.getRoadAddressAllProjects().size should be (count-1)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDaoSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDaoSpec.scala
@@ -202,4 +202,12 @@ class ProjectLinkDaoSpec  extends FunSuite with Matchers {
       project should be (Some("TestProject"))
     }
   }
+
+  test("Confirm update of LRM_Position side code"){
+    runWithRollback {
+     val sampleLinkId = sql"""SELECT pos.Link_id FROM lrm_position pos Inner Join Project_Link pl On pl.LRM_POSITION_ID = pos.ID""".as[Long].first
+      ProjectDAO.updateProjectLinkSideCode(Set(sampleLinkId))
+      sql"""SELECT pos.Link_id FROM lrm_position pos Inner Join Project_Link pl On pl.LRM_POSITION_ID = pos.ID ORDER BY pos.MODIFIED_DATE DESC""".as[Long].first should be(sampleLinkId)
+    }
+  }
 }

--- a/viite-UI/src/model/RoadAddressProjectCollection.js
+++ b/viite-UI/src/model/RoadAddressProjectCollection.js
@@ -141,7 +141,7 @@
     };
 
 
-    this.saveProjectLinks = function(toBeExpiredLinks) {
+    this.saveProjectLinks = function(toBeExpiredLinks, operation) {
       console.log("Save Project Links called");
       applicationModel.addSpinner();
       var linkIds = _.unique(_.map(toBeExpiredLinks,function (t){
@@ -152,7 +152,7 @@
 
       var projectId = projectinfo.id;
 
-      var data = {'linkIds': linkIds, 'projectId': projectId, 'newStatus': STATUS_TERMINATED};
+      var data = {'linkIds': linkIds, 'projectId': projectId, 'newStatus': STATUS_TERMINATED, 'operation': operation};
 
       if(!_.isEmpty(linkIds) && typeof projectId !== 'undefined' && projectId !== 0){
         backend.updateProjectLinks(data, function(errorObject) {

--- a/viite-UI/src/view/RoadAddressProjectEditForm.js
+++ b/viite-UI/src/view/RoadAddressProjectEditForm.js
@@ -254,6 +254,8 @@
           rootElement.find('.project-form button.update').prop("disabled", false);
         }
         else if(this.value == "uusi"){
+          //TODO: added in order for the saveProjectLinks in RoadAddressProjectCollection.js be able to fetch data for the update
+          //also in order to test it, I needed to run in the javascript console $('.btn-save').removeAttr("disabled")
           projectCollection.setDirty(projectCollection.getDirty().concat(_.map(selectedProjectLink, function (link) {
             return {'id': link.linkId, 'status': link.status};
           })));

--- a/viite-UI/src/view/RoadAddressProjectEditForm.js
+++ b/viite-UI/src/view/RoadAddressProjectEditForm.js
@@ -240,7 +240,7 @@
 
       rootElement.on('click', '.project-form button.update', function() {
         currentProject = projectCollection.getCurrentProject();
-        projectCollection.saveProjectLinks(projectCollection.getTmpExpired());
+        projectCollection.saveProjectLinks(projectCollection.getTmpExpired(), $('[id=dropDown] :selected').val());
         rootElement.html(emptyTemplate(currentProject.project));
       });
 
@@ -254,6 +254,10 @@
           rootElement.find('.project-form button.update').prop("disabled", false);
         }
         else if(this.value == "uusi"){
+          projectCollection.setDirty(projectCollection.getDirty().concat(_.map(selectedProjectLink, function (link) {
+            return {'id': link.linkId, 'status': link.status};
+          })));
+          projectCollection.setTmpExpired(projectCollection.getTmpExpired().concat(selectedProjectLink));
           rootElement.find('.new-road-address').prop("hidden", false);
         }
       });


### PR DESCRIPTION
From JIRA:

determine growth direction "randomly" to lrm_position table

Growth direction of the road address: Viite gives a guess for the first growth direction (reversing in another story) after the first save.