### PR TITLE
Droth 2755 oag urls

### DIFF
--- a/conf/env.properties
+++ b/conf/env.properties
@@ -51,3 +51,7 @@ bonecp.username=digiroad2
 bonecp.password=digiroad2
 #from ci/digiroad2.properties
 featureProvider=fi.liikennevirasto.digiroad2.service.AssetPropertyService
+#oag.properties
+#oagProxyServer=oag.vayla.fi
+#oagProxyUrl=http://oag.vayla.fi
+rasterServiceUrl=http://oag.vayla.fi/rasteripalvelu-mml

--- a/conf/env.properties
+++ b/conf/env.properties
@@ -52,6 +52,4 @@ bonecp.password=digiroad2
 #from ci/digiroad2.properties
 featureProvider=fi.liikennevirasto.digiroad2.service.AssetPropertyService
 #oag.properties
-#oagProxyServer=oag.vayla.fi
-#oagProxyUrl=http://oag.vayla.fi
 rasterServiceUrl=http://oag.vayla.fi/rasteripalvelu-mml

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/Digiroad2Properties.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/Digiroad2Properties.scala
@@ -51,8 +51,7 @@ trait Digiroad2Properties {
   val featureProvider: String
   val googleMapApiClientId: String
   val googleMapApiCryptoKey: String
-
-
+  val rasterServiceUrl: String
   val bonecpProperties: Properties
 }
 
@@ -103,6 +102,7 @@ class Digiroad2PropertiesFromEnv extends Digiroad2Properties {
   val featureProvider: String = scala.util.Properties.envOrElse("featureProvider", null)
   val googleMapApiClientId: String = scala.util.Properties.envOrElse("googlemapapi.client_id", null)
   val googleMapApiCryptoKey: String = scala.util.Properties.envOrElse("googlemapapi.crypto_key", null)
+  val rasterServiceUrl: String = scala.util.Properties.envOrElse("rasterServiceUrl", null)
 
   lazy val bonecpProperties: Properties = {
     val props = new Properties()
@@ -171,6 +171,7 @@ class Digiroad2PropertiesFromFile extends Digiroad2Properties {
   override val featureProvider: String = envProps.getProperty("featureProvider")
   override val googleMapApiClientId: String = envProps.getProperty("googlemapapi.client_id")
   override val googleMapApiCryptoKey: String = envProps.getProperty("googlemapapi.crypto_key")
+  override val rasterServiceUrl: String = envProps.getProperty("rasterServiceUrl")
 
   override lazy val bonecpProperties: Properties = {
     val props = new Properties()
@@ -247,6 +248,7 @@ object Digiroad2Properties {
   lazy val featureProvider: String = properties.featureProvider
   lazy val googleMapApiClientId: String = properties.googleMapApiClientId
   lazy val googleMapApiCryptoKey: String = properties.googleMapApiCryptoKey
+  lazy val rasterServiceUrl: String = properties.rasterServiceUrl
 
   lazy val bonecpProperties: Properties = properties.bonecpProperties
 }

--- a/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
+++ b/src/main/scala/fi/liikennevirasto/digiroad2/DigiroadServer.scala
@@ -58,7 +58,7 @@ class OAGProxyServlet extends ProxyServlet {
   private val logger = LoggerFactory.getLogger(getClass)
 
   override def rewriteURI(req: HttpServletRequest): java.net.URI = {
-    val url = "http://oag.vayla.fi/rasteripalvelu-mml" +  regex.replaceFirstIn(req.getRequestURI, "/wmts/maasto")
+    val url = Digiroad2Properties.rasterServiceUrl +  regex.replaceFirstIn(req.getRequestURI, "/wmts/maasto")
     java.net.URI.create(url)
   }
 


### PR DESCRIPTION
https://extranet.vayla.fi/jira/browse/DROTH-2755

Testauksessa käytetty Marjukan tekemää ohjetta https://extranet.vayla.fi/jira/browse/VIITE-2579 ja seuraavia linkkejä: 
http://localhost:8080/digiroad/maasto/1.0.0/taustakartta/default/ETRS-TM35FIN/12/2762/1645.png ja 
http://localhost:8080/digiroad/maasto/rasteripalvelu/wmts/?request=GetCapabilities

--> molemmat palauttivat 401-statuskoodin.