### PR TITLE
Viite 998 validation check project change table and save

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -479,8 +479,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
         "changeInfoSeq" -> project.changeInfoSeq.map(changeInfo =>
           Map("changetype" -> changeInfo.changeType.value, "roadType" -> changeInfo.roadType.value,
             "discontinuity" -> changeInfo.discontinuity.value, "source" -> changeInfo.source,
-            "target" -> changeInfo.target, "reversed" -> changeInfo.reversed)),
-        "validationErrors" -> validationErrors
+            "target" -> changeInfo.target, "reversed" -> changeInfo.reversed))
       ))
     Map("changeTable" -> changeTableData, "validationErrors" -> validationErrors)
   }

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -482,8 +482,15 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
         "changeInfoSeq" -> project.changeInfoSeq.map(changeInfo =>
           Map("changetype" -> changeInfo.changeType.value, "roadType" -> changeInfo.roadType.value,
             "discontinuity" -> changeInfo.discontinuity.value, "source" -> changeInfo.source,
-            "target" -> changeInfo.target, "reversed" -> changeInfo.reversed)))
-    ).getOrElse(None)
+            "target" -> changeInfo.target, "reversed" -> changeInfo.reversed)),
+    "validationErrors" -> projectService.validateProjectById(projectId).map(issue => {
+      Map(
+        "validationError" -> issue.validationError.value,
+        "affectedLinkIds" -> issue.affectedLinkIds.toArray,
+        "coordinates" -> issue.coordinates,
+        "optionalInformation" -> issue.optionalInformation.getOrElse("")
+      )
+    }))).getOrElse(None)
     Map("changeTable" -> changeTableData, "validationErrors" -> projectService.validateProjectById(projectId).map(issue => {
       Map(
         "id" -> issue.projectId,

--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -22,10 +22,6 @@ import org.slf4j.LoggerFactory
 import scala.util.parsing.json._
 import scala.util.{Left, Right}
 
-/**
-  * Created by venholat on 25.8.2016.
-  */
-
 case class NewAddressDataExtracted(sourceIds: Set[Long], targetIds: Set[Long])
 
 case class RevertSplitExtractor(projectId: Option[Long], linkId: Option[Long], coordinates: ProjectCoordinates)

--- a/viite-UI/src/model/ProjectChangeInfoModel.js
+++ b/viite-UI/src/model/ProjectChangeInfoModel.js
@@ -10,7 +10,7 @@
     function getChanges(projectID){
       $('.project-changes').html('<table class="change-table"></table>');
       backend.getChangeTable(projectID,function(changedata) {
-        var parsedResult=roadChangeAPIResultParser(changedata.changeTable);
+        var parsedResult=roadChangeAPIResultParser(changedata);
         if (parsedResult!==null && parsedResult.discontinuity !==null) {
           eventbus.trigger('projectChanges:fetched', roadChangeAPIResultParser(parsedResult));
         }

--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -124,7 +124,7 @@
         htmlTable += '</table>';
         $('.project-changes').html($(htmlTable));
         if (projectChangeData.validationErrors.length===0)
-        $('.change-table-header').html($('<div>Validointi ok. Alla näet muutokset projektissa.</div>'));
+          $('.change-table-header').html($('<div>Validointi ok. Alla näet muutokset projektissa.</div>'));
         else
         {
           $('.change-table-header').html($('<div>Tarkista validointitulokset. Yhteenvetotaulukko voi olla puutteellinen.</div>'));

--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -87,7 +87,7 @@
       eventbus.once('projectChanges:fetched', function(projectChangeData){
         var htmlTable ='<table class="change-table">';
         if(!_.isUndefined(projectChangeData) && projectChangeData !== null){
-          _.each(projectChangeData.changeInfoSeq, function(changeInfoSeq) {
+          _.each(projectChangeData.changeTable.changeInfoSeq, function(changeInfoSeq) {
             if (changeInfoSeq.changetype === newLinkStatus) {
               htmlTable += '<tr class="change-table-data-row">';
               htmlTable += getEmptySource(changeInfoSeq);

--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -123,8 +123,13 @@
         }
         htmlTable += '</table>';
         $('.project-changes').html($(htmlTable));
+        if (projectChangeData.validationErrors.length===0)
+        $('.change-table-header').html($('<div>Validointi ok. Alla näet muutokset projektissa.</div>'));
+        else
+        {
+          $('.change-table-header').html($('<div>Tarkista validointitulokset. Yhteenvetotaulukko voi olla puutteellinen.</div>'));
+        }
       });
-
       changeTable.on('click', 'button.close', function (){
         hide();
       });


### PR DESCRIPTION
Added validation errors to change table message,  also added info if we later on want to pinpoint location of error in changetable (we already had publishable attribute so no need to make changes to save)