### PR TITLE
DROTH-1409 Bus stops save road address on links that haven't got road address

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
@@ -110,7 +110,7 @@ class GeometryTransform {
     val roadAddress = roadAddressDao.getRoadAddress(roadAddressDao.withLinkIdAndMeasure(linkId, mValue)).headOption
 
     //If there is no roadAddress in VIITE try to find it in VKM
-    if(roadAddress.isEmpty)
+    if(roadAddress.isEmpty && road.isDefined)
       return vkmGeometryTransform.resolveAddressAndLocation(coord, heading, SideCode.apply(assetSideCode), road)
 
     val roadSide = roadAddress match {


### PR DESCRIPTION
- resolveAddressAndLocation method modified to only used VKM if roadAddress is empty and if we have a defined road on the link;
- Fetch ROADNUMBER field from the attributes list to send to resolveAddressAndLocation method.