### PR TITLE
Droth 2824 add geometry functions back

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -229,8 +229,6 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       case (Some(east), Some(north), Some(zoom)) => Some(east, north, zoom, assetTypeId)
       case _  => None
     }
-//TODO: Disabled because of the usage of municipality coordinates. See MunicipalityDao.scala. https://extranet.vayla.fi/jira/browse/DROTH-2824
-    /*
     val location = userPreferences match {
       case Some(preference) => Some(preference._1.toDouble, preference._2.toDouble, preference._3, preference._4)
       case _ =>
@@ -245,8 +243,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             None
         }
     }
-     */
-    val loc = defaultValues
+    val loc = location.getOrElse(defaultValues)
     StartupParameters(loc._1, loc._2, loc._3, loc._4)
   }
 
@@ -2117,11 +2114,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     )
   }
 
-  //TODO: Disabled because of the usage of coordinates. See MunicipalityDao.scala
-  //TODO: https://extranet.vayla.fi/jira/browse/DROTH-2824
   put("/userConfiguration/defaultLocation") {
     def getCenterView(id: Int, getCenterViewFunctionType: Int => Option[MapViewZoom], user: User): User = {
-      /*
       getCenterViewFunctionType(id) match {
         case Some(centerView) =>
           val east = Option(centerView.geometry.x.toLong)
@@ -2131,8 +2125,6 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
           user.copy(configuration = user.configuration.copy(east = east, north = north, zoom = zoom))
         case _ => user
       }
-       */
-      user
     }
 
     val user = userProvider.getCurrentUser()
@@ -2236,12 +2228,9 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     )
   }
 
-  //TODO: municipalityService calls disabled because of usage of municipality coordinates. See MunicipalityDao.scala
-  //TODO: https://extranet.vayla.fi/jira/browse/DROTH-2824
   get("/userStartLocation") {
     val user = userProvider.getCurrentUser()
     params.get("position") match {
-/*
       case Some(position) =>
         val coordinates = constructPosition(position)
 
@@ -2264,7 +2253,6 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             }
           }
         }
-*/
       case _ => Map()
     }
   }

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
@@ -227,10 +227,9 @@ class Digiroad2ApiSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     getWithUserAuth("/startupParameters") {
       status should equal(200)
       val responseJson = parse(body)
-      //TODO: Fix these test or revert changes when municipalityDao is fixed. https://extranet.vayla.fi/jira/browse/DROTH-2824
-      (responseJson \ "zoom").values should equal(2)
-      (responseJson \ "lon").values should equal(390000)
-      (responseJson \ "lat").values should equal(6900000)
+      (responseJson \ "zoom").values should equal(3)
+      (responseJson \ "lon").values should equal(470092)
+      (responseJson \ "lat").values should equal(7504895)
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
@@ -62,15 +62,12 @@ class MunicipalityDao {
     sql"""select id from municipality where id = $id """.as[Int].list
   }
 
-  //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
-  //TODO: https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getMunicipalityByCoordinates(coordinates: Point): Seq[MunicipalityInfo] = {
     sql"""
           select m.id, m.ely_nro,
                  case when m.name_fi is not null then m.name_fi else m.name_sv end as name
-          from municipality m,
-               table(sdo_util.getvertices(m.geometry)) t
-            where trunc( t.x ) = ${coordinates.x} and trunc( t.y ) = ${coordinates.y}
+          from municipality m
+            where ST_X(m.geometry) = ${coordinates.x} and ST_Y(m.geometry) = ${coordinates.y}
       """.as[MunicipalityInfo].list
   }
 
@@ -122,7 +119,6 @@ class MunicipalityDao {
     }
   }
 
-  //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
   def getElysIdAndNamesByCoordinates(lon: Int, lat: Int): Seq[(Int, String)] = {
     sql"""
          select e.id,
@@ -130,9 +126,8 @@ class MunicipalityDao {
          		when e.name_fi is not null then e.name_fi
          		else e.name_sv
          	end as name
-         from ely e,
-              table(sdo_util.getvertices(e.geometry)) t
-         	where trunc( t.x ) = $lon and trunc( t.y ) = $lat
+         from ely e
+         	where ST_X(m.geometry) = $lon and ST_Y(m.geometry) = $lat
        """.as[(Int, String)].list
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MunicipalityDao.scala
@@ -92,21 +92,18 @@ class MunicipalityDao {
     """.as[MunicipalityInfo].list
   }
 
-  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getCenterViewMunicipality(municipalityId: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from municipality where id = $municipalityId""".as[MapViewZoom].firstOption
     }
   }
 
-  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getCenterViewArea(area: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from service_area where id = $area""".as[MapViewZoom].firstOption
     }
   }
 
-  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getCenterViewEly(ely: Int): Option[MapViewZoom] =  {
     PostGISDatabase.withDynSession {
       sql"""select geometry, zoom from ely where id = $ely""".as[MapViewZoom].firstOption
@@ -126,7 +123,6 @@ class MunicipalityDao {
   }
 
   //TODO: sdo_util.getvertices() function works in Oracle but not in PostGIS
-  //TODO: Usages disabled (no municipality coordinates). https://extranet.vayla.fi/jira/browse/DROTH-2824
   def getElysIdAndNamesByCoordinates(lon: Int, lat: Int): Seq[(Int, String)] = {
     sql"""
          select e.id,


### PR DESCRIPTION
https://extranet.vayla.fi/jira/browse/DROTH-2824

Palautettu kuntien geometriaa käyttävät funktiot takaisin ja korjattu oracle-jäänteet sekä yksi testi Digiroad2ApiSpec.scalasta.