### PR TITLE
VIITE-1109 Get complementary links from VVH instead of cache (for now)

### DIFF
--- a/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
+++ b/digiroad2-viite/src/main/scala/fi/liikennevirasto/viite/RoadAddressService.scala
@@ -631,7 +631,9 @@ class RoadAddressService(roadLinkService: RoadLinkService, eventbus: DigiroadEve
         }
         (roadLinks ++ complimentaryLinks, Seq())
       } else {
-        roadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(municipality)
+        //TODO Add on the cache the all the complementary links, and then filter on the methods used by OTH
+        val (roadlinks, changes) = roadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(municipality)
+        (roadlinks.filterNot(r => r.linkSource == LinkGeomSource.ComplimentaryLinkInterface) ++ roadLinkService.getComplementaryRoadLinksFromVVH(municipality), changes)
       }
     val suravageLinks = roadLinkService.getSuravageRoadLinks(municipality)
     val allRoadLinks = roadLinksWithComplementary ++ suravageLinks


### PR DESCRIPTION
OTH cache only get complementary link for walways so, for now since this is urgent we are getting the complementary links by normal interface of VVH