### PR TITLE
Viite 649 track incompatible bug

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
@@ -302,14 +302,14 @@ object GeometryUtils {
     (Point(left, top), Point(right, bottom))
   }
 
-  def isCyclic(polyLines: Seq[PolyLine]): Boolean = {
+  def isNonLinear(polyLines: Seq[PolyLine]): Boolean = {
     if (polyLines.isEmpty)
       false
     else {
       val (p1, p2) = geometryEndpoints(polyLines.head.geometry)
       polyLines.count(p => areAdjacent(p.geometry, p1, 1.0)) > 2 ||
         polyLines.count(p => areAdjacent(p.geometry, p2, 1.0)) > 2 ||
-        isCyclic(polyLines.tail)
+        isNonLinear(polyLines.tail)
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/oracle/OracleDatabase.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/oracle/OracleDatabase.scala
@@ -55,6 +55,10 @@ object OracleDatabase {
     }
   }
 
+  def isWithinSession: Boolean = {
+    transactionOpen.get()
+  }
+
   def setSessionLanguage() {
     sqlu"""alter session set nls_language = 'american'""".execute
   }

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/AddressLinkBuilder.scala
@@ -19,12 +19,19 @@ trait AddressLinkBuilder {
   val ComplementarySubType = 3
   val formatter = DateTimeFormat.forPattern("dd.MM.yyyy")
 
-  lazy val municipalityMapping = OracleDatabase.withDynSession {
+  lazy val municipalityMapping = if (OracleDatabase.isWithinSession)
     MunicipalityDAO.getMunicipalityMapping
-  }
-  lazy val municipalityRoadMaintainerMapping = OracleDatabase.withDynSession {
-    MunicipalityDAO.getMunicipalityRoadMaintainers
-  }
+  else
+    OracleDatabase.withDynSession {
+      MunicipalityDAO.getMunicipalityMapping
+    }
+
+  lazy val municipalityRoadMaintainerMapping = if (OracleDatabase.isWithinSession)
+      MunicipalityDAO.getMunicipalityRoadMaintainers
+    else
+      OracleDatabase.withDynSession {
+        MunicipalityDAO.getMunicipalityRoadMaintainers
+      }
 
   def getRoadType(administrativeClass: AdministrativeClass, linkType: LinkType): RoadType = {
     (administrativeClass, linkType) match {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -170,13 +170,13 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
         projectAddressLink.roadLinkSource, projectAddressLink.length)
     }
 
-    def matchSideCodes(newLink: ProjectAddressLink, savedLink: ProjectAddressLink): SideCode = {
-      val (startP, endP) = savedLink.sideCode match {
-        case AgainstDigitizing => GeometryUtils.geometryEndpoints(savedLink.geometry).swap
-        case _ => GeometryUtils.geometryEndpoints(savedLink.geometry)
+    def matchSideCodes(newLink: ProjectAddressLink, existingLink: ProjectAddressLink): SideCode = {
+      val (startP, endP) = existingLink.sideCode match {
+        case AgainstDigitizing => GeometryUtils.geometryEndpoints(existingLink.geometry).swap
+        case _ => GeometryUtils.geometryEndpoints(existingLink.geometry)
       }
-      if (GeometryUtils.areAdjacent(savedLink.geometry.head, endP) ||
-        GeometryUtils.areAdjacent(savedLink.geometry.last, startP))
+      if (GeometryUtils.areAdjacent(newLink.geometry.head, endP) ||
+        GeometryUtils.areAdjacent(newLink.geometry.last, startP))
         SideCode.TowardsDigitizing
       else
         SideCode.AgainstDigitizing

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1,6 +1,7 @@
 package fi.liikennevirasto.viite
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.SuravageLinkInterface
+import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, BothDirections, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource, SideCode}
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.masstransitstop.oracle.Sequences
@@ -167,8 +168,20 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
         (projectAddressLink.startCalibrationPoint, projectAddressLink.endCalibrationPoint), floating = false,
         projectAddressLink.geometry, roadAddressProjectID, LinkStatus.New, projectAddressLink.roadType,
         projectAddressLink.roadLinkSource, projectAddressLink.length)
-
     }
+
+    def matchSideCodes(newLink: ProjectAddressLink, savedLink: ProjectAddressLink): SideCode = {
+      val (startP, endP) = savedLink.sideCode match {
+        case AgainstDigitizing => GeometryUtils.geometryEndpoints(savedLink.geometry).swap
+        case _ => GeometryUtils.geometryEndpoints(savedLink.geometry)
+      }
+      if (GeometryUtils.areAdjacent(savedLink.geometry.head, endP) ||
+        GeometryUtils.areAdjacent(savedLink.geometry.last, startP))
+        SideCode.TowardsDigitizing
+      else
+        SideCode.AgainstDigitizing
+    }
+
     withDynTransaction {
     val linksInProject = getLinksByProjectLinkId(ProjectDAO.fetchByProjectNewRoadPart(newRoadNumber,newRoadPartNumber,
       roadAddressProjectID, false).map(l => l.linkId).toSet, roadAddressProjectID, false)
@@ -179,11 +192,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     val randomSideCode =
       linksInProject.map(l => l -> projectAddressLinks.find(n => GeometryUtils.areAdjacent(l.geometry, n.geometry))).toMap.find { case (l, n) => n.nonEmpty }.map {
         case (l, Some(n)) =>
-          if (GeometryUtils.areAdjacent(l.geometry.head, n.geometry.last) ||
-            GeometryUtils.areAdjacent(l.geometry.last, n.geometry.head))
-            l.sideCode
-          else
-            switchSideCode(l.sideCode)
+          matchSideCodes(n, l)
         case _ => SideCode.TowardsDigitizing
       }.getOrElse(SideCode.TowardsDigitizing)
     ProjectDAO.getRoadAddressProjectById(roadAddressProjectID) match {


### PR DESCRIPTION
Fix track 1+2 direction logic in cases where they divert but have a common point of origin.