### PR TITLE
Viite 858 ely==0

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -253,8 +253,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
         val project = getProjectWithReservationChecks(projectId, newRoadNumber, newRoadPartNumber)
 
         val ely= if (newLinks.nonEmpty)newLinks.head.elyCode else -1
-        if (!project.isReserved(newRoadNumber, newRoadPartNumber)){}
-
+        if (!project.isReserved(newRoadNumber, newRoadPartNumber))
           ProjectDAO.reserveRoadPart(project.id, newRoadNumber, newRoadPartNumber, project.modifiedBy, ely)
         val newProjectLinks = newLinks.map(projectLink => {
           projectLink.linkId ->

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -583,9 +583,9 @@ object ProjectDAO {
     Q.queryNA[Long](query).list
   }
 
-  def reserveRoadPart(projectId: Long, roadNumber: Long, roadPartNumber: Long, user: String): Unit = {
-    sqlu"""INSERT INTO PROJECT_RESERVED_ROAD_PART(id, road_number, road_part_number, project_id, created_by)
-      SELECT viite_general_seq.nextval, $roadNumber, $roadPartNumber, $projectId, $user FROM DUAL""".execute
+  def reserveRoadPart(projectId: Long, roadNumber: Long, roadPartNumber: Long, user: String,ely:Long): Unit = {
+    sqlu"""INSERT INTO PROJECT_RESERVED_ROAD_PART(id, road_number, road_part_number, project_id, created_by, ely)
+      SELECT viite_general_seq.nextval, $roadNumber, $roadPartNumber, $projectId, $user, $ely FROM DUAL""".execute
   }
 
   def updateReservedRoadPart(reserved: ReservedRoadPart): Unit = {

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -755,7 +755,7 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
       val reservedRoadPart1 = ReservedRoadPart(164, 77, 35, 5405, 5405, Discontinuity.EndOfRoad, 8, None, None)
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.now(), DateTime.now(), "Some additional info", Seq(reservedRoadPart1), None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(rap.id, 77, 35, "TestUser")
+      ProjectDAO.reserveRoadPart(rap.id, 77, 35, "TestUser",8)
       val addressesOnPart = RoadAddressDAO.fetchByRoadPart(77, 35, false)
       ProjectDAO.create(addressesOnPart.map(address => {
         toProjectLink(rap, LinkStatus.NotHandled)(address)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/CalibrationPointDAOSpec.scala
@@ -37,8 +37,8 @@ class CalibrationPointDAOSpec extends FunSuite with Matchers {
   }
 
   def addProjectRoads(): Unit = {
-    ProjectDAO.reserveRoadPart(1, 1, 1, "TestUser")
-    ProjectDAO.reserveRoadPart(2, 1, 1, "TestUser")
+    ProjectDAO.reserveRoadPart(1, 1, 1, "TestUser",0)
+    ProjectDAO.reserveRoadPart(2, 1, 1, "TestUser",0)
     sqlu"""insert into project_link (id,project_id,track_code,discontinuity_type,road_number,road_part_number,start_addr_M,end_addr_M,lrm_position_id,created_by) VALUES (1,1,1,0,1,1,1,1,20000286,'automatedtest')""".execute
     sqlu"""insert into project_link (id,project_id,track_code,discontinuity_type,road_number,road_part_number,start_addr_M,end_addr_M,lrm_position_id,created_by) VALUES (2,2,1,0,1,1,1,1,20000286,'automatedtest')""".execute
   }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/ProjectDaoSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/dao/ProjectDaoSpec.scala
@@ -54,7 +54,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List(address), None)
       ProjectDAO.createRoadAddressProject(rap)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
-      ProjectDAO.reserveRoadPart(id, 5, 203, "TestUser")
+      ProjectDAO.reserveRoadPart(id, 5, 203, "TestUser",8)
       ProjectDAO.create(addresses)
       ProjectDAO.getRoadAddressProjectById(id).nonEmpty should be(true)
       val projectlinks = ProjectDAO.getProjectLinks(id)
@@ -83,7 +83,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List(address), None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, address.roadNumber, address.roadPartNumber, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, address.roadNumber, address.roadPartNumber, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       ProjectDAO.getRoadAddressProjectById(id).nonEmpty should be(true)
@@ -99,7 +99,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List(address), None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, address.roadNumber, address.roadPartNumber, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, address.roadNumber, address.roadPartNumber, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       ProjectDAO.getRoadAddressProjectById(id).nonEmpty should be(true)
@@ -121,7 +121,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       val projectLinks = ProjectDAO.getProjectLinks(id)
@@ -138,7 +138,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       val projectLinks = ProjectDAO.getProjectLinks(id)
@@ -156,7 +156,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses.map(x => x.copy(reversed = true)))
       val projectLinks = ProjectDAO.getProjectLinks(id)
@@ -170,7 +170,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses.map(x => x.copy(reversed = false)))
       val projectLinks = ProjectDAO.getProjectLinks(id)
@@ -249,7 +249,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       val project = ProjectDAO.roadPartReservedByProject(5, 203)
@@ -267,7 +267,7 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
       val addresses = RoadAddressDAO.fetchByRoadPart(5, 203).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       val (lrmid, linkid) = sql"select LRM_POSITION_ID,ID from PROJECT_LINK where PROJECT_LINK.PROJECT_ID = $id".as[(Long, Long)].first
@@ -313,8 +313,8 @@ class ProjectDaoSpec extends FunSuite with Matchers {
       val id = Sequences.nextViitePrimaryKeySeqValue
       val rap = RoadAddressProject(id, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("1901-01-01"), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", List.empty, None)
       ProjectDAO.createRoadAddressProject(rap)
-      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy)
-      ProjectDAO.reserveRoadPart(id, 5, 205, rap.createdBy)
+      ProjectDAO.reserveRoadPart(id, 5, 203, rap.createdBy,8)
+      ProjectDAO.reserveRoadPart(id, 5, 205, rap.createdBy,8)
       val addresses = (RoadAddressDAO.fetchByRoadPart(5, 203) ++ RoadAddressDAO.fetchByRoadPart(5, 205)).map(toProjectLink(rap))
       ProjectDAO.create(addresses)
       ProjectDAO.roadPartReservedByProject(5, 203) should be(Some("TestProject"))


### PR DESCRIPTION
fixes bug: Where the user make new roundabout or anything else NEW action, it has right ELY code in Change table. But if user opens project data form, there is ELY is 0 for new roundabout. => The user can not continue to action mode.

adds ely code to reserve table (so we avoid ely!=projectEly in UI checks). Later we might want to remove  ely ui check if project can have multiple ely's.