### PR TITLE
DROTH-997: hide x-delete button when form is only showing once service.

### DIFF
--- a/UI/src/view/PointAssetForm.js
+++ b/UI/src/view/PointAssetForm.js
@@ -9,10 +9,9 @@
     eventbus.on('application:readOnly', function(readOnly) {
       if(applicationModel.getSelectedLayer() == layerName && (!_.isEmpty(roadCollection.getAll()) && !_.isNull(selectedAsset.getId()))){
         toggleMode(rootElement, (editConstrains && editConstrains(selectedAsset)) || readOnly);
-        if (layerName == 'servicePoints'){
-          if(isSingleService(selectedAsset)){
-            rootElement.find('button.delete').hide();
-          }
+        //TODO: add form configurations to asset-type-layer-specifications.js to avoid if-clauses
+        if (layerName == 'servicePoints' && isSingleService(selectedAsset)){
+          rootElement.find('button.delete').hide();
         }
       }
     });
@@ -129,8 +128,8 @@
       renderForm(rootElement, selectedAsset, localizedTexts, editConstrains, roadCollection);
       toggleMode(rootElement, editConstrains(selectedAsset) || applicationModel.isReadOnly());
       rootElement.find('.form-controls button').prop('disabled', !selectedAsset.isDirty());
-      if(newServices.length > 1){
-        rootElement.find('button.delete').show();
+      if(newServices.length < 2){
+        rootElement.find('button.delete').hide();
       }
     });
 

--- a/UI/src/view/PointAssetForm.js
+++ b/UI/src/view/PointAssetForm.js
@@ -7,8 +7,14 @@
     var rootElement = $('#feature-attributes');
 
     eventbus.on('application:readOnly', function(readOnly) {
-      if(applicationModel.getSelectedLayer() == layerName && (!_.isEmpty(roadCollection.getAll()) && !_.isNull(selectedAsset.getId())))
+      if(applicationModel.getSelectedLayer() == layerName && (!_.isEmpty(roadCollection.getAll()) && !_.isNull(selectedAsset.getId()))){
         toggleMode(rootElement, (editConstrains && editConstrains(selectedAsset)) || readOnly);
+        if (layerName == 'servicePoints'){
+          if(isSingleService(selectedAsset)){
+            rootElement.find('button.delete').hide();
+          }
+        }
+      }
     });
 
     eventbus.on(layerName + ':selected ' + layerName + ':cancelled roadLinks:fetched', function() {
@@ -18,6 +24,9 @@
         if (layerName == 'servicePoints') {
           rootElement.find('button#save-button').prop('disabled', true);
           rootElement.find('button#cancel-button').prop('disabled', false);
+          if(isSingleService(selectedAsset)){
+            rootElement.find('button.delete').hide();
+          }
         } else {
           rootElement.find('.form-controls button').prop('disabled', !selectedAsset.isDirty());
         }
@@ -89,6 +98,9 @@
     renderForm(rootElement, selectedAsset, localizedTexts, editConstrains, roadCollection);
     toggleMode(rootElement, editConstrains(selectedAsset) || applicationModel.isReadOnly());
     rootElement.find('.form-controls button').prop('disabled', !selectedAsset.isDirty());
+    if(services.length < 2){
+      rootElement.find('button.delete').hide();
+    }
   });
 
     function modifyService(services, id, modifications) {
@@ -117,6 +129,9 @@
       renderForm(rootElement, selectedAsset, localizedTexts, editConstrains, roadCollection);
       toggleMode(rootElement, editConstrains(selectedAsset) || applicationModel.isReadOnly());
       rootElement.find('.form-controls button').prop('disabled', !selectedAsset.isDirty());
+      if(newServices.length > 1){
+        rootElement.find('button.delete').show();
+      }
     });
 
     rootElement.on('click', 'button.delete', function (evt) {
@@ -125,6 +140,9 @@
       var serviceId =  parseInt(existingService.find('input[type="text"]').attr('data-service-id'), 10);
       var services = selectedAsset.get().services;
       var newServices = _.reject(services, { id: serviceId });
+      if(newServices.length < 2){
+        rootElement.find('button.delete').hide();
+      }
       selectedAsset.set({ services: newServices });
     });
 
@@ -475,6 +493,10 @@
       '<div class="form form-horizontal" data-layer-name="' + layerName + '">' +
       '<a id="point-asset-work-list-link" class="floating-point-assets" href="#work-list/' + layerName + '">Geometrian ulkopuolelle jääneet ' + localizedTexts.manyFloatingAssetsLabel + '</a>' +
       '</div>');
+  }
+
+  function isSingleService(selectedAsset){
+    return selectedAsset.get().services.length < 2;
   }
 
   function toggleMode(rootElement, readOnly) {


### PR DESCRIPTION
-checks current layer and amount of services for asset. Hide if only one service to prevent saving "empty" asset.