### PR TITLE
VIITE-753 fix unchanged track change calculation

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressChangesDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressChangesDAO.scala
@@ -244,7 +244,7 @@ object RoadAddressChangesDAO {
             ProjectDeltaCalculator.partition(delta.terminations).foreach { case (roadAddressSection) =>
               addToBatch(roadAddressSection, ely, AddressChangeType.Termination, roadAddressChangePS)
             }
-            ProjectDeltaCalculator.projectLinkPartition(delta.newRoads).foreach { case (roadAddressSection) =>
+            ProjectDeltaCalculator.partition(delta.newRoads).foreach { case (roadAddressSection) =>
               addToBatch(roadAddressSection, ely, AddressChangeType.New, roadAddressChangePS)
             }
             ProjectDeltaCalculator.partition(delta.unChanged).foreach { case (roadAddressSection) =>


### PR DESCRIPTION
Unchanged road sections were calling a different, outdated method.

Generalized the unchanged / numbering etc. partitioning, eliminated dead code.