### PR TITLE
Viite 1035 send button enabler validation

### DIFF
--- a/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
+++ b/digiroad2-api-viite/src/main/scala/fi/liikennevirasto/digiroad2/ViiteApi.scala
@@ -339,7 +339,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
     val projectMap = roadAddressProjectToApi(project)
     val parts = project.reservedParts.map(reservedRoadPartToApi)
     val errorParts = projectService.validateProjectById(project.id)
-    val publishable = projectService.projectLinkPublishable(projectId)
+    val publishable = projectService.isProjectPublishable(projectId)
     Map("project" -> projectMap, "linkId" -> project.reservedParts.find(_.startingLinkId.nonEmpty).flatMap(_.startingLinkId),
       "projectLinks" -> parts, "publishable" -> publishable, "projectErrors" -> errorParts.map(errorPartsToApi))
   }
@@ -428,7 +428,7 @@ class ViiteApi(val roadLinkService: RoadLinkService, val vVHClient: VVHClient,
         case None =>
           writableProject.saveProjectCoordinates(links.projectId, links.coordinates)
           Map("success" -> true, "id" -> links.projectId,
-            "publishable" -> projectService.projectLinkPublishable(links.projectId),
+            "publishable" -> projectService.isProjectPublishable(links.projectId),
             "projectErrors" -> projectService.validateProjectById(links.projectId).map(errorPartsToApi))
       }
     } catch {

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -240,7 +240,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
       case None => {
         addNewLinksToProject(sortRamps(projectLinks), projectId, user, linkId) match {
           case Some(errorMessage) => Map("success" -> false, "errormessage" -> errorMessage)
-          case None => Map("success" -> true, "publishable" -> projectLinkPublishable(projectId))
+          case None => Map("success" -> true, "publishable" -> isProjectPublishable(projectId))
         }
       }
     }
@@ -1101,8 +1101,15 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     * @param projectId project-id
     * @return if project contains any notifications preventing sending
     */
