### PR TITLE
VIITE-991 - Selection on the map is too large when splitting

### DIFF
--- a/viite-UI/src/model/SelectedProjectLink.js
+++ b/viite-UI/src/model/SelectedProjectLink.js
@@ -74,7 +74,7 @@
           if (!terminatedC) {
             terminatedC = zeroLengthTerminated(suravageA);
           }
-          ids = projectLinkCollection.getMultiSelectIds(suravageA.linkId);
+          ids = [suravageA.linkId, suravageB.linkId];
           current = projectLinkCollection.getByLinkId(_.flatten(ids));
           suravageA.marker = "A";
           suravageB.marker = "B";

--- a/viite-UI/src/view/LinkPropertyLayer.js
+++ b/viite-UI/src/view/LinkPropertyLayer.js
@@ -1100,12 +1100,14 @@
     });
 
     eventbus.on('linkProperties:highlightReservedRoads', function(reservedOL3Features){
-     var styledFeatures = _.map(reservedOL3Features,function(feature) {
+      var styledFeatures = _.map(reservedOL3Features,function(feature) {
         feature.setStyle(projectLinkStyler.getProjectLinkStyle().getStyle( feature.projectLinkData, {zoomLevel: map.getView().getZoom()}));
-       return feature;
+        return feature;
       });
-      reservedRoadLayer.setZIndex(10000);
-      reservedRoadLayer.getSource().addFeatures(styledFeatures);
+      if (applicationModel.getSelectedLayer()==="linkProperty"){ //check if user is still in reservation form
+        reservedRoadLayer.setZIndex(10000);
+        reservedRoadLayer.getSource().addFeatures(styledFeatures);
+      }
     });
 
     eventbus.on('linkProperties:deselectFeaturesSelected', function(){

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -631,7 +631,7 @@
         });
         var style = new ol.style.Style({
           stroke: new ol.style.Stroke({color: '#c6c00f', width: 13, lineCap: 'round'}),
-          zIndex: 11
+          zIndex: -1
         });
         terminatedFeature.setStyle(style);
         removeFeaturesByType('pre-split');

--- a/viite-UI/src/view/ProjectLinkLayer.js
+++ b/viite-UI/src/view/ProjectLinkLayer.js
@@ -16,7 +16,6 @@
     var RoadLinkType = LinkValues.RoadLinkType;
     var LinkGeomSource = LinkValues.LinkGeomSource;
     var RoadClass = LinkValues.RoadClass;
-
     var isNotEditingData = true;
     Layer.call(this, layerName, roadLayer);
     var me = this;


### PR DESCRIPTION
Changed the linkIds that are loaded on the SelectedProjectLink.
Decreased the zIndex of the transferred Link (dark yellow).