### PR TITLE
Viite 798 fix split addressing

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectAddressLinkBuilder.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectAddressLinkBuilder.scala
@@ -19,7 +19,10 @@ object ProjectAddressLinkBuilder extends AddressLinkBuilder {
       case LinkGeomSource.Unknown => UnknownRoadLinkType
     }
 
-    val geom = roadLink.geometry
+    val geom = if (projectLink.connectedLinkId.nonEmpty)
+      GeometryUtils.truncateGeometry3D(roadLink.geometry, projectLink.startMValue, projectLink.endMValue)
+    else
+      roadLink.geometry
     val length = GeometryUtils.geometryLength(geom)
     val roadNumber = projectLink.roadNumber match {
       case 0 => roadLink.attributes.getOrElse(RoadNumber, projectLink.roadNumber).asInstanceOf[Number].longValue()

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitter.scala
@@ -98,7 +98,7 @@ object ProjectLinkSplitter {
         splitT)
     }
     def toSeq(splits: (ProjectLink, ProjectLink, ProjectLink)) = {
-      Seq(splits._1, splits._2, splits._3)
+      Seq(splits._1, splits._2, splits._3).filter(pl => Math.abs(pl.endMValue - pl.startMValue) >= fi.liikennevirasto.viite.MinAllowedRoadAddressLength)
     }
     val suravageM = GeometryUtils.calculateLinearReferenceFromPoint(split.splitPoint, suravage.geometry)
     val templateM = GeometryUtils.calculateLinearReferenceFromPoint(split.splitPoint, templateLink.geometry)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
@@ -201,22 +201,54 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers {
     sl should have size (2)
     tl should have size (1)
     val terminatedLink = tl.head
-    terminatedLink.status should be (LinkStatus.Terminated)
-    terminatedLink.startAddrMValue should be (template.startAddrMValue)
+    terminatedLink.status should be(LinkStatus.Terminated)
+    terminatedLink.startAddrMValue should be(template.startAddrMValue)
     GeometryUtils.areAdjacent(terminatedLink.geometry,
-      GeometryUtils.truncateGeometry2D(template.geometry, terminatedLink.startMValue, template.geometryLength)) should be (true)
+      GeometryUtils.truncateGeometry2D(template.geometry, terminatedLink.startMValue, template.geometryLength)) should be(true)
     sl.foreach { l =>
-      l.roadAddressId should be (template.roadAddressId)
+      l.roadAddressId should be(template.roadAddressId)
       l.startAddrMValue == terminatedLink.endAddrMValue || l.startAddrMValue == terminatedLink.startAddrMValue &&
         l.status == LinkStatus.New should be(true)
-      l.linkGeomSource should be (LinkGeomSource.SuravageLinkInterface)
+      l.linkGeomSource should be(LinkGeomSource.SuravageLinkInterface)
       l.endAddrMValue == template.endAddrMValue || l.startAddrMValue == template.startAddrMValue should be(true)
-      l.status == LinkStatus.New || l.status == LinkStatus.Transfer should be (true)
-      GeometryUtils.areAdjacent(l.geometry, suravage.geometry) should be (true)
-      l.roadNumber should be (template.roadNumber)
-      l.roadPartNumber should be (template.roadPartNumber)
-      l.sideCode should be (SideCode.TowardsDigitizing)
+      l.status == LinkStatus.New || l.status == LinkStatus.Transfer should be(true)
+      GeometryUtils.areAdjacent(l.geometry, suravage.geometry) should be(true)
+      l.roadNumber should be(template.roadNumber)
+      l.roadPartNumber should be(template.roadPartNumber)
+      l.sideCode should be(SideCode.TowardsDigitizing)
     }
 
