### PR TITLE
DROTH-883: Double clicking to select linear assets produces OL error

### DIFF
--- a/UI/src/view/AssetLabel.js
+++ b/UI/src/view/AssetLabel.js
@@ -43,7 +43,6 @@
                         var style = me.getStyle(assetValue);
                         var feature = me.createFeature(getPoint(asset));
                         feature.setStyle(style);
-                        feature.setProperties(asset);
                         return feature;
                     }
                 }).


### PR DESCRIPTION
-Removed feature.setProperties(asset) meant for traffic sign labeling. RenderFeatures is already overridden in TrafficSignLabel.js