### PR TITLE
VIITE-860 U shaped road addressing fix

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
@@ -219,8 +219,11 @@ object ProjectSectionCalculator {
         case ex: InvalidAddressDataException =>
           logger.info(s"Can't calculate road/road part ${part._1}/${part._2}: " + ex.getMessage)
           projectLinks ++ oldLinks
-        case ex: NoSuchElementException | NullPointerException =>
+        case ex: NoSuchElementException =>
           logger.info("Delta calculation failed: " + ex.getMessage, ex)
+          projectLinks ++ oldLinks
+        case ex: NullPointerException =>
+          logger.info("Delta calculation failed (NPE)", ex)
           projectLinks ++ oldLinks
         case ex: Throwable =>
           logger.info("Delta calculation not possible: " + ex.getMessage)

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectSectionCalculator.scala
@@ -74,13 +74,17 @@ object ProjectSectionCalculator {
                                 calibrationPoints: Seq[UserDefinedCalibrationPoint]): (Point, Point) = {
     val rightStartPoint = findStartingPoint(newLinks.filter(_.track != Track.LeftSide), oldLinks.filter(_.track != Track.LeftSide),
       calibrationPoints)
-    // Get left track non-connected points and find the closest to right track starting point
-    val leftLinks = newLinks.filter(_.track != Track.RightSide) ++ oldLinks.filter(_.track != Track.RightSide)
-    val leftPoints = TrackSectionOrder.findOnceConnectedLinks(leftLinks).keys
-    if (leftPoints.isEmpty)
-      throw new InvalidAddressDataException("Missing left track starting points")
-    val leftStartPoint = leftPoints.minBy(lp => (lp - rightStartPoint).length())
-    (rightStartPoint, leftStartPoint)
+    if ((oldLinks ++ newLinks).exists(l => GeometryUtils.areAdjacent(l.geometry, rightStartPoint) && l.track == Track.Combined))
+      (rightStartPoint, rightStartPoint)
+    else {
+      // Get left track non-connected points and find the closest to right track starting point
+      val leftLinks = newLinks.filter(_.track != Track.RightSide) ++ oldLinks.filter(_.track != Track.RightSide)
+      val leftPoints = TrackSectionOrder.findOnceConnectedLinks(leftLinks).keys
+      if (leftPoints.isEmpty)
+        throw new InvalidAddressDataException("Missing left track starting points")
+      val leftStartPoint = leftPoints.minBy(lp => (lp - rightStartPoint).length())
+      (rightStartPoint, leftStartPoint)
+    }
   }
   /**
     * Find a starting point for this road part
@@ -107,20 +111,7 @@ object ProjectSectionCalculator {
         // Approximate estimate of the mid point: averaged over count, not link length
         val midPoint = points.map(p => p._1 + (p._2 - p._1).scale(0.5)).foldLeft(Vector3d(0,0,0)){case (x, p) =>
           (p - Point(0,0)).scale(1.0/points.size) + x}
-
-        points.foldLeft((Point(0.0, 0.0), Double.MaxValue)) { case ((current), (start, end)) =>
-          // Find if any other link is connected to start or end: if not, add them to possible starting points' list
-          val s = Seq(current) ++
-            (if (points.exists(p => GeometryUtils.areAdjacent(p._2, start)))
-              Seq()
-            else
-              Seq(start -> direction.dot(start.toVector - midPoint))) ++
-            (if (points.exists(p => GeometryUtils.areAdjacent(p._1, end)))
-              Seq()
-            else
-              Seq(end -> direction.dot(end.toVector - midPoint)))
-          s.minBy(_._2)
-        }._1
+        TrackSectionOrder.findOnceConnectedLinks(remainLinks).keys.minBy(p => direction.dot(p.toVector - midPoint))
       }
 
     )
@@ -227,6 +218,9 @@ object ProjectSectionCalculator {
       } catch {
         case ex: InvalidAddressDataException =>
           logger.info(s"Can't calculate road/road part ${part._1}/${part._2}: " + ex.getMessage)
+          projectLinks ++ oldLinks
+        case ex: NoSuchElementException | NullPointerException =>
+          logger.info("Delta calculation failed: " + ex.getMessage, ex)
           projectLinks ++ oldLinks
         case ex: Throwable =>
           logger.info("Delta calculation not possible: " + ex.getMessage)


### PR DESCRIPTION
Fix road addressing on roads where the part has a U shape and starting point calculation fails to pick the road link at the end because of that.

* Replaced with the newer functionality to find a loose end for the track and choose from those.
* Left track starting point will be the right track starting point if the link in question is a combined track link. Otherwise old logic remains.