+  }
+
+  test("Split shorter suravage link") {
+    val sGeom = Seq(Point(480428.187, 7059183.911), Point(480441.534, 7059195.878), Point(480445.646, 7059199.566),
+      Point(480451.056, 7059204.417), Point(480453.065, 7059206.218), Point(480456.611, 7059209.042),
+      Point(480463.941, 7059214.747))
+    val tGeom = Seq(Point(480428.187,7059183.911),Point(480453.614, 7059206.710), Point(480478.813, 7059226.322),
+      Point(480503.826, 7059244.02),Point(480508.221, 7059247.010))
+    val sLen = GeometryUtils.geometryLength(sGeom)
+    val tLen = GeometryUtils.geometryLength(tGeom)
+    val suravage = ProjectLink(0L, 0L, 0L, Track.Unknown, Discontinuity.Continuous, 0L, 0L, None, None, None, 0L, 123L, 0.0, sLen,
+      SideCode.Unknown, (None, None), false, sGeom, 1L, LinkStatus.NotHandled, RoadType.Unknown, LinkGeomSource.SuravageLinkInterface,
+      sLen, 0L, None)
+    val template = ProjectLink(2L, 27L, 22L, Track.Combined, Discontinuity.Continuous, 5076L, 5131L, None, None, None, 0L, 124L, 0.0, sLen,
+      SideCode.TowardsDigitizing, (None, None), false, tGeom, 1L, LinkStatus.NotHandled, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface,
+      tLen, 0L, None)
+    val (sl, tl) = ProjectLinkSplitter.split(suravage, template, SplitOptions(Point(480463.941, 7059214.747), LinkStatus.UnChanged,
+      LinkStatus.New, 27L, 22L, Track.Combined, Discontinuity.Continuous, 8L, LinkGeomSource.NormalLinkInterface,
+      RoadType.PublicRoad, 1L)).partition(_.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
+    sl should have size (1)
+    tl should have size (1)
+    val terminatedLink = tl.head
+    val unChangedLink = sl.head
+    println(terminatedLink)
+    println(unChangedLink)
+    terminatedLink.status should be (LinkStatus.Terminated)
+    terminatedLink.endAddrMValue should be (template.endAddrMValue)
+    GeometryUtils.areAdjacent(terminatedLink.geometry, unChangedLink.geometry) should be (true)
+    GeometryUtils.areAdjacent(unChangedLink.geometry.head, sGeom.head) should be (true)
+    GeometryUtils.areAdjacent(unChangedLink.geometry.last, sGeom.last) should be (true)
+    unChangedLink.startAddrMValue should be (template.startAddrMValue)
+    unChangedLink.endAddrMValue should be (terminatedLink.startAddrMValue)
   }
 }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
@@ -241,8 +241,6 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers {
     tl should have size (1)
     val terminatedLink = tl.head
     val unChangedLink = sl.head
-    println(terminatedLink)
-    println(unChangedLink)
     terminatedLink.status should be (LinkStatus.Terminated)
     terminatedLink.endAddrMValue should be (template.endAddrMValue)
     GeometryUtils.areAdjacent(terminatedLink.geometry, unChangedLink.geometry) should be (true)

--- a/viite-UI/src/model/RoadAddressProjectCollection.js
+++ b/viite-UI/src/model/RoadAddressProjectCollection.js
@@ -287,6 +287,7 @@
       console.log("Save Cutted Project Links called");
       applicationModel.addSpinner();
 
+      // Wrong link is picked from changedLinks - not splitted but original
       var splitPoint = changedLinks[0].points[changedLinks[0].points.length-1];
 
       var linkIds = _.unique(_.map(changedLinks,function (t){

--- a/viite-UI/src/model/RoadAddressProjectCollection.js
+++ b/viite-UI/src/model/RoadAddressProjectCollection.js
@@ -297,31 +297,31 @@
       }));
 
       var projectId = projectinfo.id;
+      var form = $('#roadAddressProjectFormCut');
 
       var dataJson = {
-        splitPoint: {x: splitPoint.x, y: splitPoint.y},
+        splitPoint: {
+          x: Number(form.find('#splitx')[0].value),
+          y: Number(form.find('#splity')[0].value)
+        },
         statusA: statusCodeA,
         statusB: statusCodeB,
-        roadNumber: Number($('#roadAddressProjectFormCut').find('#tie')[0].value),
-        roadPartNumber: Number($('#roadAddressProjectFormCut').find('#osa')[0].value),
-        trackCode: Number($('#roadAddressProjectFormCut').find('#ajr')[0].value),
-        discontinuity: Number($('#roadAddressProjectFormCut').find('#discontinuityDropdown')[0].value),
-        ely: Number($('#roadAddressProjectFormCut').find('#ely')[0].value),
+        roadNumber: Number(form.find('#tie')[0].value),
+        roadPartNumber: Number(form.find('#osa')[0].value),
+        trackCode: Number(form.find('#ajr')[0].value),
+        discontinuity: Number(form.find('#discontinuityDropdown')[0].value),
+        ely: Number(form.find('#ely')[0].value),
         roadLinkSource: Number(_.first(changedLinks).roadLinkSource),
-        roadType: Number($('#roadAddressProjectFormCut').find('#roadTypeDropDown')[0].value),
+        roadType: Number(form.find('#roadTypeDropDown')[0].value),
         projectId: projectId
       };
 
       backend.saveProjectLinkSplit(dataJson, changedLinks[0].linkId, function(successObject){
-        if (!successObject.success) {
-          new ModalConfirm(successObject.reason);
-          applicationModel.removeSpinner();
-        }
-          else{
           eventbus.trigger('roadAddress:projectLinksUpdated', successObject);
-        }
-
-      }, null);
+      }, function(failureObject){
+          new ModalConfirm(failureObject.reason);
+          applicationModel.removeSpinner();
+      });
 
     };
 

