### PR TITLE
VIITE-1055 - Tarpeeton tarkastusilmoitus / unnecessary validation notification

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/dao/ProjectDAO.scala
@@ -318,11 +318,12 @@ object ProjectDAO {
     Q.queryNA[Long](query).firstOption
   }
 
-  def getProjectLinks(projectId: Long, linkStatusFilter: Option[LinkStatus] = None): Seq[ProjectLink] = {
+  def getProjectLinks(projectId: Long, linkStatusFilter: Option[LinkStatus] = None, currentAddressFilter: Boolean = false): Seq[ProjectLink] = {
     val filter = if (linkStatusFilter.isEmpty) "" else s"PROJECT_LINK.STATUS = ${linkStatusFilter.get.value} AND"
+    val currentFilter = if (currentAddressFilter) s"PROJECT_LINK.END_DATE IS NULL AND PROJECT_LINK.VALID_TO IS NULL " else s""
     val query =
       s"""$projectLinkQueryBase
-                where $filter (PROJECT_LINK.PROJECT_ID = $projectId ) order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
+                where $filter $currentFilter (PROJECT_LINK.PROJECT_ID = $projectId ) order by PROJECT_LINK.ROAD_NUMBER, PROJECT_LINK.ROAD_PART_NUMBER, PROJECT_LINK.END_ADDR_M """
     listQuery(query)
   }
 

--- a/viite-UI/src/view/ProjectForm.js
+++ b/viite-UI/src/view/ProjectForm.js
@@ -405,8 +405,10 @@
         jQuery('.modal-overlay').remove();
         setTimeout(function () {
         }, 0);
-        if (!_.isUndefined(currentProject))
+        if (!_.isUndefined(currentProject)) {
           eventbus.trigger('linkProperties:selectedProject', result.linkId, result.project);
+          eventbus.trigger('roadAddressProject:deactivateAllSelections');
+        }
         applicationModel.setProjectButton(true);
         applicationModel.setProjectFeature(currentProject.id);
         applicationModel.setOpenProject(true);


### PR DESCRIPTION
On the validation made it so that will obey the rule of "Validation should be taken into consideration only the current road addresses (END_DATE is null and VALID_TO null)."

Corrected an issue on ProjectValidator checking for minor discontinuity. 
If we find possible targets of discontinuity we will now check actual road addresses for same road number and same road part and we check if the project link discontinuity actually matches those, not only that but we also make sure that at least one of the project links overlaps with the actual road addresses.

If both of those conditions are verified then we assume that there is no minor discontinuity (for said project links will be either replacing or being merged with the actual road addresses).