### PR TITLE
DROTH-1144_complementary_links_default_on_MTS

### DIFF
--- a/UI/src/model/MassTransitStopsCollection.js
+++ b/UI/src/model/MassTransitStopsCollection.js
@@ -1,7 +1,7 @@
 (function(root) {
   root.MassTransitStopsCollection = function(backend) {
     var assets = {};
-    var isComplementaryActive = false;
+    var isComplementaryActive = true;
     var validityPeriods = {
       current: true,
       future: false,

--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -524,6 +524,10 @@
         callback(roadLinkData);
         eventbus.trigger('roadLinks:fetched');
       };
+      self.getRoadLinksWithComplementary = function(boundingBox, callback) {
+        callback(roadLinkData);
+        eventbus.trigger('roadLinks:fetched');
+      };
       return self;
     };
 

--- a/UI/src/view/navigationpanel/ActionPanelBoxes.js
+++ b/UI/src/view/navigationpanel/ActionPanelBoxes.js
@@ -457,7 +457,7 @@
     var roadLinkComplementaryCheckBox = [
       '  <div class="panel-section roadLink-complementary-checkbox">',
           '<div class="check-box-container">' +
-            '<input id="complementaryCheckbox" type="checkbox" /> <lable>Näytä täydentävä geometria</lable>' +
+            '<input id="complementaryCheckbox" type="checkbox" checked/> <lable>Näytä täydentävä geometria</lable>' +
           '</div>' +
       '</div>'
     ].join('');


### PR DESCRIPTION
-check complementary box on default for MTS
-backend.utils: getRoadLinksWithComplementary added and returning roadlinkdata for integration tests