### PR TITLE
VIITE-798 fix for split project link addressing

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V132__index_for_project_link_ra_id.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V132__index_for_project_link_ra_id.sql
@@ -1,0 +1,1 @@
+CREATE INDEX plink_road_address_idx ON PROJECT_LINK(road_address_id);

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -1,5 +1,6 @@
 package fi.liikennevirasto.viite.process
 
+import fi.liikennevirasto.digiroad2.GeometryUtils
 import fi.liikennevirasto.digiroad2.util.Track.RightSide
 import fi.liikennevirasto.digiroad2.util.{RoadAddressException, Track}
 import fi.liikennevirasto.viite.dao.{ProjectLink, _}
@@ -33,10 +34,22 @@ object ProjectDeltaCalculator {
     Delta(project.startDate, terminations, newCreations, unChanged, transferred, numbering)
   }
 
+  private def adjustIfSplit(pl: ProjectLink, ra: Option[RoadAddress]) = {
+    // Test if this link was a split case: if not, return original address, otherwise return a copy that is adjusted
+    if (pl.connectedLinkId.isEmpty)
+      ra
+    else
+      ra.map(address => {
+        val geom = GeometryUtils.truncateGeometry2D(address.geometry, pl.startMValue, pl.endMValue)
+        address.copy(startMValue = pl.startMValue, endMValue = pl.endMValue,
+          startAddrMValue = pl.startAddrMValue, endAddrMValue = pl.endAddrMValue, geometry = geom)
+      })
+  }
+
   private def findTerminations(projectLinks: Map[RoadPart, Seq[ProjectLink]], currentAddresses: Map[Long, RoadAddress]) = {
     val terminations = projectLinks.mapValues(pll =>
       pll.filter(_.status == LinkStatus.Terminated).flatMap(pl =>
-        currentAddresses.get(pl.roadAddressId)
+        adjustIfSplit(pl, currentAddresses.get(pl.roadAddressId))
       )
     )
     terminations.filterNot(t => t._2.isEmpty).values.foreach(validateTerminations)
@@ -46,13 +59,14 @@ object ProjectDeltaCalculator {
   private def findUnChanged(projectLinks: Map[RoadPart, Seq[ProjectLink]], currentAddresses: Map[Long, RoadAddress]) = {
     projectLinks.mapValues(pll =>
       pll.filter(_.status == LinkStatus.UnChanged).flatMap(pl =>
-        currentAddresses.get(pl.roadAddressId)
+        adjustIfSplit(pl, currentAddresses.get(pl.roadAddressId))
       )
     ).values.flatten.toSeq
   }
 
   private def findTransfers(projectLinks: Seq[ProjectLink], currentAddresses: Map[Long, RoadAddress]) = {
-    projectLinks.filter(_.status == LinkStatus.Transfer).map(pl => currentAddresses(pl.roadAddressId) -> pl)
+    projectLinks.filter(_.status == LinkStatus.Transfer).map(pl =>
+      adjustIfSplit(pl, currentAddresses.get(pl.roadAddressId)).get -> pl)
   }
 
   private def findNumbering(projectLinks: Seq[ProjectLink], currentAddresses: Map[Long, RoadAddress]) = {
@@ -196,6 +210,7 @@ object ProjectDeltaCalculator {
     * @param projectLinks Project Links that have the transfer address values
     * @return Map between the sections old -> new
     */
+  @Deprecated
   def partition(roadAddresses: Seq[RoadAddress], projectLinks: Seq[ProjectLink]): Map[RoadAddressSection, RoadAddressSection] = {
     partition(pair(roadAddresses, projectLinks.groupBy(_.roadAddressId)))
   }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculatorSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculatorSpec.scala
@@ -1,9 +1,12 @@
 package fi.liikennevirasto.viite.process
 
+import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point, Vector3d}
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset.SideCode.TowardsDigitizing
+import fi.liikennevirasto.digiroad2.masstransitstop.oracle.{Queries, Sequences}
+import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.digiroad2.util.Track
 import fi.liikennevirasto.viite.RoadType
 import fi.liikennevirasto.viite.RoadType.PublicRoad
@@ -11,8 +14,20 @@ import fi.liikennevirasto.viite.dao.Discontinuity.Continuous
 import fi.liikennevirasto.viite.dao._
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
+import slick.driver.JdbcDriver.backend.Database
+import slick.driver.JdbcDriver.backend.Database.dynamicSession
+import slick.jdbc.StaticQuery.interpolation
 
 class ProjectDeltaCalculatorSpec  extends FunSuite with Matchers{
+  def withDynTransaction[T](f: => T): T = OracleDatabase.withDynTransaction(f)
+  def runWithRollback[T](f: => T): T = {
+    Database.forDataSource(OracleDatabase.ds).withDynTransaction {
+      val t = f
+      dynamicSession.rollback()
+      t
+    }
+  }
+
   private def createRoadAddress(start: Long, distance: Long) = {
     RoadAddress(id = start, roadNumber = 5, roadPartNumber = 205, roadType = PublicRoad, track = Track.Combined,
       discontinuity = Continuous, startAddrMValue = start, endAddrMValue = start+distance, lrmPositionId = start, linkId = start,
@@ -260,4 +275,63 @@ class ProjectDeltaCalculatorSpec  extends FunSuite with Matchers{
       to.endMAddr should be (130)
     })
   }
+
+  test("Calculate delta for split suravage link") {
+    runWithRollback {
+      val reservationId = Sequences.nextViitePrimaryKeySeqValue
+      val lrms = Queries.fetchLrmPositionIds(4)
+      val ids = (0 until 4).map(_ => Sequences.nextViitePrimaryKeySeqValue)
+      val project = RoadAddressProject(Sequences.nextViitePrimaryKeySeqValue, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2999-01-01"), "TestUser", DateTime.parse("2999-01-01"), DateTime.parse("2999-01-01"), "Some additional info", Seq(), None , None)
+      ProjectDAO.createRoadAddressProject(project)
+      sqlu"""INSERT INTO PROJECT_RESERVED_ROAD_PART(id, road_number, road_part_number, project_id, created_by, first_link_id, road_length, address_length, discontinuity, ely)
+            values ($reservationId, 6591, 1, ${project.id}, '-', 6550673, 85, 85, 5, 9)
+          """.execute
+      sqlu"""Insert into LRM_POSITION (ID,LANE_CODE,SIDE_CODE,START_MEASURE,END_MEASURE,MML_ID,LINK_ID,ADJUSTED_TIMESTAMP,
+            MODIFIED_DATE,LINK_SOURCE) values (${lrms(0)},null,'3','0','86,818',null,'6550673','1476392565000',
+            to_timestamp('19.10.2017 16:36:04,740409000','DD.MM.RRRR HH24:MI:SSXFF'),'1')""".execute
+      sqlu"""Insert into ROAD_ADDRESS (ID,ROAD_NUMBER,ROAD_PART_NUMBER,TRACK_CODE,DISCONTINUITY,START_ADDR_M,END_ADDR_M,
+            LRM_POSITION_ID,START_DATE,END_DATE,CREATED_BY,VALID_FROM,CALIBRATION_POINTS,FLOATING,GEOMETRY,VALID_TO) values
+            (${ids(0)},'6591','1','0','5','0','85',${lrms(0)},to_date('01.01.1996','DD.MM.RRRR'),null,'tr',
+            to_date('16.10.1998','DD.MM.RRRR'),'0','0',MDSYS.SDO_GEOMETRY(4002,3067,NULL,MDSYS.SDO_ELEM_INFO_ARRAY(1,2,1),
+            MDSYS.SDO_ORDINATE_ARRAY(445889.442,7004298.67,0,0,445956.884,7004244.253,0,85)),null)""".execute
+      sqlu"""Insert into LRM_POSITION (ID,LANE_CODE,SIDE_CODE,START_MEASURE,END_MEASURE,MML_ID,LINK_ID,ADJUSTED_TIMESTAMP,MODIFIED_DATE,LINK_SOURCE)
+            values (${lrms(1)},null,'3','0','63,926',null,'499972936','0',to_timestamp('20.10.2017 11:15:35,505115000','DD.MM.RRRR HH24:MI:SSXFF'),'3')""".execute
+      sqlu"""Insert into LRM_POSITION (ID,LANE_CODE,SIDE_CODE,START_MEASURE,END_MEASURE,MML_ID,LINK_ID,ADJUSTED_TIMESTAMP,MODIFIED_DATE,LINK_SOURCE)
+            values (${lrms(2)},null,'3','63,926','307,99',null,'499972936','0',to_timestamp('20.10.2017 11:15:35,505115000','DD.MM.RRRR HH24:MI:SSXFF'),'3')""".execute
+      sqlu"""Insert into LRM_POSITION (ID,LANE_CODE,SIDE_CODE,START_MEASURE,END_MEASURE,MML_ID,LINK_ID,ADJUSTED_TIMESTAMP,MODIFIED_DATE,LINK_SOURCE)
+            values (${lrms(3)},null,'3','63,752','86,818',null,'6550673','0',to_timestamp('20.10.2017 11:15:35,505115000','DD.MM.RRRR HH24:MI:SSXFF'),'1')""".execute
+      sqlu"""Insert into PROJECT_LINK (ID,PROJECT_ID,TRACK_CODE,DISCONTINUITY_TYPE,ROAD_NUMBER,ROAD_PART_NUMBER,
+            START_ADDR_M,END_ADDR_M,LRM_POSITION_ID,CREATED_BY,MODIFIED_BY,CREATED_DATE,MODIFIED_DATE,STATUS,
+            CALIBRATION_POINTS,ROAD_TYPE,ROAD_ADDRESS_ID,CONNECTED_LINK_ID)
+            values (${ids(1)},${project.id},'0','5','6591','1','0','62',${lrms(1)},'silari',null,
+            to_date('20.10.2017','DD.MM.RRRR'),null,'1','0','1',${ids(0)},'6550673')""".execute
+      sqlu"""Insert into PROJECT_LINK (ID,PROJECT_ID,TRACK_CODE,DISCONTINUITY_TYPE,ROAD_NUMBER,ROAD_PART_NUMBER,
+            START_ADDR_M,END_ADDR_M,LRM_POSITION_ID,CREATED_BY,MODIFIED_BY,CREATED_DATE,MODIFIED_DATE,STATUS,
+            CALIBRATION_POINTS,ROAD_TYPE,ROAD_ADDRESS_ID,CONNECTED_LINK_ID)
+             values (${ids(2)},${project.id},'0','5','6591','1','62','85',${lrms(2)},'silari',null,
+             to_date('20.10.2017','DD.MM.RRRR'),null,'2','0','1',${ids(0)},'6550673')""".execute
+      sqlu"""Insert into PROJECT_LINK (ID,PROJECT_ID,TRACK_CODE,DISCONTINUITY_TYPE,ROAD_NUMBER,ROAD_PART_NUMBER,
+            START_ADDR_M,END_ADDR_M,LRM_POSITION_ID,CREATED_BY,MODIFIED_BY,CREATED_DATE,MODIFIED_DATE,STATUS,
+            CALIBRATION_POINTS,ROAD_TYPE,ROAD_ADDRESS_ID,CONNECTED_LINK_ID)
+            values (${ids(3)},${project.id},'0','5','6591','1','62','85',${lrms(3)},'silari',null,
+            to_date('20.10.2017','DD.MM.RRRR'),null,'5','2','9',${ids(0)},'499972936')""".execute
+      val delta = ProjectDeltaCalculator.delta(project.id)
+      delta.terminations should have size (1)
+      delta.unChanged should have size (1)
+      delta.newRoads should have size (1)
+      val term = delta.terminations.head
+      term.startAddrMValue should be (62)
+      term.endAddrMValue should be (85)
+      term.id should be (ids(0))
+      val unc = delta.unChanged.head
+      unc.startAddrMValue should be (0)
+      unc.endAddrMValue should be (62)
+      unc.id should be (ids(0))
+      val cre = delta.newRoads.head
+      cre.startAddrMValue should be (62)
+      cre.endAddrMValue should be (85)
+      cre.id should be (ids(2))
+    }
+  }
+
 }

--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -32,17 +32,10 @@
       right.points = split.secondSplitVertices;
       var measureLeft = calculateMeasure(left);
       var measureRight = calculateMeasure(right);
-      if (measureLeft < measureRight) {
-        splitSuravage.created = left;
-        splitSuravage.created.endMValue = measureLeft;
-        splitSuravage.existing = right;
-        splitSuravage.existing.endMValue = measureRight;
-      } else {
-        splitSuravage.created = right;
-        splitSuravage.created.endMValue = measureRight;
-        splitSuravage.existing = left;
-        splitSuravage.existing.endMValue = measureLeft;
-      }
+      splitSuravage.created = left;
+      splitSuravage.created.endMValue = measureLeft;
+      splitSuravage.existing = right;
+      splitSuravage.existing.endMValue = measureRight;
       splitSuravage.created.splitPoint = split.point;
       splitSuravage.existing.splitPoint = split.point;
 


### PR DESCRIPTION
Change the UI to always use digitization ordering.
Change delta calculator so that it understands split links in calculation.