### PR TITLE
DROTH-1758 ZoneID field needs to be added to Vallu-xml

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/vallu/ValluStoreStopChangeMessage.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/vallu/ValluStoreStopChangeMessage.scala
@@ -60,6 +60,7 @@ object ValluStoreStopChangeMessage extends AssetPropertiesReader {
         <ContactEmails>
           <Contact>pysakit@digiroad.fi</Contact>
         </ContactEmails>
+        <ZoneId>{extractPropertyValueOption(stop, "vyohyketieto").getOrElse("")}</ZoneId>
       </Stop>
     </Stops>.toString
   }

--- a/digiroad2-api-common/src/test/resources/StopChange.xsd
+++ b/digiroad2-api-common/src/test/resources/StopChange.xsd
@@ -195,6 +195,13 @@
 								</xs:unique>
 							</xs:element>
 
+							<xs:element name="ZoneId" type="xs:string">
+								<xs:annotation>
+									<xs:documentation>Id zone where stop exists
+									</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+
 						</xs:sequence>
 					</xs:complexType>
 				</xs:element>

--- a/digiroad2-api-common/src/test/scala/fi/liikennevirasto/digiroad2/vallu/ValluStoreStopChangeMessageSpec.scala
+++ b/digiroad2-api-common/src/test/scala/fi/liikennevirasto/digiroad2/vallu/ValluStoreStopChangeMessageSpec.scala
@@ -46,6 +46,7 @@ class ValluStoreStopChangeMessageSpec extends FlatSpec with MustMatchers {
     (xml \ "Comments").text must equal("")
     (xml \ "PlatformCode").text must equal("")
     (xml \ "ConnectedToTerminal").text must equal("")
+    (xml \ "ZoneId").text must equal("")
   }
 
   it must "specify external id" in {


### PR DESCRIPTION
- New field "vyöhyketieto" (ZoneId) added to vallu-xml message and to unit tests too.