### PR TITLE
DROTH-1755 Change http.nonProxyHosts to work with vayla.fi-domain

### DIFF
--- a/conf/dev/digiroad2.properties
+++ b/conf/dev/digiroad2.properties
@@ -21,5 +21,5 @@ digiroad2.viite.importTimeStamp=1510876800000
 http.proxySet=false
 http.proxyHost=172.17.208.16
 http.proxyPort=8085
-http.nonProxyHosts=172.17.*|localhost|127.*|oag.liikennevirasto.fi
+http.nonProxyHosts=172.17.*|localhost|127.*|oag.vayla.fi
 digiroad2.feedbackAssetsEndPoint=http://localhost:9001/index.html

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -103,7 +103,7 @@ module.exports = function(grunt) {
                 },
                 {
                     context: '/maasto',
-                    host: 'oag.liikennevirasto.fi',
+                    host: 'oag.vayla.fi',
                     https: false,
                     changeOrigin: true,
                     xforward: false

--- a/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
@@ -80,7 +80,7 @@ class OAGProxyServlet extends ProxyServlet {
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
-    val url = "http://oag.liikennevirasto.fi/rasteripalvelu-mml" +  regex.replaceFirstIn(req.getRequestURI, "/wmts/maasto")
+    val url = "http://oag.vayla.fi/rasteripalvelu-mml" +  regex.replaceFirstIn(req.getRequestURI, "/wmts/maasto")
     java.net.URI.create(url)
   }
 


### PR DESCRIPTION
- In variable http.nonProxyHosts of digiroad2.properties file the value with reference to "oag.liikennevirasto.fi", switched to "oag.vayla.fi";
- Modified other cases who still using 'oag.liikennevirasto.fi'.