### PR TITLE
DROTH-2935 Now returns correct roadlinks depending on user role

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -921,7 +921,12 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
     val diagonal = Vector3d(10, 10, 0)
 
     val roadLinks =
-      if (user.isOperator()) getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal))
+      if (user.isOperator()) {
+        getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal)).filter(_.administrativeClass.value != 1)
+      }
+      else if (user.isMunicipalityMaintainer()) {
+        getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities).filter(_.administrativeClass.value != 1)
+      }
       else getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities)
 
     val closestRoadLinks =

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -922,10 +922,10 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
 
     val roadLinks =
       if (user.isOperator()) {
-        getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal)).filter(_.administrativeClass.value != 1)
+        getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal)).filter(_.administrativeClass != State)
       }
       else if (user.isMunicipalityMaintainer()) {
-        getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities).filter(_.administrativeClass.value != 1)
+        getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities).filter(_.administrativeClass.value != State)
       }
       else getVVHRoadLinks(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities)
 


### PR DESCRIPTION
Nyt CSV-importtia pistemäiselle tietolajille tehdessä, menevät käyttäjän roolin mukaan oikein. Ennen muutosta operaattorit ja kuntakäyttäjät pystyivät lisäämään valtion omistamille teille, nyt eivät voi. 