### PR TITLE
DROTH-2127 unable to save floating stops on terminated roads

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -306,8 +306,7 @@ trait MassTransitStopService extends PointAssetOperations {
         case _ => asset.linkId
       }
 
-      val optRoadLink = roadLinkService.getRoadLinkAndComplementaryFromVVH(linkId, newTransaction = false)
-      val optHistoric = if(optRoadLink.isEmpty) roadLinkService.getHistoryDataLinkFromVVH(linkId, newTransaction = false) else None
+      val (optRoadLink, optHistoric) = (roadLinkService.getRoadLinkAndComplementaryFromVVH(linkId, false), roadLinkService.getHistoryDataLinkFromVVH(linkId, false))
 
       val (previousStrategy, currentStrategy) = getStrategy(properties, asset, optRoadLink)
       val roadLink = currentStrategy.pickRoadLink(optRoadLink, optHistoric)


### PR DESCRIPTION
In the case of bus stop 307276:
It was located on link 4385749. There is changes made to this link, so it becomes one-directional and another road is added next to it. In Tierekisteri it is terminated. But in this case, it is keeping the old link Id, but the the road now has only one direction. In the code we assume that if the old link Id still exists, the road is not terminated. This will be changed to always check for both the current link and the historic one, because the Terminated strategy uses the historic one.