### PR TITLE
Droth 2969 lane visualization fix

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LaneFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LaneFiller.scala
@@ -116,7 +116,7 @@ class LaneFiller {
     if (keeperOpt.nonEmpty) {
       val keeper = keeperOpt.get
       val overlapping = sortedAssets.tail.flatMap(asset => GeometryUtils.overlap(toSegment(keeper), toSegment(asset)) match {
-        case Some(overlap) if keeper.laneCode == asset.laneCode =>
+        case Some(overlap) if keeper.laneCode == asset.laneCode && keeper.sideCode == asset.sideCode=>
           Seq(
             asset.copy(startMeasure = asset.startMeasure, endMeasure = overlap._1),
             asset.copy(id = 0L, startMeasure = overlap._2, endMeasure = asset.endMeasure)

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LaneFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LaneFillerSpec.scala
@@ -27,8 +27,8 @@ class LaneFillerSpec extends FunSuite with Matchers {
     val topology = Seq( roadLinkTowards1 )
 
     val lane = PersistedLane(1L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      11, 745L, 10.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+      1, 745L, 10.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
     val linearAssets = Map(
@@ -49,23 +49,23 @@ class LaneFillerSpec extends FunSuite with Matchers {
   test("Multiple lanes outside topology. One lane should dropped due the shortness after conversion.") {
     val topology = Seq( roadLinkTowards1 )
 
-    val lane11 = PersistedLane(1L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      11, 745L, 10.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+    val lane1 = PersistedLane(1L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      1, 745L, 10.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
-    val lane12 = PersistedLane(2L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      12, 745L, 10.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(12))))
+    val lane2 = PersistedLane(2L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      2, 745L, 10.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
-    val lane13 = PersistedLane(3L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      13, 745L, 13.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(13))))
+    val lane3 = PersistedLane(3L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      3, 745L, 13.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(3))))
     )
 
     val linearAssets = Map(
-      roadLinkTowards1.linkId -> Seq( lane11, lane12, lane13 )
+      roadLinkTowards1.linkId -> Seq( lane1, lane2, lane3 )
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
@@ -83,8 +83,8 @@ class LaneFillerSpec extends FunSuite with Matchers {
     val topology = Seq( roadLinkTowards1 )
 
     val lane = PersistedLane(1L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      11, 745L, 0.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+      1, 745L, 0.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
     val linearAssets = Map(
@@ -106,18 +106,18 @@ class LaneFillerSpec extends FunSuite with Matchers {
     val topology = Seq( roadLinkTowards3, roadLinkTowards1 )
 
     val lane = PersistedLane(1L, roadLinkTowards3.linkId, SideCode.TowardsDigitizing.value,
-      11, 745L, 0.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+      1, 745L, 0.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
     val lane2 = PersistedLane(2L, roadLinkTowards3.linkId, SideCode.AgainstDigitizing.value,
-      21, 745L, 5.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(21))))
+      1, 745L, 5.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
     val lane3 = PersistedLane(20L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      21, 745L, 5.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(21))))
+      1, 745L, 5.0, 15.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
 
@@ -141,22 +141,22 @@ class LaneFillerSpec extends FunSuite with Matchers {
     val topology = Seq( roadLinkTowards1 )
 
     val lane = PersistedLane(20L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      11, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+      1, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
-    val lane12 = PersistedLane(21L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      12, 745L, 7.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(12))))
+    val lane2 = PersistedLane(21L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      2, 745L, 7.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
-    val lane12b = PersistedLane(22L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      12, 745L, 4.0, 7.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(12))))
+    val lane2b = PersistedLane(22L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      2, 745L, 4.0, 7.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
     val linearAssets = Map(
-      roadLinkTowards1.linkId -> Seq( lane, lane12, lane12b )
+      roadLinkTowards1.linkId -> Seq( lane, lane2, lane2b )
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
@@ -175,18 +175,18 @@ class LaneFillerSpec extends FunSuite with Matchers {
     val topology = Seq( roadLinkTowards1 )
 
     val lane = PersistedLane(20L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      11, 745L, 1.0, 2.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+      1, 745L, 1.0, 2.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
-    val lane12 = PersistedLane(21L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      12, 745L, 8.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(12))))
+    val lane2 = PersistedLane(21L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      2, 745L, 8.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
 
     val linearAssets = Map(
-      roadLinkTowards1.linkId -> Seq( lane, lane12 )
+      roadLinkTowards1.linkId -> Seq( lane, lane2 )
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
@@ -204,18 +204,18 @@ class LaneFillerSpec extends FunSuite with Matchers {
     val topology = Seq( roadLinkTowards4 )
 
     val lane = PersistedLane(20L, roadLinkTowards4.linkId, SideCode.BothDirections.value,
-      21, 745L, 0.0, 1.9, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(21))))
+      1, 745L, 0.0, 1.9, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
-    val lane12 = PersistedLane(21L, roadLinkTowards4.linkId, SideCode.BothDirections.value,
-      22, 745L, 0.0, 1.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(22))))
+    val lane2 = PersistedLane(21L, roadLinkTowards4.linkId, SideCode.BothDirections.value,
+      2, 745L, 0.0, 1.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
 
     val linearAssets = Map(
-      roadLinkTowards4.linkId -> Seq( lane, lane12 )
+      roadLinkTowards4.linkId -> Seq( lane, lane2 )
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
@@ -231,28 +231,28 @@ class LaneFillerSpec extends FunSuite with Matchers {
   test("Expire duplicate lane") {
     val topology = Seq(roadLinkTowards1)
 
-    val lane11 = PersistedLane(1L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+    val lane1 = PersistedLane(1L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
       1, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1))))
     )
 
-    val lane12 = PersistedLane(2L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      12, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(12))))
+    val lane2 = PersistedLane(2L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      2, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
-    val lane12Duplicated = PersistedLane(3L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      12, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(12))))
+    val lane2Duplicated = PersistedLane(3L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      2, 745L, 0.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))))
     )
 
-    val lane13 = PersistedLane(4L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
-      13, 745L, 5.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
-      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(13))))
+    val lane3 = PersistedLane(4L, roadLinkTowards1.linkId, SideCode.BothDirections.value,
+      3, 745L, 5.0, 10.0, None, None, None, None, None, None, expired = false, 0L, None,
+      Seq(LaneProperty("lane_code", Seq(LanePropertyValue(3))))
     )
 
     val linearAssets = Map(
-      roadLinkTowards1.linkId -> Seq(lane11, lane12, lane12Duplicated, lane13)
+      roadLinkTowards1.linkId -> Seq(lane1, lane2, lane2Duplicated, lane3)
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -590,8 +590,16 @@ trait LaneOperations {
       throw new IllegalArgumentException("Lane code attribute not found!")
   }
 
-  def validateStartDate(newLane: NewLane, laneCode: Int): Unit = {
+  def validateStartDateOneDigit(newLane: NewLane, laneCode: Int): Unit = {
     if (!LaneNumberOneDigit.isMainLane(laneCode)) {
+      val startDateValue = getPropertyValue(newLane.properties, "start_date")
+      if (startDateValue == None || startDateValue.toString.trim.isEmpty)
+        throw new IllegalArgumentException("Start Date attribute not found on additional lane!")
+    }
+  }
+
+  def validateStartDate(newLane: NewLane, laneCode: Int): Unit = {
+    if (!LaneNumber.isMainLane(laneCode)) {
       val startDateValue = getPropertyValue(newLane.properties, "start_date")
       if (startDateValue == None || startDateValue.toString.trim.isEmpty)
         throw new IllegalArgumentException("Start Date attribute not found on additional lane!")
@@ -716,7 +724,7 @@ trait LaneOperations {
 
         newLanes.map { newLane =>
           val laneCode = getLaneCode(newLane)
-          validateStartDate(newLane, laneCode.toInt)
+          validateStartDateOneDigit(newLane, laneCode.toInt)
 
           val laneToInsert = PersistedLane(0, linkId, sideCode, laneCode.toInt, newLane.municipalityCode,
                                       newLane.startMeasure, newLane.endMeasure, Some(username), Some(DateTime.now()), None, None, None, None,
@@ -736,7 +744,7 @@ trait LaneOperations {
           newLanes.map { newLane =>
 
             val laneCode = getLaneCode(newLane)
-            validateStartDate(newLane, laneCode.toInt)
+            validateStartDateOneDigit(newLane, laneCode.toInt)
 
             val roadLink = if (viiteRoadLinks(linkId).nonEmpty)
                             viiteRoadLinks(linkId).head

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -5,7 +5,7 @@ import fi.liikennevirasto.digiroad2.asset.SideCode
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
 import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, VVHClient}
 import fi.liikennevirasto.digiroad2.dao.{RoadAddressTEMP, RoadLinkTempDAO}
-import fi.liikennevirasto.digiroad2.lane.LaneNumberOneDigit.MainLane
+import fi.liikennevirasto.digiroad2.lane.LaneNumber.MainLane
 import fi.liikennevirasto.digiroad2.lane.{LaneRoadAddressInfo, NewLane, PersistedLane}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.lane.LaneService
@@ -32,7 +32,7 @@ object LaneUtils {
   lazy val viiteClient: SearchViiteClient = { new SearchViiteClient(Digiroad2Properties.viiteRestApiEndPoint, HttpClientBuilder.create().build()) }
   lazy val roadAddressService: RoadAddressService = new RoadAddressService(viiteClient)
 
-  lazy val MAIN_LANES = Seq(MainLane.laneCode)
+  lazy val MAIN_LANES = Seq(MainLane.towardsDirection, MainLane.againstDirection, MainLane.motorwayMaintenance)
 
   def processNewLanesByRoadAddress(newLanes: Set[NewLane], laneRoadAddressInfo: LaneRoadAddressInfo,
                                    sideCode: Int, username: String, withTransaction: Boolean = true): Any = {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -1204,7 +1204,7 @@ class LaneServiceSpec extends LaneTestSupporter {
         LaneProperty("lane_type", Seq(LanePropertyValue("3")))
       )
       val thrown = intercept[IllegalArgumentException] {
-        ServiceWithDao.validateStartDate(NewLane(0, 0, 500, 745, false, false, lanePropertiesValues), 2)
+        ServiceWithDao.validateStartDateOneDigit(NewLane(0, 0, 500, 745, false, false, lanePropertiesValues), 2)
       }
       thrown.getMessage should be("Start Date attribute not found on additional lane!")
     }


### PR DESCRIPTION
LaneFillerin expireOverLappedRecursively korjattu toimimaan yksinumeroisella kaistakoodilla, ottaa sideCoden huomioon päällekkäisyyttä päätellessä. LaneFiller testit korjattu käyttämään yksinumeroista. Lisätty validateStartDateOneDigit ja jätetty vanha CSV-importtia varten