### PR TITLE
VIITE-983 - Jakamalla JATKUU-koodin muutos on tallennettava vain A-tai B-osalle

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -523,20 +523,6 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
 
   def preSplitSuravageLinkInTX(linkId: Long, username: String,
                                splitOptions: SplitOptions): (Option[Seq[ProjectLink]], Option[String], Option[(Point, Vector3d)]) = {
-    //Discontinuity of splits should be the given only for the part with the biggest M Address Value
-    //The rest of them should be 5 (Continuous)
-    def adjustSplitsDiscontinuity(splitLinks: Seq[ProjectLink]) = {
-      val bigEndAddr = splitLinks.filter(_.id == NewRoadAddress).maxBy(_.endAddrMValue).endAddrMValue
-      splitLinks.map(split => {
-        if(split.id == NewRoadAddress)
-          if(split.endAddrMValue == bigEndAddr)
-            split.copy(discontinuity = splitOptions.discontinuity)
-          else
-            split.copy(discontinuity = Discontinuity.Continuous)
-        else
-          split
-      })
-    }
     val projectId = splitOptions.projectId
     val sOption = roadLinkService.getSuravageRoadLinksByLinkIdsFromVVH(Set(Math.abs(linkId)), false).headOption
     val previousSplit = ProjectDAO.fetchSplitLinks(projectId, linkId)
@@ -568,7 +554,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       else {
         val bestFit = commonSections.maxBy(_._2)._1
         val splitLinks = ProjectLinkSplitter.split(newProjectLink(suravageLink, project, splitOptions), bestFit, splitOptions)
-        (Some(adjustSplitsDiscontinuity(splitLinks)), None, GeometryUtils.calculatePointAndHeadingOnGeometry(suravageLink.geometry, splitOptions.splitPoint))
+        (Some(splitLinks), None, GeometryUtils.calculatePointAndHeadingOnGeometry(suravageLink.geometry, splitOptions.splitPoint))
       }
     }
   }

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitterSpec.scala
@@ -14,7 +14,7 @@ import fi.liikennevirasto.digiroad2.masstransitstop.oracle.Sequences
 import fi.liikennevirasto.digiroad2.oracle.OracleDatabase
 import fi.liikennevirasto.viite.RoadType.{PublicRoad, UnknownOwnerRoad}
 import fi.liikennevirasto.viite._
-import fi.liikennevirasto.viite.dao.Discontinuity.Continuous
+import fi.liikennevirasto.viite.dao.Discontinuity.{Continuous, MinorDiscontinuity}
 import fi.liikennevirasto.viite.dao.LinkStatus.{New, NotHandled}
 import fi.liikennevirasto.viite.dao._
 import fi.liikennevirasto.viite.MaxSuravageToleranceToGeometry
@@ -194,7 +194,7 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
       SideCode.TowardsDigitizing, (None, None), false, tGeom, 1L, LinkStatus.NotHandled, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface,
       tLen, 0L, 5, false, None, 85088L)
     val (sl, tl) = ProjectLinkSplitter.split(suravage, template, SplitOptions(Point(15.5, 0.75), LinkStatus.UnChanged,
-      LinkStatus.New, 5L, 205L, Track.Combined, Discontinuity.Continuous, 8L, LinkGeomSource.NormalLinkInterface,
+      LinkStatus.New, 5L, 205L, Track.Combined, Discontinuity.EndOfRoad, 8L, LinkGeomSource.NormalLinkInterface,
       RoadType.PublicRoad, 1L, ProjectCoordinates(0, 1, 1))).partition(_.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
     val (splitA, splitB) = sl.partition(_.status != LinkStatus.New)
     sl should have size (2)
@@ -204,6 +204,8 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
     terminatedLink.endAddrMValue should be (template.endAddrMValue)
     terminatedLink.startAddrMValue should be (splitB.head.startAddrMValue)
     splitA.head.endAddrMValue should be (splitB.head.startAddrMValue)
+    splitB.head.discontinuity should be (Discontinuity.EndOfRoad)
+    splitA.head.discontinuity should be (Continuous)
     sl.foreach { l =>
       l.endAddrMValue == terminatedLink.startAddrMValue || l.startAddrMValue == terminatedLink.startAddrMValue should be(true)
       l.linkGeomSource should be (LinkGeomSource.SuravageLinkInterface)
@@ -253,11 +255,11 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
     val suravage = ProjectLink(0L, 0L, 0L, Track.Unknown, Discontinuity.Continuous, 0L, 0L, None, None, None, 0L, 123L, 0.0, sLen,
       SideCode.Unknown, (None, None), false, sGeom, 1L, LinkStatus.NotHandled, RoadType.Unknown, LinkGeomSource.SuravageLinkInterface,
       sLen, 0L, 5, false, None, 85088L)
-    val template = ProjectLink(2L, 5L, 205L, Track.Combined, Discontinuity.Continuous, 1024L, 1040L, None, None, None, 0L, 124L, 0.0, tLen,
+    val template = ProjectLink(2L, 5L, 205L, Track.Combined, Discontinuity.EndOfRoad, 1024L, 1040L, None, None, None, 0L, 124L, 0.0, tLen,
       SideCode.TowardsDigitizing, (None, None), false, tGeom, 1L, LinkStatus.NotHandled, RoadType.PublicRoad, LinkGeomSource.NormalLinkInterface,
       tLen, 0L, 5, false, None, 85088L)
     val (sl, tl) = ProjectLinkSplitter.split(suravage, template, SplitOptions(Point(15.5, 0.75), LinkStatus.UnChanged,
-      LinkStatus.New, 5L, 205L, Track.Combined, Discontinuity.Continuous, 8L, LinkGeomSource.NormalLinkInterface,
+      LinkStatus.New, 5L, 205L, Track.Combined, Discontinuity.MinorDiscontinuity, 8L, LinkGeomSource.NormalLinkInterface,
       RoadType.PublicRoad, 1L, ProjectCoordinates(0, 1, 1))).partition(_.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
     sl should have size (2)
     tl should have size (1)
@@ -267,6 +269,8 @@ class ProjectLinkSplitterSpec extends FunSuite with Matchers with BeforeAndAfter
     terminatedLink.endAddrMValue should be (template.endAddrMValue)
     terminatedLink.startAddrMValue should be (splitA.head.endAddrMValue)
     terminatedLink.startAddrMValue should be (splitB.head.startAddrMValue)
+    splitA.head.discontinuity should be (Continuous)
+    splitB.head.discontinuity should be (MinorDiscontinuity)
     GeometryUtils.minimumDistance(terminatedLink.geometry.head, splitA.head.geometry) should be < MaxSuravageToleranceToGeometry
     GeometryUtils.areAdjacent(terminatedLink.geometry, template.geometry) should be (true)
     sl.foreach { l =>


### PR DESCRIPTION
Added Discontinuity adjustment method to the pre-split links.