### PR TITLE
DROTH-793_complementary_links_not_drawn_after_zoom

### DIFF
--- a/UI/src/view/LinearAssetLayer.js
+++ b/UI/src/view/LinearAssetLayer.js
@@ -16,6 +16,7 @@ window.LinearAssetLayer = function(params) {
   me.minZoomForContent = zoomlevels.minZoomForAssets;
 
   var isComplementaryChecked = false;
+  var extraEventListener = _.extend({running: false}, eventbus);
 
   var singleElementEvents = function() {
     return _.map(arguments, function(argument) { return singleElementEventCategory + ':' + argument; }).join(' ');
@@ -283,8 +284,15 @@ window.LinearAssetLayer = function(params) {
     eventListener.listenTo(eventbus, multiElementEvent('cancelled'), linearAssetCancelled);
     eventListener.listenTo(eventbus, singleElementEvents('selectByLinkId'), selectLinearAssetByLinkId);
     eventListener.listenTo(eventbus, multiElementEvent('massUpdateFailed'), cancelSelection);
-    eventListener.listenTo(eventbus, 'complementaryLinks:show', showWithComplementary);
-    eventListener.listenTo(eventbus, 'complementaryLinks:hide', hideComplementary);
+  };
+
+  var startListeningExtraEvents = function(){
+    extraEventListener.listenTo(eventbus, 'complementaryLinks:show', showWithComplementary);
+    extraEventListener.listenTo(eventbus, 'complementaryLinks:hide', hideComplementary);
+  };
+
+  var stopListeningExtraEvents = function(){
+    extraEventListener.stopListening(eventbus);
   };
 
   var selectLinearAssetByLinkId = function(linkId) {
@@ -449,6 +457,7 @@ window.LinearAssetLayer = function(params) {
   };
 
   var show = function(map) {
+    startListeningExtraEvents();
     vectorLayer.setVisible(true);
     indicatorLayer.setVisible(true);
     me.refreshView();
@@ -472,6 +481,7 @@ window.LinearAssetLayer = function(params) {
     vectorLayer.setVisible(false);
     indicatorLayer.setVisible(false);
     selectedLinearAsset.close();
+    stopListeningExtraEvents();
     me.stop();
     me.hide();
   };

--- a/UI/src/view/LinkPropertyLayer.js
+++ b/UI/src/view/LinkPropertyLayer.js
@@ -145,6 +145,7 @@
     var currentRenderIntent = 'default';
     var linkPropertyLayerStyles = LinkPropertyLayerStyles(roadLayer);
     var isComplementaryActive = false;
+    var extraEventListener = _.extend({running: false}, eventbus);
 
     this.minZoomForContent = zoomlevels.minZoomForRoadLinks;
 
@@ -328,13 +329,20 @@
       eventListener.listenTo(eventbus, 'roadLinks:historyFetched', draw);
       eventListener.listenTo(eventbus, 'linkProperties:dataset:changed', draw);
       eventListener.listenTo(eventbus, 'linkProperties:updateFailed', cancelSelection);
-      eventListener.listenTo(eventbus, 'roadLinkComplementary:show', showRoadLinksWithComplementary);
-      eventListener.listenTo(eventbus, 'roadLinkComplementary:hide', hideRoadLinksWithComplementary);
       eventListener.listenTo(eventbus, 'linkProperties:selected linkProperties:multiSelected', function(link) {
         verifyClickEvent(link);
         redrawSelected();
         currentRenderIntent = 'select';
       });
+    };
+
+    var startListeningExtraEvents = function(){
+      extraEventListener.listenTo(eventbus, 'roadLinkComplementary:show', showRoadLinksWithComplementary);
+      extraEventListener.listenTo(eventbus, 'roadLinkComplementary:hide', hideRoadLinksWithComplementary);
+    };
+
+    var stopListeningExtraEvents = function(){
+      extraEventListener.stopListening(eventbus);
     };
 
     var cancelSelection = function() {
@@ -398,12 +406,14 @@
     };
 
     var show = function(map) {
+      startListeningExtraEvents();
       me.show(map);
     };
 
     var hideLayer = function() {
       unselectRoadLink();
       historyLayer.clear();
+      stopListeningExtraEvents();
       me.stop();
       me.hide();
     };

--- a/UI/src/view/PointAssetLayer.js
+++ b/UI/src/view/PointAssetLayer.js
@@ -14,7 +14,7 @@
     Layer.call(this, layerName, roadLayer);
     var me = this;
     me.minZoomForContent = zoomlevels.minZoomForAssets;
-
+    var extraEventListener = _.extend({running: false}, eventbus);
     var vectorSource = new ol.source.Vector();
     var vectorLayer = new ol.layer.Vector({
        source : vectorSource,
@@ -203,9 +203,16 @@
       eventListener.listenTo(eventbus, layerName + ':unselected', handleUnSelected);
       eventListener.listenTo(eventbus, layerName + ':changed', handleChanged);
       eventListener.listenTo(eventbus, 'application:readOnly', toggleMode);
-      eventListener.listenTo(eventbus, 'withComplementary:show', showWithComplementary);
-      eventListener.listenTo(eventbus, 'withComplementary:hide', hideComplementary);
     }
+
+    var startListeningExtraEvents = function(){
+      extraEventListener.listenTo(eventbus, 'withComplementary:show', showWithComplementary);
+      extraEventListener.listenTo(eventbus, 'withComplementary:hide', hideComplementary);
+    };
+
+    var stopListeningExtraEvents = function(){
+      extraEventListener.stopListening(eventbus);
+    };
 
     function handleCreationCancelled() {
       mapOverlay.hide();
@@ -286,6 +293,7 @@
     }
 
     function show(map) {
+      startListeningExtraEvents();
       vectorLayer.setVisible(true);
       me.refreshView();
       me.show(map);
@@ -300,6 +308,7 @@
     function hide() {
       selectedAsset.close();
       vectorLayer.setVisible(false);
+      stopListeningExtraEvents();
       me.stop();
       me.hide();
     }

--- a/UI/src/view/SpeedLimitLayer.js
+++ b/UI/src/view/SpeedLimitLayer.js
@@ -7,6 +7,7 @@ window.SpeedLimitLayer = function(params) {
       style = params.style,
       layerName = 'speedLimit';
   var isActive = false;
+  var extraEventListener = _.extend({running: false}, eventbus);
 
   Layer.call(this, layerName, roadLayer);
   this.activateSelection = function() {
@@ -289,8 +290,15 @@ window.SpeedLimitLayer = function(params) {
     eventListener.listenTo(eventbus, 'speedLimits:drawSpeedLimitsHistory', drawSpeedLimitsHistory);
     eventListener.listenTo(eventbus, 'speedLimits:hideSpeedLimitsHistory', hideSpeedLimitsHistory);
     eventListener.listenTo(eventbus, 'speedLimits:showSpeedLimitsHistory', showSpeedLimitsHistory);
-    eventListener.listenTo(eventbus, 'speedLimits:hideSpeedLimitsComplementary', hideSpeedLimitsComplementary);
-    eventListener.listenTo(eventbus, 'speedLimits:showSpeedLimitsComplementary', showSpeedLimitsComplementary);
+  };
+
+  var startListeningExtraEvents = function(){
+    extraEventListener.listenTo(eventbus, 'speedLimits:hideSpeedLimitsComplementary', hideSpeedLimitsComplementary);
+    extraEventListener.listenTo(eventbus, 'speedLimits:showSpeedLimitsComplementary', showSpeedLimitsComplementary);
+  };
+
+  var stopListeningExtraEvents = function(){
+    extraEventListener.stopListening(eventbus);
   };
 
   var showSpeedLimitsHistory = function() {
@@ -513,6 +521,7 @@ window.SpeedLimitLayer = function(params) {
   };
 
   var show = function(map) {
+    startListeningExtraEvents();
     vectorLayer.setVisible(true);
     indicatorLayer.setVisible(true);
     me.show(map);
@@ -525,6 +534,7 @@ window.SpeedLimitLayer = function(params) {
     vectorLayer.setVisible(false);
     vectorLayerHistory.setVisible(false);
     indicatorLayer.setVisible(false);
+    stopListeningExtraEvents();
     me.stop();
     me.hide();
   };


### PR DESCRIPTION
Created separate event listeners(set when the layer is created) to layers the check if complementaries are shown/not shown. The existing event listeners were not active when zoomed >200 meters.