### PR TITLE
Viite 571 define error message when reserved

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -264,19 +264,6 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
       Map("success"-> errorMessageOpt.get)
   }
 
-  get("/roadlinks/roadaddress/project/validatenewroadlink"){
-    val roadNumber = params("roadNumber").toLong
-    val part = params("part").toLong
-    val projID = params("projID").toLong
-    val errorMessageOpt=projectService.checkNewRoadAddressNumberAndPart(roadNumber, part, projID)
-    errorMessageOpt match {
-      case Some(error) =>
-        Map("success"->"false",
-          "errormessage"->error)
-      case None => Map("success"->"true")
-    }
-  }
-
   put("/roadlinks/roadaddress/project/savenewroadlink") {
     val projID = params("projID").toLong
     try { //check for validity

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -12,6 +12,7 @@ import fi.liikennevirasto.viite.model.{ProjectAddressLink, ProjectAddressLinkLik
 import fi.liikennevirasto.viite.process.{Delta, ProjectDeltaCalculator, RoadAddressFiller}
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
+import org.joda.time.format.DateTimeFormat
 
 import scala.collection.mutable.ListBuffer
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -61,7 +62,9 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       if (roadAddresses.isEmpty) {
         None
       } else {
-       Some(s"TIE $roadNumber OSA $roadPart on jo olemassa projektin alkupäivänä ${project.startDate}, tarkista tiedot.") //message to user if address is already in use
+        val fmt = DateTimeFormat.forPattern("dd.MM.yyyy")
+
+       Some(s"TIE $roadNumber OSA $roadPart on jo olemassa projektin alkupäivänä ${project.startDate.toString(fmt)}, tarkista tiedot.") //message to user if address is already in use
       }
     }
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -52,16 +52,16 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     * Checks that new road address is not already reserved (currently only checks roadaddresstable)
     * @param roadNumber road number
     * @param roadPart road part number
-    * @param projectId project id
+    * @param project  roadaddress project needed for id and error message
     * @return
     */
-  def checkNewRoadAddressNumberAndPart(roadNumber: Long, roadPart: Long, projectId :Long): Option[String] = {
+  def checkNewRoadAddressNumberAndPart(roadNumber: Long, roadPart: Long, project :RoadAddressProject): Option[String] = {
     withDynTransaction {
-      val roadAddresses = RoadAddressDAO.isNewRoadPartUsed(roadNumber, roadPart, projectId)
+      val roadAddresses = RoadAddressDAO.isNewRoadPartUsed(roadNumber, roadPart, project.id)
       if (roadAddresses.isEmpty) {
         None
       } else {
-       Some("Tieosa on jo käytössä") //message to user if address is already in use
+       Some(s"TIE $roadNumber OSA $roadPart on jo olemassa projektin alkupäivänä ${project.startDate}, tarkista tiedot.") //message to user if address is already in use
       }
     }
   }
@@ -129,7 +129,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
   def addNewLinkToProject(projectLink:ProjectLink, roadAddressProjectID :Long):String = {
     ProjectDAO.getRoadAddressProjectById(roadAddressProjectID) match {
       case Some(project) =>{
-        checkNewRoadAddressNumberAndPart (projectLink.roadNumber, projectLink.roadPartNumber, projectLink.projectId) match {
+        checkNewRoadAddressNumberAndPart (projectLink.roadNumber, projectLink.roadPartNumber, project) match {
           case Some (errorMessage) => errorMessage
           case None => {
             val newProjectLink = ProjectLink (NewRoadAddress, projectLink.roadNumber, projectLink.roadPartNumber, projectLink.track, projectLink.discontinuity, projectLink.startAddrMValue,

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -126,8 +126,6 @@ object ProjectDAO {
   }
 
   def updateRoadAddressProject(roadAddressProject: RoadAddressProject): Unit = {
-
-   val test= roadAddressProject.startDate
     sqlu"""
          update project set state = ${roadAddressProject.status.value}, name = ${roadAddressProject.name}, modified_by = '-' ,modified_date = sysdate, add_info=${roadAddressProject.additionalInfo}, start_date=${roadAddressProject.startDate} where id = ${roadAddressProject.id}
          """.execute

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -126,8 +126,10 @@ object ProjectDAO {
   }
 
   def updateRoadAddressProject(roadAddressProject: RoadAddressProject): Unit = {
+
+   val test= roadAddressProject.startDate
     sqlu"""
-         update project set state = ${roadAddressProject.status.value}, name = ${roadAddressProject.name}, modified_by = '-' ,modified_date = sysdate, add_info=${roadAddressProject.additionalInfo} where id = ${roadAddressProject.id}
+         update project set state = ${roadAddressProject.status.value}, name = ${roadAddressProject.name}, modified_by = '-' ,modified_date = sysdate, add_info=${roadAddressProject.additionalInfo}, start_date=${roadAddressProject.startDate} where id = ${roadAddressProject.id}
          """.execute
   }
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -144,7 +144,7 @@ object ProjectDAO {
           FROM project $where"""
     Q.queryNA[(Long, Long, String, String, DateTime, DateTime, String, DateTime, String, Option[Long], Option[String])](query).list.map {
       case (id, state, name, createdBy, createdDate, start_date, modifiedBy, modifiedDate, addInfo, ely, statusInfo) =>
-        RoadAddressProject(id, ProjectState.apply(state), name, createdBy, start_date, modifiedBy, createdDate, modifiedDate, addInfo, List.empty[ReservedRoadPart], statusInfo, ely)
+        RoadAddressProject(id, ProjectState.apply(state), name, createdBy,createdDate, modifiedBy, start_date, modifiedDate, addInfo, List.empty[ReservedRoadPart], statusInfo, ely)
     }.headOption
   }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -565,7 +565,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
         val idr = RoadAddressDAO.getNextRoadAddressId
         val id = Sequences.nextViitePrimaryKeySeqValue
         val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"), "TestUser", DateTime.parse("1972-03-03"), DateTime.parse("2700-01-01"), "Some additional info", List.empty[ReservedRoadPart], None)
-        val projectLink = toProjectLink(rap)(RoadAddress(idr, 5, 203, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
+        val projectLink = toProjectLink(rap)(RoadAddress(idr, 5, 203, RoadType.Unknown, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
           Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
         ProjectDAO.createRoadAddressProject(rap)
       val message=  projectService.addNewLinkToProject(projectLink, id)
@@ -574,7 +574,4 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
         message should be ("TIE 5 OSA 203 on jo olemassa projektin alkupäivänä 03.03.1972, tarkista tiedot.")
       }
     }
-
-
-
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -454,6 +454,26 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     }
   }
 
+  test("Check for new roadaddress reservation") {
+    var count = 0
+    runWithRollback {
+      val countCurrentProjects = projectService.getRoadAddressAllProjects()
+      val id = 0
+      val addresses:List[ReservedRoadPart]= List(ReservedRoadPart(5:Long, 203:Long, 203:Long, 5:Double, Discontinuity.apply("jatkuva"), 8:Long, None:Option[DateTime], None:Option[DateTime]))
+      val roadAddressProject = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", addresses, None)
+      projectService.createRoadLinkProject(roadAddressProject)
+      val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
+      count = countCurrentProjects.size + 1
+      countAfterInsertProjects.size should be (count)
+      val project = projectService.getRoadAddressSingleProject(id)
+      project.size should be(1)
+      project.head.name should be ("TestProject")
+    }
+    runWithRollback {
+      projectService.getRoadAddressAllProjects().size should be (count-1)
+    }
+  }
+
   test("get the project with it's reserved road parts") {
     var projectId = 0L
     val roadNumber = 1943845

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -556,8 +556,25 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
         Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
       ProjectDAO.createRoadAddressProject(rap)
       projectService.addNewLinkToProject(projectLink, id)
-     val links= ProjectDAO.getProjectLinks(id)
-      links.size should be (1)
+      val links = ProjectDAO.getProjectLinks(id)
+      links.size should be(1)
     }
   }
+    test("error message when reserving already used road number&part") {
+      runWithRollback {
+        val idr = RoadAddressDAO.getNextRoadAddressId
+        val id = Sequences.nextViitePrimaryKeySeqValue
+        val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"), "TestUser", DateTime.parse("1972-03-03"), DateTime.parse("2700-01-01"), "Some additional info", List.empty[ReservedRoadPart], None)
+        val projectLink = toProjectLink(rap)(RoadAddress(idr, 5, 203, Track.Combined, Discontinuous, 0L, 10L, Some(DateTime.parse("1901-01-01")), Some(DateTime.parse("1902-01-01")), Option("tester"), 0, 12345L, 0.0, 9.8, SideCode.TowardsDigitizing, 0, (None, None), false,
+          Seq(Point(0.0, 0.0), Point(0.0, 9.8)), LinkGeomSource.NormalLinkInterface))
+        ProjectDAO.createRoadAddressProject(rap)
+      val message=  projectService.addNewLinkToProject(projectLink, id)
+        val links = ProjectDAO.getProjectLinks(id)
+        links.size should be(0)
+        message should be ("TIE 5 OSA 203 on jo olemassa projektin alkupäivänä 13.07.2017, tarkista tiedot.")
+      }
+    }
+
+
+
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -454,28 +454,6 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     }
   }
 
-  test("Check for new roadaddress reservation") {
-    var count = 0
-    runWithRollback {
-      val countCurrentProjects = projectService.getRoadAddressAllProjects()
-      val id = 0
-      val addresses:List[ReservedRoadPart]= List(ReservedRoadPart(5:Long, 203:Long, 203:Long, 5:Double, Discontinuity.apply("jatkuva"), 8:Long, None:Option[DateTime], None:Option[DateTime]))
-      val roadAddressProject = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", addresses, None)
-      projectService.createRoadLinkProject(roadAddressProject)
-      val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
-      count = countCurrentProjects.size + 1
-      countAfterInsertProjects.size should be (count)
-      val project = projectService.getRoadAddressSingleProject(id)
-      project.size should be(1)
-      project.head.name should be ("TestProject")
-    }
-    runWithRollback {
-      projectService.getRoadAddressAllProjects().size should be (count-1)
-    }
-  }
-
-
-
   test("get the project with it's reserved road parts") {
     var projectId = 0L
     val roadNumber = 1943845
@@ -569,7 +547,6 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
     }
     runWithRollback { projectService.getRoadAddressAllProjects() } should have size (count - 1)
   }
-
   test("add nonexisting roadlink to project"){
     runWithRollback {
       val idr = RoadAddressDAO.getNextRoadAddressId

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -571,7 +571,7 @@ class ProjectServiceSpec  extends FunSuite with Matchers {
       val message=  projectService.addNewLinkToProject(projectLink, id)
         val links = ProjectDAO.getProjectLinks(id)
         links.size should be(0)
-        message should be ("TIE 5 OSA 203 on jo olemassa projektin alkupäivänä 13.07.2017, tarkista tiedot.")
+        message should be ("TIE 5 OSA 203 on jo olemassa projektin alkupäivänä 03.03.1972, tarkista tiedot.")
       }
     }
 

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDaoSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/ProjectLinkDaoSpec.scala
@@ -172,7 +172,7 @@ class ProjectLinkDaoSpec  extends FunSuite with Matchers {
         case Some(project) =>
           project.name should be("newname")
           project.additionalInfo should be("updated info")
-          project.createdDate should be(DateTime.parse("1901-01-01"))
+          project.startDate should be(DateTime.parse("1901-01-02"))
           project.dateModified.getMillis should be > DateTime.parse("1901-01-03").getMillis + 100000000
         case None => None should be(RoadAddressProject)
       }


### PR DESCRIPTION
error message now shows roadnumber, roadpartnumber and project date (as in task description)
Also fixes bug where fetching roadaddressproject startdate was switched with createdate