### PR TITLE
DROTH-2437 (US 2218) Roadworks are not created from traffic signs

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/TrafficSignManager.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/TrafficSignManager.scala
@@ -104,7 +104,7 @@ case class TrafficSignManager(manoeuvreService: ManoeuvreService, roadLinkServic
           insertTrafficSignToProcess(trSign.id, ParkingProhibition, Some(trSign), newTransaction)
 
         case signType if TrafficSignManager.belongsToRoadwork(signType) =>
-          insertTrafficSignToProcess(trSign.id, RoadWorksAsset, Some(trSign))
+          insertTrafficSignToProcess(trSign.id, RoadWorksAsset, Some(trSign), newTransaction)
 
         case _ => None
       }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
@@ -539,7 +539,7 @@ trait TrafficSignLinearGenerator {
     //RoadLink with the same Finnish/Swedish name
     tsRoadNameInfo.map { case (roadNamePublicIds, roadNameSource) =>
       roadLinkService.getRoadLinksAndComplementaryByRoadNameFromVVH(roadNamePublicIds, Set(roadNameSource), false).filter(_.administrativeClass != State)
-    }.getOrElse(Seq())
+    }.getOrElse(Seq(signRoadLink))
   }
 
   def isToUpdateRelation(newSeg: TrafficSignToLinear)(oldSeg: TrafficSignToLinear): Boolean = {


### PR DESCRIPTION
-Fixed a bug where the process was not creating a roadworks asset in a link with no road name
-Fixed a bug when deleting a traffic sign