### PR TITLE
VIITE-947 removed (incorrect) sorting for track change positions

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/package.scala
@@ -59,8 +59,8 @@ package object viite {
   val DefaultScreenWidth = 1920
   val DefaultScreenHeight = 1080
   val Resolutions = Array(2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125, 0.0625)
-  val DefaultLongitude = 390000.0
-  val DefaultLatitude = 6900000.0
+  val DefaultLongitude = 6900000.0
+  val DefaultLatitude = 390000.0
   val DefaultZoomLevel = 2
 
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/process/ProjectDeltaCalculator.scala
@@ -241,15 +241,15 @@ object ProjectDeltaCalculator {
 
   def partition(transfers: Seq[(RoadAddress, ProjectLink)]): Map[RoadAddressSection, RoadAddressSection] = {
     def toRoadAddressSection(o: Seq[BaseRoadAddress]): Seq[RoadAddressSection] = {
-      o.sortBy(_.startAddrMValue).map(ra =>
+      o.map(ra =>
         RoadAddressSection(ra.roadNumber, ra.roadPartNumber, ra.roadPartNumber,
           ra.track, ra.startAddrMValue, ra.endAddrMValue, ra.discontinuity, ra.roadType, ra.ely, ra.reversed))
     }
     val sectioned = transfers.groupBy(x => (x._1.roadNumber, x._1.roadPartNumber, x._1.track, x._2.roadNumber, x._2.roadPartNumber, x._2.track))
       .mapValues(v => combinePair(v.sortBy(_._1.startAddrMValue)))
       .mapValues(v => {
-        val x = v.unzip
-        toRoadAddressSection(x._1) -> toRoadAddressSection(x._2)
+        val (from, to) = v.unzip
+        toRoadAddressSection(from) -> toRoadAddressSection(to)
       })
     sectioned.flatMap { case (key, (src, target)) =>
       val matches = matchingTracks(sectioned, key)


### PR DESCRIPTION
Fix for incorrectly sorting the section mapping for discontinuous reversed transfers.
Fixed mixed default coordinates (lat <-> lon) for users without default