### PR TITLE
VIITE-1004 fix resplit not keeping previous values for discontinuity,…

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/RoadLinkService.scala
@@ -692,18 +692,23 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
       Nil
   }
 
-  def getViiteCurrentAndHistoryRoadLinksFromVVH(roadAddressesLinkIds: Set[Long], frozenTimeVVHAPIServiceEnabled : Boolean = false): (Seq[RoadLink], Seq[VVHHistoryRoadLink]) = {
+  def getViiteCurrentAndHistoryRoadLinksFromVVH(linkIds: Set[Long],
+                                                frozenTimeVVHAPIServiceEnabled: Boolean = false): (Seq[RoadLink], Seq[VVHHistoryRoadLink]) = {
     val fut = for{
-      f1Result <- vvhClient.historyData.fetchVVHRoadLinkByLinkIdsF(roadAddressesLinkIds)
-      f2Result <- if(frozenTimeVVHAPIServiceEnabled)vvhClient.frozenTimeRoadLinkData.fetchByLinkIdsF(roadAddressesLinkIds) else {vvhClient.roadLinkData.fetchByLinkIdsF(roadAddressesLinkIds)}
-      f3Result <- vvhClient.complementaryData.fetchByLinkIdsF(roadAddressesLinkIds)
+      f1Result <- vvhClient.historyData.fetchVVHRoadLinkByLinkIdsF(linkIds)
+      f2Result <- if(frozenTimeVVHAPIServiceEnabled)vvhClient.frozenTimeRoadLinkData.fetchByLinkIdsF(linkIds) else {vvhClient.roadLinkData.fetchByLinkIdsF(linkIds)}
+      f3Result <- vvhClient.complementaryData.fetchByLinkIdsF(linkIds)
     } yield (f1Result, f2Result, f3Result)
 
     val (historyData, currentData, complementaryData) = Await.result(fut, Duration.Inf)
     val uniqueHistoryData = historyData.groupBy(_.linkId).mapValues(_.maxBy(_.endDate)).values.toSeq
 
-    withDynTransaction {
+    if (OracleDatabase.isWithinSession)
       (enrichRoadLinksFromVVH(currentData ++ complementaryData, Seq()), uniqueHistoryData)
+    else {
+      withDynTransaction {
+        (enrichRoadLinksFromVVH(currentData ++ complementaryData, Seq()), uniqueHistoryData)
+      }
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/VVHClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/VVHClient.scala
@@ -72,7 +72,9 @@ case class ChangeInfo(oldId: Option[Long], newId: Option[Long], mmlId: Long, cha
 }
 
 case class VVHHistoryRoadLink(linkId: Long, municipalityCode: Int, geometry: Seq[Point], administrativeClass: AdministrativeClass,
-                              trafficDirection: TrafficDirection, featureClass: FeatureClass, createdDate:BigInt, endDate: BigInt, attributes: Map[String, Any] = Map())
+                              trafficDirection: TrafficDirection, featureClass: FeatureClass, createdDate:BigInt, endDate: BigInt, attributes: Map[String, Any] = Map()) {
+  val vvhTimeStamp: Long = attributes.getOrElse("LAST_EDITED_DATE", createdDate).asInstanceOf[BigInt].longValue()
+}
 
 case class VVHRoadNodes(objectId: Long, geometry: Point, nodeId: Long, formOfNode: NodeType, municipalityCode: Int, subtype: Int)
 

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectValidator.scala
@@ -234,7 +234,7 @@ object ProjectValidator {
         val nextProjectPart = projectNextRoadParts.filter(_.newLength.getOrElse(0L) > 0L)
           .map(_.roadPartNumber).sorted.headOption
         val nextAddressPart = RoadAddressDAO.getValidRoadParts(road.toInt, project.startDate)
-          .filterNot(p => projectNextRoadParts.exists(_.roadPartNumber == p)).sorted.headOption
+          .filterNot(p => p == part || projectNextRoadParts.exists(_.roadPartNumber == p)).sorted.headOption
         if (nextProjectPart.isEmpty && nextAddressPart.isEmpty) {
           if (discontinuity != EndOfRoad)
             return error(ValidationError.MissingEndOfRoad)(lastProjectLinks)
@@ -248,9 +248,9 @@ object ProjectValidator {
           if (nextLinks.exists(_.ely != ely) && discontinuity != ChangingELYCode)
             return error(ValidationError.ElyCodeChangeDetected)(lastProjectLinks)
           val isConnected = lastProjectLinks.forall(lpl => nextLinks.exists(nl => trackMatch(nl.track, lpl.track) &&
-          connected(lpl, nl)))
+            connected(lpl, nl)))
           val isDisConnected = !lastProjectLinks.exists(lpl => nextLinks.exists(nl => trackMatch(nl.track, lpl.track) &&
-          connected(lpl, nl)))
+            connected(lpl, nl)))
           if (isDisConnected) {
             discontinuity match {
               case Continuous | MinorDiscontinuity =>

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -238,7 +238,7 @@ object ProjectDAO {
     val nonUpdatingStatus = Set[LinkStatus](NotHandled, UnChanged)
     val addresses = RoadAddressDAO.fetchByIdMassQuery(projectLinks.map(_.roadAddressId).toSet).map(ra => ra.id -> ra).toMap
     val links = projectLinks.map{ pl =>
-      if (nonUpdatingStatus.contains(pl.status) && addresses.contains(pl.roadAddressId)) {
+      if (!pl.isSplit && nonUpdatingStatus.contains(pl.status) && addresses.contains(pl.roadAddressId)) {
         val ra = addresses(pl.roadAddressId)
         // Discontinuity, road type and calibration points may change with Unchanged (and NotHandled) status
         pl.copy(roadNumber = ra.roadNumber, roadPartNumber = ra.roadPartNumber, track = ra.track,

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitter.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/util/ProjectLinkSplitter.scala
@@ -144,7 +144,6 @@ object ProjectLinkSplitter {
         movedFromEnd(suravageM, templateM, splitAddressM, isReversed)
       else
         movedFromStart(suravageM, templateM, splitAddressM, isReversed)
-
     toSeq(
       if (isReversed)
         switchDigitization(splits)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -161,46 +161,6 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
     StaticTestData.roadLinkMocker(roadLinkTemplate)(linkIds)
   }
 
-  ignore("Fetch project links") { // Needs more of mocking because of Futures + transactions disagreeing
-    val roadLinkService = new RoadLinkService(new VVHClient(properties.getProperty("digiroad2.VVHRestApiEndPoint")), mockEventBus, new DummySerializer) {
-      override def withDynSession[T](f: => T): T = f
-
-      override def withDynTransaction[T](f: => T): T = f
-    }
-    val roadAddressService = new RoadAddressService(roadLinkService, mockEventBus) {
-      override def withDynSession[T](f: => T): T = f
-
-      override def withDynTransaction[T](f: => T): T = f
-    }
-    val projectService = new ProjectService(roadAddressService, roadLinkService, mockEventBus) {
-      override def withDynSession[T](f: => T): T = f
-
-      override def withDynTransaction[T](f: => T): T = f
-    }
-    runWithRollback {
-      val addresses: List[ReservedRoadPart] = List(ReservedRoadPart(Sequences.nextViitePrimaryKeySeqValue: Long, 5: Long, 205: Long, Some(5L), Some(Discontinuity.apply("jatkuva")), Some(8L), newLength = None, newDiscontinuity = None, newEly = None))
-      val roadAddressProject = RoadAddressProject(0, ProjectState.apply(1), "TestProject", "TestUser", DateTime.now(), "TestUser", DateTime.parse("1901-01-01"), DateTime.now(), "Some additional info", addresses, None)
-      val savedProject = projectService.createRoadLinkProject(roadAddressProject)
-      val startingLinkId = ProjectDAO.getProjectLinks(savedProject.id).filter(_.track == Track.LeftSide).minBy(_.startAddrMValue).linkId
-      val boundingRectangle = roadLinkService.fetchVVHRoadlinks(Set(startingLinkId)).map { vrl =>
-        val x = vrl.geometry.map(l => l.x)
-        val y = vrl.geometry.map(l => l.y)
-
-        BoundingRectangle(Point(x.min, y.min) + Vector3d(-5.0, -5.0, 0.0), Point(x.max, y.max) + Vector3d(5.0, 5.0, 0.0))
-      }.head
-
-      val links = projectService.getProjectRoadLinks(savedProject.id, boundingRectangle, Seq(), Set(), true, true)
-      links.nonEmpty should be(true)
-      links.exists(_.status == LinkStatus.Unknown) should be(true)
-      links.exists(_.status == LinkStatus.NotHandled) should be(true)
-      val (unk, nh) = links.partition(_.status == LinkStatus.Unknown)
-      nh.forall(l => l.roadNumber == 5 && l.roadPartNumber == 205) should be(true)
-      unk.forall(l => l.roadNumber != 5 || l.roadPartNumber != 205) should be(true)
-      nh.map(_.linkId).toSet.intersect(unk.map(_.linkId).toSet) should have size (0)
-      unk.exists(_.attributes.getOrElse("ROADPARTNUMBER", "0").toString == "203") should be(true)
-    }
-  }
-
   test("update project link status and check project status") {
     var count = 0
     val roadLink = RoadLink(5170939L, Seq(Point(535605.272, 6982204.22, 85.90899999999965))
@@ -269,48 +229,63 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
 
   }
 
-  ignore("Splitting link test") {
+  private def createProjectDataForSplit(): RoadAddressProject = {
+    val projectId = Sequences.nextViitePrimaryKeySeqValue
+    val lrmPositionId = Sequences.nextLrmPositionPrimaryKeySeqValue
+    val lrmPositionId2 = Sequences.nextLrmPositionPrimaryKeySeqValue
+    val rap = RoadAddressProject(projectId, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"), "TestUser", DateTime.parse("2700-01-01"), DateTime.now(), "Some additional info", List.empty[ReservedRoadPart], None)
+    ProjectDAO.createRoadAddressProject(rap)
+    val raId = Sequences.nextViitePrimaryKeySeqValue
+    sqlu""" insert into LRM_Position(id,start_Measure,end_Measure,Link_id, side_code) Values ($lrmPositionId,0,87,1,2) """.execute
+    sqlu"""insert into ROAD_ADDRESS (id, lrm_position_id, road_number, road_part_number,
+         track_code, discontinuity, START_ADDR_M, END_ADDR_M, start_date, end_date, created_by,
+         VALID_FROM, geometry, floating, calibration_points) VALUES ($raId, $lrmPositionId, 1, 1, 0, 5, 0, 87, date'2011-01-01', null, 'foo', date'2011-01-01', MDSYS.SDO_GEOMETRY(4002,3067,NULL,MDSYS.SDO_ELEM_INFO_ARRAY(1,2,1),MDSYS.SDO_ORDINATE_ARRAY(0,0,0,0,0,87.0,0,87)), 0, 0)""".execute
+    ProjectDAO.reserveRoadPart(projectId, 1, 1, "TestUser")
+    sqlu"""insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp, link_source)
+          values ($lrmPositionId2, 1, 2, 0.0, 87.0, 0, 1)""".execute
+    sqlu""" INSERT INTO PROJECT_LINK (ID, PROJECT_ID, TRACK_CODE, DISCONTINUITY_TYPE, ROAD_NUMBER, ROAD_PART_NUMBER,
+          START_ADDR_M, END_ADDR_M, LRM_POSITION_ID, CREATED_BY, CREATED_DATE, STATUS, ROAD_ADDRESS_ID, GEOMETRY) VALUES
+          (${Sequences.nextViitePrimaryKeySeqValue},$projectId,0,0,1,1,0,87,$lrmPositionId2,'testuser',
+          TO_DATE('2017-10-06 14:54:41', 'YYYY-MM-DD HH24:MI:SS'),0, $raId,
+          ${fi.liikennevirasto.viite.toGeomString(Seq(Point(0, 0), Point(0, 45.3), Point(0, 87)))})""".execute
+    ProjectDAO.getRoadAddressProjectById(projectId).get
+  }
+
+  test("Splitting link test") {
     runWithRollback {
-      val projectId = Sequences.nextViitePrimaryKeySeqValue
-      val lrmPositionId = Sequences.nextLrmPositionPrimaryKeySeqValue
       val roadLink = RoadLink(1, Seq(Point(0, 0), Point(0, 45.3), Point(0, 87))
-        , 540.3960283713503, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"), Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+        , 87.0, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"),
+        Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
         InUse, NormalLinkInterface)
-      val suravageAddressLink = RoadAddressLink(2, 2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
-        AdministrativeClass.apply(1), LinkType.apply(1), RoadLinkType.UnknownRoadLinkType, ConstructionType.Planned, LinkGeomSource.SuravageLinkInterface, RoadType.PublicRoad, "testRoad",
-        8, None, None, null, 1, 1, Track.Combined.value, 8, Discontinuity.Continuous.value, 0, 123, "", "", 0, 123, SideCode.AgainstDigitizing, None, None, Anomaly.None, 1)
-      val options = SplitOptions(Point(0, 45.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous, 1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, projectId, ProjectCoordinates(0,0,0))
-      when(mockRoadAddressService.getSuravageRoadLinkAddressesByLinkIds(any[Set[Long]])).thenReturn(Seq(suravageAddressLink))
+      val suravageAddressLink = RoadLink(2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
+        State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"),
+        Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+        InUse, LinkGeomSource.SuravageLinkInterface)
+      when(mockRoadLinkService.getSuravageRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean])).thenReturn(Seq(suravageAddressLink))
       when(mockRoadLinkService.getRoadLinksWithComplementaryFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean])).thenReturn(Seq(roadLink))
-      val rap = RoadAddressProject(projectId, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"), "TestUser", DateTime.parse("2700-01-01"), DateTime.now(), "Some additional info", List.empty[ReservedRoadPart], None)
-      ProjectDAO.createRoadAddressProject(rap)
-      sqlu""" insert into LRM_Position(id,start_Measure,end_Measure,Link_id) Values($lrmPositionId,0,87,1) """.execute
-      sqlu""" INSERT INTO PROJECT_RESERVED_ROAD_PART (ID, ROAD_NUMBER, ROAD_PART_NUMBER, PROJECT_ID, CREATED_BY, ROAD_LENGTH, ADDRESS_LENGTH, DISCONTINUITY, ELY) VALUES (${Sequences.nextViitePrimaryKeySeqValue},1,1,$projectId,'""',87,900,0,0)""".execute
-      sqlu""" INSERT INTO PROJECT_LINK (ID, PROJECT_ID, TRACK_CODE, DISCONTINUITY_TYPE, ROAD_NUMBER, ROAD_PART_NUMBER, START_ADDR_M, END_ADDR_M, LRM_POSITION_ID, CREATED_BY, CREATED_DATE, STATUS) VALUES (${Sequences.nextViitePrimaryKeySeqValue},$projectId,0,0,1,1,0,87,$lrmPositionId,'testuser',TO_DATE('2017-10-06 14:54:41', 'YYYY-MM-DD HH24:MI:SS'),0)""".execute
-      val failmessage = projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options)
-      failmessage should be(None)
-      val projectLinks = ProjectDAO.getProjectLinks(projectId)
-      val newSuravageLink = projectLinks.filter(x => x.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
-      val unchangedLink = projectLinks.filter(x => x.status == LinkStatus.UnChanged).head
-      val newLink = projectLinks.filter(x => x.status == LinkStatus.New).head
-      val templateLink = projectLinks.filter(x => x.linkGeomSource != LinkGeomSource.SuravageLinkInterface).head
+
+      val rap = createProjectDataForSplit()
+      val options = SplitOptions(Point(0, 45.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous,
+        1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, rap.id, ProjectCoordinates(0,0,0))
+      val errorOpt = projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options)
+      errorOpt should be(None)
+      val projectLinks = ProjectDAO.getProjectLinks(rap.id)
       checkSplit(projectLinks, 45.3, 0, 45, 87, 123.0)
     }
   }
 
   private def checkSplit(projectLinks: Seq[ProjectLink], splitMValue: Double, startAddrMValue: Long,
                          splitAddrMValue: Long, endAddrMValue: Long, survageEndMValue: Double) = {
-    val newSuravageLink = projectLinks.filter(x => x.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
-    val unchangedLink = projectLinks.filter(x => x.status == LinkStatus.UnChanged).head
+    projectLinks.count(x => x.connectedLinkId.isDefined) should be(3)
+    val unchangedLink = projectLinks.filter(x => x.status == LinkStatus.UnChanged || x.status == LinkStatus.Transfer).head
     val newLink = projectLinks.filter(x => x.status == LinkStatus.New).head
     val templateLink = projectLinks.filter(x => x.linkGeomSource != LinkGeomSource.SuravageLinkInterface).head
-    projectLinks.count(x => x.connectedLinkId.isDefined) should be(3)
     newLink.connectedLinkId should be(Some(templateLink.linkId))
     unchangedLink.connectedLinkId should be(Some(templateLink.linkId))
     templateLink.connectedLinkId should be(Some(newLink.linkId))
     newLink.startMValue should be(splitMValue)
     newLink.startAddrMValue should be(splitAddrMValue)
-    newLink.endAddrMValue should be(endAddrMValue)
+    newLink.endAddrMValue should be > (splitAddrMValue)
     newLink.endMValue should be(survageEndMValue)
     unchangedLink.startMValue should be(0)
     unchangedLink.startAddrMValue should be(startAddrMValue)
@@ -318,121 +293,65 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
     unchangedLink.endMValue should be(splitMValue)
     templateLink.status should be(LinkStatus.Terminated)
     templateLink.startAddrMValue should be(newLink.startAddrMValue)
-    templateLink.endAddrMValue should be(newLink.endAddrMValue)
     templateLink.roadAddressId should be(newLink.roadAddressId)
   }
 
-  ignore("Split and revert links") {
+  test("Split and revert links") {
     runWithRollback {
-      val projectId = Sequences.nextViitePrimaryKeySeqValue
       val roadLink = RoadLink(1, Seq(Point(0, 0), Point(0, 45.3), Point(0, 87))
-        , 540.3960283713503, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"), Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+        , 87.0, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"),
+        Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
         InUse, NormalLinkInterface)
-      val suravageAddressLink = RoadAddressLink(2, 2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
-        AdministrativeClass.apply(1), LinkType.apply(1), RoadLinkType.UnknownRoadLinkType, ConstructionType.Planned, LinkGeomSource.SuravageLinkInterface, RoadType.PublicRoad, "testRoad",
-        8, None, None, null, 1, 1, Track.Combined.value, 8, Discontinuity.Continuous.value, 0, 123, "", "", 0, 123, SideCode.AgainstDigitizing, None, None, Anomaly.None, 1)
-      val options = SplitOptions(Point(0, 25.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous, 1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, projectId, ProjectCoordinates(0,0,0))
-      when(mockRoadAddressService.getSuravageRoadLinkAddressesByLinkIds(any[Set[Long]])).thenReturn(Seq(suravageAddressLink))
+      val suravageAddressLink = RoadLink(2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
+        State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"),
+        Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+        InUse, LinkGeomSource.SuravageLinkInterface)
+      when(mockRoadLinkService.getSuravageRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean])).thenReturn(Seq(suravageAddressLink))
       when(mockRoadLinkService.getRoadLinksWithComplementaryFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean])).thenReturn(Seq(roadLink))
-      val rap = RoadAddressProject(projectId, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"), "TestUser", DateTime.parse("2700-01-01"), DateTime.now(), "Some additional info", List.empty[ReservedRoadPart], None)
-      val lrmPositionId = Sequences.nextLrmPositionPrimaryKeySeqValue
-      val lrmPositionId2 = Sequences.nextLrmPositionPrimaryKeySeqValue
-      val raId = Sequences.nextViitePrimaryKeySeqValue
-      ProjectDAO.createRoadAddressProject(rap)
-      sqlu""" insert into LRM_Position(id,start_Measure,end_Measure,Link_id) Values($lrmPositionId,0,87,1) """.execute
-      sqlu""" INSERT INTO PROJECT_RESERVED_ROAD_PART (ID, ROAD_NUMBER, ROAD_PART_NUMBER, PROJECT_ID, CREATED_BY, ROAD_LENGTH, ADDRESS_LENGTH, DISCONTINUITY, ELY) VALUES (${Sequences.nextViitePrimaryKeySeqValue},1,1,$projectId,'""',87,900,0,0)""".execute
-      sqlu"""insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp, link_source) values ($lrmPositionId2, 1, 1, 0.0, 87.0, 0, 1)""".execute
-      sqlu"""insert into ROAD_ADDRESS (id, lrm_position_id, road_number, road_part_number,
-         track_code, discontinuity, START_ADDR_M, END_ADDR_M, start_date, end_date, created_by,
-         VALID_FROM, geometry, floating, calibration_points) VALUES ($raId, $lrmPositionId2, 1, 1, 0, 5, 0, 87, date'2011-01-01', null, 'foo', date'2011-01-01', MDSYS.SDO_GEOMETRY(4002,3067,NULL,MDSYS.SDO_ELEM_INFO_ARRAY(1,2,1),MDSYS.SDO_ORDINATE_ARRAY(0,0,0,0,0,87.0,0,87)), 0, 0)""".execute
-      sqlu""" INSERT INTO PROJECT_LINK (ID, PROJECT_ID, TRACK_CODE, DISCONTINUITY_TYPE, ROAD_NUMBER, ROAD_PART_NUMBER, START_ADDR_M, END_ADDR_M, LRM_POSITION_ID, CREATED_BY, CREATED_DATE, STATUS, ROAD_ADDRESS_ID) VALUES (${Sequences.nextViitePrimaryKeySeqValue},$projectId,0,0,1,1,0,87,$lrmPositionId,'testuser',TO_DATE('2017-10-06 14:54:41', 'YYYY-MM-DD HH24:MI:SS'),0, $raId)""".execute
-      RoadAddressDAO.fetchByIdMassQuery(Set(raId), true, true).size should be(1)
-      projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options) should be(None)
-      val projectLinks = ProjectDAO.getProjectLinks(projectId)
+      when(mockRoadLinkService.getViiteCurrentAndHistoryRoadLinksFromVVH(any[Set[Long]], any[Boolean])).thenReturn((Seq(roadLink), Seq()))
+      val rap = createProjectDataForSplit()
+      val options = SplitOptions(Point(0, 25.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous,
+        1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, rap.id, ProjectCoordinates(0,0,0))
+      val errorOpt = projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options)
+      errorOpt should be(None)
+      val projectLinks = ProjectDAO.getProjectLinks(rap.id)
       checkSplit(projectLinks, 25.3, 0, 25, 87, 123.0)
-      when(mockRoadLinkService.getViiteRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean], any[Boolean]))
-        .thenReturn(Seq(toRoadLink(suravageAddressLink), roadLink))
-      when(mockRoadAddressService.getSuravageRoadLinkAddressesByLinkIds(any[Set[Long]])).thenReturn(Seq(suravageAddressLink))
-      projectServiceWithRoadAddressMock.revertSplit(projectId, 1, "user") should be (None)
+      val options2 = SplitOptions(Point(0, 65.3), LinkStatus.Transfer, LinkStatus.New, 1, 1, Track.Combined,
+        Discontinuity.Continuous, 1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, rap.id, ProjectCoordinates(0,0,0))
+      val preSplitData = projectServiceWithRoadAddressMock.preSplitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options2)._1.getOrElse(Seq())
+      preSplitData should have size (3)
+      // Test that the transfer is not returned back in pre-split for already split suravage but the old values are
+      preSplitData.exists(_.status == Transfer) should be (false)
+      projectServiceWithRoadAddressMock.revertSplit(rap.id, 1, "user") should be (None)
+      ProjectDAO.getProjectLinks(rap.id) should have size (1)
     }
   }
 
-  ignore("Updating split link test") {
-    val roadLink = RoadLink(1, Seq(Point(0, 0), Point(0, 45.3), Point(0, 87))
-      , 540.3960283713503, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"), Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
-      InUse, NormalLinkInterface)
-    val suravageAddressLink = RoadAddressLink(2, 2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
-      AdministrativeClass.apply(1), LinkType.apply(1), RoadLinkType.UnknownRoadLinkType, ConstructionType.Planned, LinkGeomSource.SuravageLinkInterface, RoadType.PublicRoad, "testRoad",
-      8, None, None, null, 1, 1, Track.Combined.value, 8, Discontinuity.Continuous.value, 0, 123, "", "", 0, 123, SideCode.AgainstDigitizing, None, None, Anomaly.None, 1)
+  test("Updating split link test") {
     runWithRollback {
-      val projectId = Sequences.nextViitePrimaryKeySeqValue
-      val rap = RoadAddressProject(projectId, ProjectState.apply(1), "TestProject", "TestUser", DateTime.parse("2700-01-01"), "TestUser", DateTime.parse("2700-01-01"), DateTime.now(), "Some additional info", List.empty[ReservedRoadPart], None)
-      val options = SplitOptions(Point(0, 45.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous, 1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, projectId, ProjectCoordinates(0,0,0))
-      val options2 = SplitOptions(Point(0, 65.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous, 1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, projectId, ProjectCoordinates(0,0,0))
-      when(mockRoadAddressService.getSuravageRoadLinkAddressesByLinkIds(any[Set[Long]])).thenReturn(Seq(suravageAddressLink))
+      val roadLink = RoadLink(1, Seq(Point(0, 0), Point(0, 45.3), Point(0, 87))
+        , 87.0, State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"),
+        Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+        InUse, NormalLinkInterface)
+      val suravageAddressLink = RoadLink(2, Seq(Point(0, 0), Point(0, 45.3), Point(0, 123)), 123,
+        State, 99, TrafficDirection.AgainstDigitizing, UnknownLinkType, Some("25.06.2015 03:00:00"),
+        Some("vvh_modified"), Map("MUNICIPALITYCODE" -> BigInt.apply(749)),
+        InUse, LinkGeomSource.SuravageLinkInterface)
+      when(mockRoadLinkService.getSuravageRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean])).thenReturn(Seq(suravageAddressLink))
       when(mockRoadLinkService.getRoadLinksWithComplementaryFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean])).thenReturn(Seq(roadLink))
-      val lrmPositionId = Sequences.nextLrmPositionPrimaryKeySeqValue
-      val lrmPositionId2 = Sequences.nextLrmPositionPrimaryKeySeqValue
-      val raId = Sequences.nextViitePrimaryKeySeqValue
-      ProjectDAO.createRoadAddressProject(rap)
-      sqlu""" insert into LRM_Position(id,start_Measure,end_Measure,Link_id) Values($lrmPositionId,0,87,1) """.execute
-      sqlu""" INSERT INTO PROJECT_RESERVED_ROAD_PART (ID, ROAD_NUMBER, ROAD_PART_NUMBER, PROJECT_ID, CREATED_BY, ROAD_LENGTH, ADDRESS_LENGTH, DISCONTINUITY, ELY) VALUES (${Sequences.nextViitePrimaryKeySeqValue},1,1,$projectId,'""',87,900,0,0)""".execute
-      sqlu"""insert into lrm_position (ID, link_id, SIDE_CODE, start_measure, end_measure, adjusted_timestamp, link_source) values ($lrmPositionId2, 1, 1, 0.0, 87.0, 0, 1)""".execute
-      sqlu"""insert into ROAD_ADDRESS (id, lrm_position_id, road_number, road_part_number,
-         track_code, discontinuity, START_ADDR_M, END_ADDR_M, start_date, end_date, created_by,
-         VALID_FROM, geometry, floating, calibration_points) VALUES ($raId, $lrmPositionId2, 1, 1, 0, 5, 0, 87, date'2011-01-01', null, 'foo', date'2011-01-01', MDSYS.SDO_GEOMETRY(4002,3067,NULL,MDSYS.SDO_ELEM_INFO_ARRAY(1,2,1),MDSYS.SDO_ORDINATE_ARRAY(0,0,0,0,0,87.0,0,87)), 0, 0)""".execute
-      sqlu""" INSERT INTO PROJECT_LINK (ID, PROJECT_ID, TRACK_CODE, DISCONTINUITY_TYPE, ROAD_NUMBER, ROAD_PART_NUMBER,
-            START_ADDR_M, END_ADDR_M, LRM_POSITION_ID, CREATED_BY, CREATED_DATE, STATUS, ROAD_ADDRESS_ID) VALUES
-            (${Sequences.nextViitePrimaryKeySeqValue},$projectId,0,0,1,1,0,87,$lrmPositionId,'testuser',TO_DATE('2017-10-06 14:54:41', 'YYYY-MM-DD HH24:MI:SS'),0, $raId)""".execute
-      RoadAddressDAO.fetchByIdMassQuery(Set(raId), true, true).size should be(1)
-      ProjectDAO.getProjectLinks(projectId) should have size (1)
-      projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options) should be(None)
-      val projectLinks = ProjectDAO.getProjectLinks(projectId)
-      val newSuravageLink = projectLinks.filter(x => x.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
-      val unchangedLink = projectLinks.filter(x => x.status == LinkStatus.UnChanged).head
-      val newLink = projectLinks.filter(x => x.status == LinkStatus.New).head
-      val templateLink = projectLinks.filter(x => x.linkGeomSource != LinkGeomSource.SuravageLinkInterface).head
-      projectLinks.count(x => x.connectedLinkId.isDefined) should be(3)
-      newLink.connectedLinkId should be(Some(templateLink.linkId))
-      unchangedLink.connectedLinkId should be(Some(templateLink.linkId))
-      templateLink.connectedLinkId should be(Some(newLink.linkId))
-      newLink.startMValue should be(45.3)
-      newLink.startAddrMValue should be(45)
-      newLink.endAddrMValue should be(87) //123-45,3 =~87
-      newLink.endMValue should be(123)
-      unchangedLink.startMValue should be(0)
-      unchangedLink.startAddrMValue should be(0)
-      unchangedLink.endAddrMValue should be(45)
-      unchangedLink.endMValue should be(45.3)
-      templateLink.status should be(LinkStatus.Terminated)
-      templateLink.startAddrMValue should be(newLink.startAddrMValue)
-      templateLink.endAddrMValue should be(newLink.endAddrMValue)
-      templateLink.roadAddressId should be(newLink.roadAddressId)
-      when(mockRoadLinkService.getViiteRoadLinksByLinkIdsFromVVH(any[Set[Long]], any[Boolean], any[Boolean]))
-        .thenReturn(Seq(toRoadLink(suravageAddressLink), roadLink))
-      when(mockRoadAddressService.getSuravageRoadLinkAddressesByLinkIds(any[Set[Long]])).thenReturn(Seq(suravageAddressLink))
-      projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options2) should be(None)
-      val projectLinks2 = ProjectDAO.getProjectLinks(projectId)
-      projectLinks2.count(x => x.connectedLinkId.isDefined) should be(3)
-      val newSuravageLink2 = projectLinks2.filter(x => x.linkGeomSource == LinkGeomSource.SuravageLinkInterface)
-      val unchangedLink2 = projectLinks2.filter(x => x.status == LinkStatus.UnChanged).head
-      val newLink2 = projectLinks2.filter(x => x.status == LinkStatus.New).head
-      val templateLink2 = projectLinks2.filter(x => x.linkGeomSource != LinkGeomSource.SuravageLinkInterface).head
-      newLink2.connectedLinkId should be(Some(templateLink.linkId))
-      unchangedLink2.connectedLinkId should be(Some(templateLink.linkId))
-      templateLink2.connectedLinkId should be(Some(newLink.linkId))
-      newLink2.startMValue should be(65.3)
-      newLink2.startAddrMValue should be(65)
-      newLink2.endAddrMValue should be(87) //123-45,3 =~87
-      newLink2.endMValue should be(123)
-      unchangedLink2.startMValue should be(0)
-      unchangedLink2.startAddrMValue should be(0)
-      unchangedLink2.endAddrMValue should be(65)
-      unchangedLink2.endMValue should be(65.3)
-      templateLink2.status should be(LinkStatus.Terminated)
-      templateLink2.startAddrMValue should be(newLink2.startAddrMValue)
-      templateLink2.endAddrMValue should be(newLink2.endAddrMValue)
-      templateLink2.roadAddressId should be(newLink2.roadAddressId)
+      when(mockRoadLinkService.getViiteCurrentAndHistoryRoadLinksFromVVH(any[Set[Long]], any[Boolean])).thenReturn((Seq(roadLink), Seq()))
+      val rap = createProjectDataForSplit()
+      val options = SplitOptions(Point(0, 25.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined, Discontinuity.Continuous,
+        1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, rap.id, ProjectCoordinates(0,0,0))
+      val errorOpt = projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options)
+      errorOpt should be(None)
+      val projectLinks = ProjectDAO.getProjectLinks(rap.id)
+      checkSplit(projectLinks, 25.3, 0, 25, 87, 123.0)
+      val options2 = SplitOptions(Point(0, 45.3), LinkStatus.UnChanged, LinkStatus.New, 1, 1, Track.Combined,
+        Discontinuity.Continuous, 1, LinkGeomSource.NormalLinkInterface, RoadType.PublicRoad, rap.id, ProjectCoordinates(0,0,0))
+      projectServiceWithRoadAddressMock.splitSuravageLinkInTX(suravageAddressLink.linkId, "testUser", options2) should be (None)
+      checkSplit(ProjectDAO.getProjectLinks(rap.id), 45.3, 0, 45, 87, 123.0)
+      ProjectDAO.getProjectLinks(rap.id).exists(_.status == LinkStatus.Transfer) should be (false)
     }
   }
 

--- a/viite-UI/src/view/SplitForm.js
+++ b/viite-UI/src/view/SplitForm.js
@@ -143,7 +143,7 @@
       var fireChange = _.isUndefined(triggerChange) ? true : triggerChange;
       var rootElement = $('#feature-attributes');
       var link = _.first(_.filter(selectedProjectLink, function (l) {
-        return !_.isUndefined(l.status);
+        return !_.isUndefined(l.status) && l.status == statusCode;
       }));
       if (statusCode === LinkStatus.Unchanged.value) {
         $("#dropDown_0 option[value=" + LinkStatus.Transfer.description + "]").prop('disabled', false).prop('hidden', false);
@@ -169,8 +169,11 @@
           $("#dropDown_2 option[value=" + LinkStatus.Terminated.description + "]").attr('selected', 'selected').change();
         else $("#dropDown_2 option[value=" + LinkStatus.Terminated.description + "]").attr('selected', 'selected');
       }
-      $('#discontinuityDropdown').val(link.discontinuity);
-      $('#roadTypeDropDown').val(link.roadTypeId);
+      // Set discontinuity from A/B unless it is continuous (defaults to Continuous if both are Continuous)
+      if (!_.isUndefined(link.discontinuity) && link.discontinuity !== 5 && (link.marker == 'A' || link.marker == 'B'))
+        $('#discontinuityDropdown').val(link.discontinuity);
+      if (!_.isUndefined(link.marker) && (link.marker == 'A' || link.marker == 'B'))
+        $('#roadTypeDropDown').val(link.roadTypeId);
     };
 
     var disableFormInputs = function () {


### PR DESCRIPTION
… road type etc.

Fix saving of recalculation results for split links that have unchanged parts.
Fix discontinuity validation bug where equal road part was checked as being after the road part
Add vvh timestamp for vvh history links
Return ignored splitting project links tests into operation
Fix invalid values presented on UI form by picking the suravage link values into it