--- a/viite-UI/src/model/RoadAddressProjectCollection.js
+++ b/viite-UI/src/model/RoadAddressProjectCollection.js
@@ -216,7 +216,6 @@
     };
 
     this.saveProjectLinks = function(changedLinks, statusCode) {
-      console.log("Save Project Links called");
       applicationModel.addSpinner();
       //TODO in the future if we want to choose multiple actions foreach link (linkId, newStatus) combo should be used
       var linkIds = _.unique(_.map(changedLinks,function (t){
@@ -276,19 +275,12 @@
           });
         }
       } else {
-        console.log(!_.isEmpty(linkIds));
-        console.log(typeof projectId);
-        console.log(linkIds);
         eventbus.trigger('roadAddress:projectLinksUpdateFailed', PRECONDITION_FAILED_412);
       }
     };
 
     this.saveCuttedProjectLinks = function(changedLinks, statusCodeA, statusCodeB){
-      console.log("Save Cutted Project Links called");
       applicationModel.addSpinner();
-
-      // Wrong link is picked from changedLinks - not splitted but original
-      var splitPoint = changedLinks[0].points[changedLinks[0].points.length-1];
 
       var linkIds = _.unique(_.map(changedLinks,function (t){
         if(!_.isUndefined(t.linkId)){
@@ -322,7 +314,6 @@
           new ModalConfirm(failureObject.reason);
           applicationModel.removeSpinner();
       });
-
     };
 
     this.createProject = function (data) {
@@ -372,7 +363,6 @@
 
     this.publishProject = function() {
       backend.sendProjectToTR(projectinfo.id, function(result) {
-        console.log("Success");
         if(result.sendSuccess) {
           eventbus.trigger('roadAddress:projectSentSuccess');
         }
@@ -380,7 +370,6 @@
           eventbus.trigger('roadAddress:projectSentFailed', result.errorMessage);
         }
       }, function(result) {
-        console.log("Failure");
         eventbus.trigger('roadAddress:projectSentFailed', result.status);
       });
     };

--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -19,7 +19,7 @@
 
     var splitSuravageLink = function(suravage, split) {
       splitSuravageLinks(suravage, split, function(splitedSuravageLinks) {
-        selection = [splitedSuravageLinks.created, splitedSuravageLinks.existing];
+        var selection = [splitedSuravageLinks.created, splitedSuravageLinks.existing];
         eventbus.trigger('splited:projectLinks', selection);
       });
     };

--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -41,6 +41,7 @@
 
       splitSuravage.created.id = null;
       splitSuravage.splitMeasure = split.splitMeasure;
+      console.log("split point " + split.point);
 
       splitSuravage.created.marker = 'A';
       splitSuravage.existing.marker = 'B';

--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -17,14 +17,14 @@
       eventbus.trigger('projectLink:clicked', get());
     };
 
-    var splitSuravageLink = function(suravage, split) {
-      splitSuravageLinks(suravage, split, function(splitedSuravageLinks) {
+    var splitSuravageLink = function(suravage, split, mousePoint) {
+      splitSuravageLinks(suravage, split, mousePoint, function(splitedSuravageLinks) {
         var selection = [splitedSuravageLinks.created, splitedSuravageLinks.existing];
         eventbus.trigger('splited:projectLinks', selection);
       });
     };
 
-    var splitSuravageLinks = function(nearestSuravage, split, callback) {
+    var splitSuravageLinks = function(nearestSuravage, split, mousePoint, callback) {
       var left = _.cloneDeep(nearestSuravage);
       left.points = split.firstSplitVertices;
 
@@ -36,8 +36,8 @@
       splitSuravage.created.endMValue = measureLeft;
       splitSuravage.existing = right;
       splitSuravage.existing.endMValue = measureRight;
-      splitSuravage.created.splitPoint = split.point;
-      splitSuravage.existing.splitPoint = split.point;
+      splitSuravage.created.splitPoint = mousePoint;
+      splitSuravage.existing.splitPoint = mousePoint;
 
       splitSuravage.created.id = null;
       splitSuravage.splitMeasure = split.splitMeasure;

--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -41,7 +41,6 @@
 
       splitSuravage.created.id = null;
       splitSuravage.splitMeasure = split.splitMeasure;
-      console.log("split point " + split.point);
 
       splitSuravage.created.marker = 'A';
       splitSuravage.existing.marker = 'B';

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -650,7 +650,8 @@
           var lineString = pointsToLineString(nearestSuravage.points);
           var splitMeasure = GeometryUtils.calculateMeasureAtPoint(lineString, point);
           var splitVertices = GeometryUtils.splitByPoint(lineString, point);
-          return _.merge({ splitMeasure: splitMeasure, point: point }, splitVertices);
+          console.log(splitVertices.secondSplitVertices[0]);
+          return _.merge({ splitMeasure: splitMeasure, point: splitVertices.secondSplitVertices[0] }, splitVertices);
         };
 
         var nearest = findNearestSuravageLink([mousePoint.x, mousePoint.y]);

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -650,7 +650,6 @@
           var lineString = pointsToLineString(nearestSuravage.points);
           var splitMeasure = GeometryUtils.calculateMeasureAtPoint(lineString, point);
           var splitVertices = GeometryUtils.splitByPoint(lineString, point);
-          console.log(splitVertices.secondSplitVertices[0]);
           return _.merge({ splitMeasure: splitMeasure, point: splitVertices.secondSplitVertices[0] }, splitVertices);
         };
 

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -662,7 +662,7 @@
         }
         var nearestSuravage = nearest.feature.projectLinkData;
         var splitProperties = calculateSplitProperties(nearestSuravage, mousePoint);
-        selectedProjectLinkProperty.splitSuravageLink(nearestSuravage, splitProperties);
+        selectedProjectLinkProperty.splitSuravageLink(nearestSuravage, splitProperties, mousePoint);
         selectSingleClick.getFeatures().clear();
         selectSingleClick.getFeatures().push(nearest.feature);
         projectCollection.setTmpDirty([nearest.feature.projectLinkData]);

--- a/viite-UI/src/view/RoadAddressProjectEditForm.js
+++ b/viite-UI/src/view/RoadAddressProjectEditForm.js
@@ -222,6 +222,8 @@
 
     var selectionFormCutted = function(selection, selected){
       return '<form id="roadAddressProjectFormCut" class="input-unit-combination form-group form-horizontal roadAddressProject">'+
+        '<input type="hidden" id="splitx" value="' + selected[0].splitPoint.x + '"/>' +
+        '<input type="hidden" id="splity" value="' + selected[0].splitPoint.y + '"/>' +
         '<label>Toimenpiteet,' + selection[0]  + '</label>' +
           '<span class="marker">'+markers[0]+'</span>'+
         dropdownOption(0, selected) +


### PR DESCRIPTION
Fixes for incorrect split point being passed to the backend, negative values for resplitting (currently refuses resubmitting) and incorrect geometry for split links in address link builder.