### PR TITLE
DROTH-2762 disable calls to functions with municipality coordinates as parameters

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -229,7 +229,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       case (Some(east), Some(north), Some(zoom)) => Some(east, north, zoom, assetTypeId)
       case _  => None
     }
-
+//TODO: Disabled because of the usage of municipality coordinates. See MunicipalityDao.scala
+    /*
     val location = userPreferences match {
       case Some(preference) => Some(preference._1.toDouble, preference._2.toDouble, preference._3, preference._4)
       case _ =>
@@ -244,7 +245,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             None
         }
     }
-    val loc = location.getOrElse(defaultValues)
+     */
+    val loc = defaultValues
     StartupParameters(loc._1, loc._2, loc._3, loc._4)
   }
 
@@ -2115,8 +2117,10 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     )
   }
 
+  //TODO: Disabled because of the usage of coordinates. See MunicipalityDao.scala
   put("/userConfiguration/defaultLocation") {
     def getCenterView(id: Int, getCenterViewFunctionType: Int => Option[MapViewZoom], user: User): User = {
+      /*
       getCenterViewFunctionType(id) match {
         case Some(centerView) =>
           val east = Option(centerView.geometry.x.toLong)
@@ -2126,6 +2130,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
           user.copy(configuration = user.configuration.copy(east = east, north = north, zoom = zoom))
         case _ => user
       }
+       */
+      user
     }
 
     val user = userProvider.getCurrentUser()
@@ -2229,9 +2235,11 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     )
   }
 
+  //TODO: municipalityService calls disabled because of usage of municipality coordinates. See MunicipalityDao.scala
   get("/userStartLocation") {
     val user = userProvider.getCurrentUser()
     params.get("position") match {
+/*
       case Some(position) =>
         val coordinates = constructPosition(position)
 
@@ -2254,6 +2262,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             }
           }
         }
+*/
       case _ => Map()
     }
   }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -229,7 +229,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       case (Some(east), Some(north), Some(zoom)) => Some(east, north, zoom, assetTypeId)
       case _  => None
     }
-//TODO: Disabled because of the usage of municipality coordinates. See MunicipalityDao.scala
+//TODO: Disabled because of the usage of municipality coordinates. See MunicipalityDao.scala. https://extranet.vayla.fi/jira/browse/DROTH-2824
     /*
     val location = userPreferences match {
       case Some(preference) => Some(preference._1.toDouble, preference._2.toDouble, preference._3, preference._4)
@@ -2118,6 +2118,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   }
 
   //TODO: Disabled because of the usage of coordinates. See MunicipalityDao.scala
+  //TODO: https://extranet.vayla.fi/jira/browse/DROTH-2824
   put("/userConfiguration/defaultLocation") {
     def getCenterView(id: Int, getCenterViewFunctionType: Int => Option[MapViewZoom], user: User): User = {
       /*
@@ -2236,6 +2237,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   }
 
   //TODO: municipalityService calls disabled because of usage of municipality coordinates. See MunicipalityDao.scala
+  //TODO: https://extranet.vayla.fi/jira/browse/DROTH-2824
   get("/userStartLocation") {
     val user = userProvider.getCurrentUser()
     params.get("position") match {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
@@ -62,6 +62,7 @@ class MunicipalityDao {
     sql"""select id from municipality where id = $id """.as[Int].list
   }
 
+  //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
   def getMunicipalityByCoordinates(coordinates: Point): Seq[MunicipalityInfo] = {
     sql"""
           select m.id, m.ely_nro,
@@ -90,20 +91,21 @@ class MunicipalityDao {
     """.as[MunicipalityInfo].list
   }
 
+  //TODO: Usages disabled (no municipality coordinates)
   def getCenterViewMunicipality(municipalityId: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from municipality where id = $municipalityId""".as[MapViewZoom].firstOption
     }
   }
 
-
+  //TODO: Usages disabled (no municipality coordinates)
   def getCenterViewArea(area: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from service_area where id = $area""".as[MapViewZoom].firstOption
     }
   }
 
-
+  //TODO: Usages disabled (no municipality coordinates)
   def getCenterViewEly(ely: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from ely where id = $ely""".as[MapViewZoom].firstOption
@@ -122,6 +124,8 @@ class MunicipalityDao {
     }
   }
 
+  //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
+  //TODO: Usages disabled (no municipality coordinates)
   def getElysIdAndNamesByCoordinates(lon: Int, lat: Int): Seq[(Int, String)] = {
     sql"""
          select e.id,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
@@ -63,6 +63,7 @@ class MunicipalityDao {
   }
 
   //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
+  //TODO: https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getMunicipalityByCoordinates(coordinates: Point): Seq[MunicipalityInfo] = {
     sql"""
           select m.id, m.ely_nro,
@@ -91,21 +92,21 @@ class MunicipalityDao {
     """.as[MunicipalityInfo].list
   }
 
-  //TODO: Usages disabled (no municipality coordinates)
+  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getCenterViewMunicipality(municipalityId: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from municipality where id = $municipalityId""".as[MapViewZoom].firstOption
     }
   }
 
-  //TODO: Usages disabled (no municipality coordinates)
+  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getCenterViewArea(area: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from service_area where id = $area""".as[MapViewZoom].firstOption
     }
   }
 
-  //TODO: Usages disabled (no municipality coordinates)
+  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getCenterViewEly(ely: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from ely where id = $ely""".as[MapViewZoom].firstOption
@@ -125,7 +126,7 @@ class MunicipalityDao {
   }
 
   //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
-  //TODO: Usages disabled (no municipality coordinates)
+  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getElysIdAndNamesByCoordinates(lon: Int, lat: Int): Seq[(Int, String)] = {
     sql"""
          select e.id,


### PR DESCRIPTION
Disabloidaan funktiot, jotka käyttää kuntien geometriaa/koordinaatteja. 