### PR TITLE
Remove when().thenReturn() to fix lane creation test

### DIFF
--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -590,7 +590,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
       when(lanesCsvImporter.laneUtils.processNewLanesByRoadAddress(any[Set[NewLane]], any[LaneRoadAddressInfo],
         any[Int], any[String], any[Boolean])).thenReturn()
 
-      when(lanesCsvImporter.laneService.expireAllAdditionalLanes(any[String])).thenReturn()
+      lanesCsvImporter.laneService.expireAllAdditionalLanes(any[String])
 
       val laneRow = Map("kaista" -> 12, "katyyppi" -> 2, "tie" -> 999, "osa" -> 999, "ajorata" -> 1, "aet" -> 0, "let" -> 1000)
 


### PR DESCRIPTION
Korjaa csv import testin "Create new lane", kun expireAllAdditionalLanes funktio on vaihdettu palauttamaan Unit, Any sijaan.