### PR TITLE
DROTH-1502 Link selection not working

### DIFF
--- a/UI/src/view/linear_asset/manoeuvreLayer.js
+++ b/UI/src/view/linear_asset/manoeuvreLayer.js
@@ -140,7 +140,8 @@
         },
         onSelect: selectManoeuvre,
         draggable : false,
-        enableSelect : enableSelect
+        enableSelect : enableSelect,
+        layerName : layerName
     });
 
     this.selectControl = selectControl;

--- a/UI/src/view/link_property/linkPropertyLayer.js
+++ b/UI/src/view/link_property/linkPropertyLayer.js
@@ -217,7 +217,8 @@
           return provider.getStyle(feature, {zoomLevel: roadLayer.getZoomLevel()});
       },
       onInteractionEnd: onInteractionEnd,
-      onSelect: selectRoadLink
+      onSelect: selectRoadLink,
+      layerName : layerName
     });
 
     this.activateSelection = function() {

--- a/UI/src/view/providers/selectToolControl.js
+++ b/UI/src/view/providers/selectToolControl.js
@@ -25,7 +25,9 @@
             layers: []
         }, options);
 
-        var dragBoxInteraction = new ol.interaction.DragBox({
+      var layerName = settings.layerName ? settings.layerName : layer.get('name');
+
+      var dragBoxInteraction = new ol.interaction.DragBox({
             condition: function(event){ return ol.events.condition.platformModifierKeyOnly(event) && settings.enableBoxSelect(); }
         });
 
@@ -165,8 +167,8 @@
         };
 
         var activate = function() {
+          if(applicationModel.getSelectedLayer() === layerName) {
             enabled = true;
-
             if(!initialized){
                 map.addInteraction(selectInteraction);
                 map.addInteraction(multiSelectInteraction);
@@ -180,6 +182,7 @@
                 });
             });
             toggleDragBox();
+          }
         };
 
         var deactivate = function() {


### PR DESCRIPTION
-Added condition to selectToolControl: compare current layer with select tool control to activate. select tool can be activated by fetches from previous layers, causing irregularities when selecting assets/links