### PR TITLE
DROTH-2706 fix to_timestamp_tz function to work with  postgresql

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -50,7 +50,7 @@ sealed trait RoadLinkDAO{
 
   def insertValues(linkId: Long, username: Option[String], value: Int, timeStamp: String) = {
     sqlu""" insert into #$table (id, link_id, #$column, modified_date, modified_by)
-            select nextval('primary_key_seq'), ${linkId}, $value,to_timestamp_tz($timeStamp, 'YYYY-MM-DD"T"HH24:MI:SS.ff3"+"TZH:TZM'), $username
+            select nextval('primary_key_seq'), ${linkId}, $value,to_timestamp($timeStamp, 'YYYY-MM-DD"T"HH24:MI:SS.ff3"+"TZH:TZM'), $username
            where not exists (select * from #$table where link_id = $linkId)""".execute
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/OracleLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/OracleLinearAssetDao.scala
@@ -564,12 +564,12 @@ class OracleLinearAssetDao(val vvhClient: VVHClient, val roadLinkService: RoadLi
     val sideCodeValue = sideCode.value
 
     val creationDate = createdDate match {
-      case Some(datetime) => s"""TO_TIMESTAMP_TZ('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
+      case Some(datetime) => s"""TO_TIMESTAMP('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
       case None => "current_timestamp"
     }
 
     val modifiedDate = modifiedAt match {
-      case Some(datetime) => s"""TO_TIMESTAMP_TZ('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
+      case Some(datetime) => s"""TO_TIMESTAMP('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
       case None => "NULL"
     }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/OracleSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/OracleSpeedLimitDao.scala
@@ -436,12 +436,12 @@ class OracleSpeedLimitDao(val vvhClient: VVHClient, val roadLinkService: RoadLin
     val sideCodeValue = sideCode.value
 
     val creationDate = createdDate match {
-      case Some(datetime) => s"""TO_TIMESTAMP_TZ('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
+      case Some(datetime) => s"""TO_TIMESTAMP('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
       case None => "current_timestamp"
     }
 
     val modifiedDate = modifiedAt match {
-      case Some(datetime) => s"""TO_TIMESTAMP_TZ('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
+      case Some(datetime) => s"""TO_TIMESTAMP('$datetime', 'YYYY-MM-DD"T"HH24:MI:SS.FF3TZH:TZM')"""
       case None => "NULL"
     }
 


### PR DESCRIPTION
https://extranet.vayla.fi/jira/browse/DROTH-2706

Oraclen to_timestamp_tz-funktio korvattu postgresql:n vastineella, eli to_timestamp-funktiolla (sisältää aikavyöhykkeen).