-  def projectLinkPublishable(projectId: Long): Boolean = {
+  def isProjectPublishable(projectId: Long): Boolean = {
     validateProjectById(projectId).isEmpty
+  }
+
+  def allLinksHandeled(projectId: Long): Boolean ={ //some tests want to know if all projectlinks have been handeled. to remove this test need to be updated to check if termination is correctly applied etc best done after all validations have been implemented
+    withDynSession {
+      ProjectDAO.getProjectLinks(projectId, Some(LinkStatus.NotHandled)).isEmpty &&
+        ProjectDAO.getProjectLinks(projectId).nonEmpty
+    }
   }
 
   /** Nullifies projects tr_id attribute, changes status to unfinnished and saves tr_info value to status_info. Tries to append old status info if it is possible

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1105,7 +1105,7 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     validateProjectById(projectId).isEmpty
   }
 
-  def allLinksHandeled(projectId: Long): Boolean ={ //some tests want to know if all projectlinks have been handeled. to remove this test need to be updated to check if termination is correctly applied etc best done after all validations have been implemented
+  def allLinksHandled(projectId: Long): Boolean ={ //some tests want to know if all projectlinks have been handled. to remove this test need to be updated to check if termination is correctly applied etc best done after all validations have been implemented
     withDynSession {
       ProjectDAO.getProjectLinks(projectId, Some(LinkStatus.NotHandled)).isEmpty &&
         ProjectDAO.getProjectLinks(projectId).nonEmpty

--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/ProjectService.scala
@@ -1096,12 +1096,13 @@ class ProjectService(roadAddressService: RoadAddressService, roadLinkService: Ro
     setProjectDeltaToDB(delta, projectId)
   }
 
+  /**
+    * method to check if project is publishable. add filters for cases we do not want to prevent sending
+    * @param projectId project-id
+    * @return if project contains any notifications preventing sending
+    */
   def projectLinkPublishable(projectId: Long): Boolean = {
-    // TODO: add other checks after transfers etc. are enabled
-    withDynSession {
-      ProjectDAO.getProjectLinks(projectId, Some(LinkStatus.NotHandled)).isEmpty &&
-        ProjectDAO.getProjectLinks(projectId).nonEmpty
-    }
+    validateProjectById(projectId).isEmpty
   }
 
   /** Nullifies projects tr_id attribute, changes status to unfinnished and saves tr_info value to status_info. Tries to append old status info if it is possible

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceLinkSpec.scala
@@ -184,10 +184,10 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
         partitioned._1.map(pl => roadLink.copy(linkId = pl.linkId, geometry = Seq(Point(pl.startAddrMValue, 0.0), Point(pl.endAddrMValue, 0.0)))))
 
 
-      projectService.projectLinkPublishable(saved.id) should be(false)
+      projectService.isProjectPublishable(saved.id) should be(false)
       val linkIds = ProjectDAO.getProjectLinks(saved.id).map(_.linkId).toSet
       projectService.updateProjectLinks(saved.id, linkIds, LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int])
-      projectService.projectLinkPublishable(saved.id) should be(true)
+      projectService.isProjectPublishable(saved.id) should be(true)
     }
     runWithRollback {
       projectService.getRoadAddressAllProjects()
@@ -220,7 +220,7 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
       when(mockRoadLinkService.getViiteRoadLinksByLinkIdsFromVVH(linkIds207, false, false)).thenReturn(
         partitioned._1.map(pl => roadLinks.head.copy(linkId = pl.linkId, geometry = Seq(Point(pl.startAddrMValue, 0.0), Point(pl.endAddrMValue, 0.0)))))
 
-      projectService.projectLinkPublishable(saved.id) should be(false)
+      projectService.isProjectPublishable(saved.id) should be(false)
       val linkIds = ProjectDAO.getProjectLinks(saved.id).map(_.linkId).toSet
       projectService.updateProjectLinks(saved.id, linkIds, LinkStatus.Numbering, "-", 99999, 1, 0, Option.empty[Int])
       val afterNumberingLinks = ProjectDAO.getProjectLinks(saved.id)
@@ -376,7 +376,7 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.projectLinkPublishable(saved.id) should be(false)
+      projectService.isProjectPublishable(saved.id) should be(false)
       val projectLinks = ProjectDAO.getProjectLinks(saved.id)
       val partitioned = projectLinks.partition(_.roadPartNumber == 205)
       val linkIds205 = partitioned._1.map(_.linkId).toSet
@@ -388,11 +388,11 @@ class ProjectServiceLinkSpec extends FunSuite with Matchers with BeforeAndAfter 
       )
 
       projectService.updateProjectLinks(saved.id, linkIds205, LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int])
-      projectService.projectLinkPublishable(saved.id) should be(false)
+      projectService.isProjectPublishable(saved.id) should be(false)
 
 
       projectService.updateProjectLinks(saved.id, linkIds206, LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int])
-      projectService.projectLinkPublishable(saved.id) should be(true)
+      projectService.isProjectPublishable(saved.id) should be(true)
 
       val changeProjectOpt = projectService.getChangeProject(saved.id)
       changeProjectOpt.map(_.changeInfoSeq).getOrElse(Seq()) should have size (5)

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -355,7 +355,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.projectLinkPublishable(savedProject.id) should be(false)
+      projectService.allLinksHandeled(savedProject.id) should be(false)
       projectService.getRoadAddressSingleProject(savedProject.id).nonEmpty should be(true)
       projectService.getRoadAddressSingleProject(savedProject.id).get.reservedParts.nonEmpty should be(true)
       val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -368,11 +368,11 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
         toMockAnswer(projectLinks, roadLink)
       )
       projectService.updateProjectLinks(savedProject.id, linkIds205, LinkStatus.UnChanged, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.projectLinkPublishable(savedProject.id) should be(false)
+      projectService.allLinksHandeled(savedProject.id) should be(false)
       projectService.updateProjectLinks(savedProject.id, linkIds206, LinkStatus.UnChanged, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.projectLinkPublishable(savedProject.id) should be(true)
+      projectService.allLinksHandeled(savedProject.id) should be(true)
       projectService.updateProjectLinks(savedProject.id, Set(5168573), LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.projectLinkPublishable(savedProject.id) should be(true)
+      projectService.allLinksHandeled(savedProject.id) should be(true)
       val changeProjectOpt = projectService.getChangeProject(savedProject.id)
       val change = changeProjectOpt.get
       val updatedProjectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -406,7 +406,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.projectLinkPublishable(savedProject.id) should be(false)
+      projectService.allLinksHandeled(savedProject.id) should be(false)
       val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
       val partitioned = projectLinks.partition(_.roadPartNumber == 207)
       val highestDistanceEnd = projectLinks.map(p => p.endAddrMValue).max
@@ -418,7 +418,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       )
       projectService.updateProjectLinks(savedProject.id, linkIds207, LinkStatus.Transfer, "-", 0, 0, 0, Option.empty[Int]) should be(None)
       projectService.updateProjectLinks(savedProject.id, Set(5168510), LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.projectLinkPublishable(savedProject.id) should be(true)
+      projectService.allLinksHandeled(savedProject.id) should be(true)
       val changeProjectOpt = projectService.getChangeProject(savedProject.id)
       val change = changeProjectOpt.get
       val updatedProjectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -451,7 +451,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.projectLinkPublishable(savedProject.id) should be(false)
+      projectService.allLinksHandeled(savedProject.id) should be(false)
       val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
       val partitioned = projectLinks.partition(_.roadPartNumber == 207)
       val highestDistanceStart = projectLinks.map(p => p.startAddrMValue).max
@@ -464,7 +464,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       )
       projectService.updateProjectLinks(savedProject.id, Set(5168510), LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int])
       projectService.updateProjectLinks(savedProject.id, linkIds207 - 5168510, LinkStatus.Transfer, "-", 0, 0, 0, Option.empty[Int])
-      projectService.projectLinkPublishable(savedProject.id) should be(true)
+      projectService.allLinksHandeled(savedProject.id) should be(true)
       val changeProjectOpt = projectService.getChangeProject(savedProject.id)
       val change = changeProjectOpt.get
       val updatedProjectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -517,7 +517,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       createProjectLinks(newLinkTemplates.tail.take(1).map(_.linkId), savedProject.id, 5L, 205L, 2, 5, 2, 1, 8, "U").get("success") should be (Some(true))
       ProjectDAO.getProjectLinks(savedProject.id).size should be (68)
       val changeInfo = projectService.getChangeProject(savedProject.id)
-      projectService.projectLinkPublishable(savedProject.id) should be(true)
+      projectService.allLinksHandeled(savedProject.id) should be(true)
       changeInfo.get.changeInfoSeq.foreach { ci =>
         ci.changeType match {
           case Termination =>

--- a/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
+++ b/digiroad2-viite/src/test/scala/fi/liikennevirasto/viite/ProjectServiceSpec.scala
@@ -355,7 +355,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.allLinksHandeled(savedProject.id) should be(false)
+      projectService.allLinksHandled(savedProject.id) should be(false)
       projectService.getRoadAddressSingleProject(savedProject.id).nonEmpty should be(true)
       projectService.getRoadAddressSingleProject(savedProject.id).get.reservedParts.nonEmpty should be(true)
       val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -368,11 +368,11 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
         toMockAnswer(projectLinks, roadLink)
       )
       projectService.updateProjectLinks(savedProject.id, linkIds205, LinkStatus.UnChanged, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.allLinksHandeled(savedProject.id) should be(false)
+      projectService.allLinksHandled(savedProject.id) should be(false)
       projectService.updateProjectLinks(savedProject.id, linkIds206, LinkStatus.UnChanged, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.allLinksHandeled(savedProject.id) should be(true)
+      projectService.allLinksHandled(savedProject.id) should be(true)
       projectService.updateProjectLinks(savedProject.id, Set(5168573), LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.allLinksHandeled(savedProject.id) should be(true)
+      projectService.allLinksHandled(savedProject.id) should be(true)
       val changeProjectOpt = projectService.getChangeProject(savedProject.id)
       val change = changeProjectOpt.get
       val updatedProjectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -406,7 +406,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.allLinksHandeled(savedProject.id) should be(false)
+      projectService.allLinksHandled(savedProject.id) should be(false)
       val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
       val partitioned = projectLinks.partition(_.roadPartNumber == 207)
       val highestDistanceEnd = projectLinks.map(p => p.endAddrMValue).max
@@ -418,7 +418,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       )
       projectService.updateProjectLinks(savedProject.id, linkIds207, LinkStatus.Transfer, "-", 0, 0, 0, Option.empty[Int]) should be(None)
       projectService.updateProjectLinks(savedProject.id, Set(5168510), LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int]) should be(None)
-      projectService.allLinksHandeled(savedProject.id) should be(true)
+      projectService.allLinksHandled(savedProject.id) should be(true)
       val changeProjectOpt = projectService.getChangeProject(savedProject.id)
       val change = changeProjectOpt.get
       val updatedProjectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -451,7 +451,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       val countAfterInsertProjects = projectService.getRoadAddressAllProjects()
       count = countCurrentProjects.size + 1
       countAfterInsertProjects.size should be(count)
-      projectService.allLinksHandeled(savedProject.id) should be(false)
+      projectService.allLinksHandled(savedProject.id) should be(false)
       val projectLinks = ProjectDAO.getProjectLinks(savedProject.id)
       val partitioned = projectLinks.partition(_.roadPartNumber == 207)
       val highestDistanceStart = projectLinks.map(p => p.startAddrMValue).max
@@ -464,7 +464,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       )
       projectService.updateProjectLinks(savedProject.id, Set(5168510), LinkStatus.Terminated, "-", 0, 0, 0, Option.empty[Int])
       projectService.updateProjectLinks(savedProject.id, linkIds207 - 5168510, LinkStatus.Transfer, "-", 0, 0, 0, Option.empty[Int])
-      projectService.allLinksHandeled(savedProject.id) should be(true)
+      projectService.allLinksHandled(savedProject.id) should be(true)
       val changeProjectOpt = projectService.getChangeProject(savedProject.id)
       val change = changeProjectOpt.get
       val updatedProjectLinks = ProjectDAO.getProjectLinks(savedProject.id)
@@ -517,7 +517,7 @@ class ProjectServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       createProjectLinks(newLinkTemplates.tail.take(1).map(_.linkId), savedProject.id, 5L, 205L, 2, 5, 2, 1, 8, "U").get("success") should be (Some(true))
       ProjectDAO.getProjectLinks(savedProject.id).size should be (68)
       val changeInfo = projectService.getChangeProject(savedProject.id)
-      projectService.allLinksHandeled(savedProject.id) should be(true)
+      projectService.allLinksHandled(savedProject.id) should be(true)
       changeInfo.get.changeInfoSeq.foreach { ci =>
         ci.changeType match {
           case Termination =>

--- a/viite-UI/src/view/ProjectChangeTable.js
+++ b/viite-UI/src/view/ProjectChangeTable.js
@@ -84,10 +84,10 @@
 
     function bindEvents(){
       $('.row-changes').remove();
-      eventbus.once('projectChanges:fetched', function(projectChangeData){
-        var htmlTable ="";
-        if(!_.isUndefined(projectChangeData) && projectChangeData !== null){
-          _.each(projectChangeData.changeTable.changeInfoSeq, function(changeInfoSeq) {
+      eventbus.once('projectChanges:fetched', function(projectChangeData) {
+        var htmlTable = "";
+        if (!_.isUndefined(projectChangeData) && projectChangeData !== null) {
+          _.each(projectChangeData.changeTable.changeInfoSeq, function (changeInfoSeq) {
             if (changeInfoSeq.changetype === newLinkStatus) {
               htmlTable += '<tr class="row-changes">';
               htmlTable += getEmptySource(changeInfoSeq);
@@ -123,8 +123,11 @@
         }
         $('.row-changes').remove();
         $('.change-table-dimensions').append($(htmlTable));
-        if (projectChangeData.validationErrors.length===0)
+        if (projectChangeData.validationErrors.length === 0){
           $('.change-table-header').html($('<div>Validointi ok. Alla näet muutokset projektissa.</div>'));
+          if($('.change-table-frame').css('display')==="block")
+            $('#send-button').attr('disabled',false); //enables send button if changetable is open
+        }
         else
         {
           $('.change-table-header').html($('<div>Tarkista validointitulokset. Yhteenvetotaulukko voi olla puutteellinen.</div>'));


### PR DESCRIPTION
Send button is enabled only if validations pass and project change table is open. Changed publishable method to check validations and renamed old method to it's current use of checking if all links have been processed. This way we are not doing same thing twice