### PR TITLE
DROTH-1745 UI: separation causes duplicate features

### DIFF
--- a/UI/src/less/site/linear-asset-form.less
+++ b/UI/src/less/site/linear-asset-form.less
@@ -40,7 +40,9 @@
   .input-group-addon.traffic-volume {
     width: 115px;
   }
-  .input-group-addon.lane-count {
+  .input-group-addon.lane-count,
+  .input-group-addon.lane-count-a,
+  .input-group-addon.lane-count-b{
     width: 60px;
   }
 

--- a/UI/src/model/selectedLinearAsset.js
+++ b/UI/src/model/selectedLinearAsset.js
@@ -6,6 +6,7 @@
     var originalLinearAssetValue = null;
     var isSeparated = false;
     var isValid = true;
+    var multipleSelected;
 
     var singleElementEvent = function(eventName) {
       return singleElementEventCategory + ':' + eventName;
@@ -35,6 +36,7 @@
     };
 
     this.open = function(linearAsset, singleLinkSelect) {
+      multipleSelected = false;
       self.close();
       selection = singleLinkSelect ? [linearAsset] : collection.getGroup(linearAsset);
       originalLinearAssetValue = self.getValue();
@@ -63,6 +65,7 @@
     };
 
     this.openMultiple = function(linearAssets) {
+      multipleSelected = true;
       var partitioned = _.groupBy(linearAssets, isUnknown);
       var existingLinearAssets = _.uniq(partitioned[false] || [], 'id');
       var unknownLinearAssets = _.uniq(partitioned[true] || [], 'generatedId');
@@ -283,14 +286,14 @@
         var newGroup = _.map(selection, function(s) { return _.assign({}, s, { value: value }); });
         selection = collection.replaceSegments(selection, newGroup);
         dirty = true;
-        eventbus.trigger(singleElementEvent('valueChanged'), self);
+        eventbus.trigger(singleElementEvent('valueChanged'), self, multipleSelected);
       }
     };
 
     this.setMultiValue = function(value) {
         var newGroup = _.map(selection, function(s) { return _.assign({}, s, { value: value }); });
         selection = collection.replaceSegments(selection, newGroup);
-        eventbus.trigger(multiElementEvent('valueChanged'), self);
+        eventbus.trigger(multiElementEvent('valueChanged'), self, multipleSelected);
     };
 
     function isValueDifferent(selection){

--- a/UI/src/model/selectedLinearAssetFactory.js
+++ b/UI/src/model/selectedLinearAssetFactory.js
@@ -14,12 +14,7 @@
       massTransitLanes: function() { return true; },
       carryingCapacity: function() { return true; },
       pavedRoad: function() { return true; },
-      careClass: function(val) {
-        return true;
-        //TODO: check functionality after merge
-        // if(_.isUndefined(val) {return false;}
-        // else if(val.properties[0].values.length > 0) {return true;}
-      },
+      careClass: function() {return true; },
       default: function(val) {
         if(_.isUndefined(val)) { return true; }
         else if(val > 0) { return true; }

--- a/UI/src/view/linear_asset/linearAssetLayer.js
+++ b/UI/src/view/linear_asset/linearAssetLayer.js
@@ -318,7 +318,6 @@ root.LinearAssetLayer  = function(params) {
 
   var bindEvents = function(eventListener) {
     var linearAssetChanged = _.partial(handleLinearAssetChanged, eventListener);
-    var linearAssetsChanged = _.partial(handleLinearAssetChanged, eventListener);
     var linearAssetCancelled = _.partial(handleLinearAssetCancelled, eventListener);
     eventListener.listenTo(eventbus, singleElementEvents('unselect'), linearAssetUnSelected);
     eventListener.listenTo(eventbus, singleElementEvents('selected'), linearAssetSelected);
@@ -331,7 +330,7 @@ root.LinearAssetLayer  = function(params) {
     eventListener.listenTo(eventbus, multiElementEvent('cancelled'), linearAssetCancelled);
     eventListener.listenTo(eventbus, singleElementEvents('selectByLinkId'), selectLinearAssetByLinkId);
     eventListener.listenTo(eventbus, multiElementEvent('massUpdateFailed'), cancelSelection);
-    eventListener.listenTo(eventbus, multiElementEvent('valueChanged'), linearAssetsChanged);
+    eventListener.listenTo(eventbus, multiElementEvent('valueChanged'), linearAssetChanged);
     eventListener.listenTo(eventbus, 'toggleWithRoadAddress', refreshSelectedView);
     eventListener.listenTo(eventbus, 'layer:linearAsset', refreshReadOnlyLayer);
   };


### PR DESCRIPTION
-linearAssetLayer: more responsibility shifted to decorateSelection() to decide if offset is needed or not.
-pass a parameter to know if multiple assets are selected. if they are, do not use cloneDeep to avoid slowness. if not, enable cloneDeep so that separation works visually.
-selection is now removed before applying a new one to avoid duplicated layers.