### PR TITLE
VIITE-923 change sort for change table

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressChangesDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/RoadAddressChangesDAO.scala
@@ -173,7 +173,9 @@ object RoadAddressChangesDAO {
                 rac.old_discontinuity, rac.old_ely, p.tr_id, rac.reversed
                 From Road_Address_Changes rac Inner Join Project p on rac.project_id = p.id
                 $withProjectIds
-                ORDER BY rac.old_road_number, rac.OLD_ROAD_PART_NUMBER, rac.old_start_addr_m, rac.old_track_code DESC"""
+                ORDER BY COALESCE(rac.old_road_number, rac.new_road_number), COALESCE(rac.old_road_part_number, rac.new_road_part_number),
+                  COALESCE(rac.old_start_addr_m, rac.new_start_addr_m), COALESCE(rac.old_track_code, rac.new_track_code),
+                  CHANGE_TYPE DESC"""
     queryList(query)
   }
 


### PR DESCRIPTION
Sort change table by road, part, startAddrM, track and change type.

Pick old data first (used for all change types except new) but use new side for additions.