### PR TITLE
DROTH-2806 Disabled manoeuvre extension radio buttons after click

### DIFF
--- a/UI/src/view/linear_asset/manoeuvreForm.js
+++ b/UI/src/view/linear_asset/manoeuvreForm.js
@@ -470,6 +470,7 @@
 
         // Listen to link chain radio button click
         rootElement.find('.continue-option-group').on('click', 'input:radio[name="target"]', function(event) {
+          $(":radio[name='target']").attr("disabled", true);
           var formGroupElement = $(event.delegateTarget);
           var targetLinkId = Number(formGroupElement.attr('linkId'));
           var checkedLinkId = parseInt(formGroupElement.find(':checked').val(), 10);

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ManoeuvreService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ManoeuvreService.scala
@@ -152,15 +152,27 @@ class ManoeuvreService(roadLinkService: RoadLinkService, eventBus: DigiroadEvent
       ManoeuvreElement(0, linkPair._1, linkPair._2, ElementTypes.IntermediateElement)
     )
 
-    for( x <- 0 until linkPairs.length - 1){
-      if( linkPairs(x)._1 == linkPairs(x + 1)._2 || linkPairs(x)._1 == linkPairs(x)._2 || linkPairs(x+1)._1 == linkPairs(x+1)._2) return false
-    }
+    if (isValidLinkChain(linkPairs) == false) return false
 
     val cleanedManoeuvreElements = cleanChain(firstElement, lastElement, intermediateElements)
 
     val manoeuvre = Manoeuvre(0, cleanedManoeuvreElements, newManoeuvre.validityPeriods, newManoeuvre.exceptions, None, null, newManoeuvre.additionalInfo.orNull, null, null, false)
 
     isValidManoeuvre(roadLinks)(manoeuvre)
+  }
+
+  /**
+    * Check if the chain makes sense and is truly a chain. Loops through the linkPairs and checks
+    * that each pair's starting roadlink is not equal to next pair's
+    * ending roadlink, also checks that pair's starting and ending roadlinks are not the same roadlink.
+    * @param linkPairs sequence containing the start and end roadlinks for each pair
+    * @return false if chain breaks the rules, otherwise true
+    */
+  private def isValidLinkChain(linkPairs: Seq[(Long, Long)]) : Boolean = {
+    for( i <- 0 until linkPairs.length - 1){
+    if( linkPairs(i)._1 == linkPairs(i + 1)._2 || linkPairs(i)._1 == linkPairs(i)._2 || linkPairs(i+1)._1 == linkPairs(i+1)._2) return false
+  }
+  true
   }
 
   private def getBySourceRoadLinks(roadLinks: Seq[RoadLink]): Seq[Manoeuvre] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ManoeuvreService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ManoeuvreService.scala
@@ -152,6 +152,10 @@ class ManoeuvreService(roadLinkService: RoadLinkService, eventBus: DigiroadEvent
       ManoeuvreElement(0, linkPair._1, linkPair._2, ElementTypes.IntermediateElement)
     )
 
+    for( x <- 0 until linkPairs.length - 1){
+      if( linkPairs(x)._1 == linkPairs(x + 1)._2 || linkPairs(x)._1 == linkPairs(x)._2 || linkPairs(x+1)._1 == linkPairs(x+1)._2) return false
+    }
+
     val cleanedManoeuvreElements = cleanChain(firstElement, lastElement, intermediateElements)
 
     val manoeuvre = Manoeuvre(0, cleanedManoeuvreElements, newManoeuvre.validityPeriods, newManoeuvre.exceptions, None, null, newManoeuvre.additionalInfo.orNull, null, null, false)


### PR DESCRIPTION
Lisätessä kääntymisrajoituksen tielinkki "ketjuun" tielinkkejä, oli mahdollista klikkailla useita radio-näppäimiä ennen kuin seuraavan linkin vaihtoehdot latautuivat. Tekemäni muutos disabloi jatkolinkkien valintaan käytettävät radiopainikkeet niitä klikatessa