### PR TITLE
DROTH-1554 Polygon tool not working at linear assets

### DIFF
--- a/UI/src/view/providers/selectToolControl.js
+++ b/UI/src/view/providers/selectToolControl.js
@@ -91,13 +91,11 @@
 
         drawInteraction.on('drawend', function(evt){
             evt.preventDefault();
-            var polygonGeometry = evt.feature.getGeometry();
-            var features =  layer.getSource().getFeatures();
-            var selected = _.filter(features, function(feature) {
-                return _.some(feature.getGeometry().getCoordinates(), function(coordinate) {
-                    return polygonGeometry.intersectsCoordinate(coordinate);
-                });
-              });
+            var selected = [];
+            var polygonGeometryExtent = evt.feature.getGeometry().getExtent();
+            layer.getSource().forEachFeatureIntersectingExtent(polygonGeometryExtent, function (feature) {
+              selected.push(feature);
+            });
             var selectedProperties = _.map(selected, function(select) { return select.getProperties(); });
             settings.onInteractionEnd(selectedProperties);
         });


### PR DESCRIPTION
- drawInteraction on "drawend" redefined to do the intersect by Extent instead of by Coordinates.