### PR TITLE
DROTH-2762 setting schema back to digiroad2

### DIFF
--- a/aws/task-definition/dev/task-definition.json
+++ b/aws/task-definition/dev/task-definition.json
@@ -108,7 +108,7 @@
           },
           {
             "name": "bonecp.jdbcUrl",
-            "value": "jdbc:postgresql://ddw6gldo8fiqt4.c8sq5c8rj3gu.eu-west-1.rds.amazonaws.com:5432/digiroad2?currentSchema=dr2user"
+            "value": "jdbc:postgresql://ddw6gldo8fiqt4.c8sq5c8rj3gu.eu-west-1.rds.amazonaws.com:5432/digiroad2"
           },
           {
             "name": "bonecp.username",


### PR DESCRIPTION
https://extranet.vayla.fi/jira/browse/DROTH-2762

Koska aws:n tekemä rakenne ei suoraan toimi, vaihdetaan toistaiseksi takaisin meidän originaaliin kantayhteyteen, niin pääsee testaamaan muuta.