### PR TITLE
Droth 3000 lane highlight fix

### DIFF
--- a/UI/src/controller/laneModellingCollection.js
+++ b/UI/src/controller/laneModellingCollection.js
@@ -19,7 +19,6 @@
     };
 
     self.getGroup = function(segment) {
-      console.trace();
       return _.find(self.linearAssets, function(linearAssetGroup) {
         return _.some(linearAssetGroup, function(la) {
           var laneLaneCode = _.head(Property.getPropertyByPublicId(la.value, 'lane_code').values).value;

--- a/UI/src/controller/laneModellingCollection.js
+++ b/UI/src/controller/laneModellingCollection.js
@@ -19,11 +19,12 @@
     };
 
     self.getGroup = function(segment) {
+      console.trace();
       return _.find(self.linearAssets, function(linearAssetGroup) {
         return _.some(linearAssetGroup, function(la) {
           var laneLaneCode = _.head(Property.getPropertyByPublicId(la.value, 'lane_code').values).value;
           var segmentLaneCode = _.head(Property.getPropertyByPublicId(segment.value, 'lane_code').values).value;
-          return la.linkId == segment.linkId && laneLaneCode == segmentLaneCode;});
+          return la.linkId == segment.linkId && laneLaneCode == segmentLaneCode && la.sideCode == segment.sideCode;});
       });
     };
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -101,9 +101,7 @@ case class Vector3d(x: Double, y: Double, z: Double) {
 
 case class Point(x: Double, y: Double, z: Double = 0.0) {
   def round(): Point = {
-   // val result = Point(point.x - (point.x % 0.01), point.y - (point.y % 0.01), point.z - (point.z % 0.01))
-    val result = Point(this.x.toInt, this.y.toInt, this.z.toInt)
-    result
+    Point(this.x.toInt, this.y.toInt, this.z.toInt)
   }
 
   def distance2DTo(point: Point): Double =

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -100,6 +100,12 @@ case class Vector3d(x: Double, y: Double, z: Double) {
 }
 
 case class Point(x: Double, y: Double, z: Double = 0.0) {
+  def round(): Point = {
+   // val result = Point(point.x - (point.x % 0.01), point.y - (point.y % 0.01), point.z - (point.z % 0.01))
+    val result = Point(this.x.toInt, this.y.toInt, this.z.toInt)
+    result
+  }
+
   def distance2DTo(point: Point): Double =
     Math.sqrt(Math.pow(point.x - x, 2) + Math.pow(point.y - y, 2))
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -101,7 +101,7 @@ case class Vector3d(x: Double, y: Double, z: Double) {
 
 case class Point(x: Double, y: Double, z: Double = 0.0) {
   def round(): Point = {
-    Point(this.x.toInt, this.y.toInt, this.z.toInt)
+    Point(Math.round(this.x), Math.round(this.y), Math.round(this.z))
   }
 
   def distance2DTo(point: Point): Double =

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -126,10 +126,10 @@ object LanePartitioner extends GraphPartitioner {
               laneAndContinuingLanes.values.head.size == 1 || laneAndContinuingLanes.values.head.isEmpty
             }).getOrElse(lanesOnRoad.head)
           }
-          val onlyStartingLaneEndPoints = startingLane.keys.head.endpoints
-          val onlyContinuingLanesEndPoints = startingLane.values.flatten.flatMap(_.endpoints)
-          val continuingPoint = onlyContinuingLanesEndPoints.find(point =>
-            point.round() == onlyStartingLaneEndPoints.head.round() || point.round() == onlyStartingLaneEndPoints.last.round())
+          val startingEndPoints = startingLane.keys.head.endpoints
+          val continuingEndPoints = startingLane.values.flatten.flatMap(_.endpoints)
+          val continuingPoint = continuingEndPoints.find(point =>
+            point.round() == startingEndPoints.head.round() || point.round() == startingEndPoints.last.round())
           if (continuingPoint.isDefined) {
             getSortedLanes(continuingPoint.get, startingLane.keys.toSeq)
           }
@@ -140,7 +140,7 @@ object LanePartitioner extends GraphPartitioner {
 
       }
 
-//      Returns option of lane continuing from lane that we are inspecting
+      //Returns lanes continuing from from given lane
       def getContinuingWithIdentifier(lane: PieceWiseLane, laneRoadIdentifier: Option[Either[Int,String]]): Seq[PieceWiseLane] = {
         lanes.filter(potentialLane => potentialLane.endpoints.map(point =>
           point.round()).exists(lane.endpoints.map(point =>
@@ -169,9 +169,9 @@ object LanePartitioner extends GraphPartitioner {
       }
 
       val lanesAdjusted = replaceLanesWithWrongSideCode()
-      val groupedLanesByRoadLinkAndSideCode = lanesAdjusted.groupBy(lane => lane.linkId)
+      val groupedLanesByRoadLink = lanesAdjusted.groupBy(lane => lane.linkId)
 
-      val (cutLaneConfiguration, uncutLaneConfiguration) = groupedLanesByRoadLinkAndSideCode.partition { case (roadLinkId, lanes) =>
+      val (cutLaneConfiguration, uncutLaneConfiguration) = groupedLanesByRoadLink.partition { case (roadLinkId, lanes) =>
         roadLinks.get(roadLinkId) match {
           case Some(roadLink) =>
             lanes.exists { lane =>

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.lane
 
-import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
-import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, SideCode, TrafficDirection}
+import fi.liikennevirasto.digiroad2.Point
+import fi.liikennevirasto.digiroad2.asset.{SideCode, TrafficDirection}
 import fi.liikennevirasto.digiroad2.linearasset.{GraphPartitioner, RoadLink}
 
 
@@ -45,8 +45,6 @@ object LanePartitioner extends GraphPartitioner {
       partitionedAdditionalLanesTowards, partitionedAdditionalLanesAgainst)
 
   }
-
-
 
   def partition(allLanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink]): Seq[Seq[PieceWiseLane]] = {
     def groupLanes(lanes: Seq[PieceWiseLane]): Seq[Seq[PieceWiseLane]] = {

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -27,6 +27,7 @@ object LanePartitioner extends GraphPartitioner {
     val (lanesOnOneDirection, lanesOnTwoDirection) = linearAssets.partition(lane =>
       roadLinks(lane.linkId).trafficDirection.value != BothDirections.value)
     val (mainLanesOnOneDirection, additionalLanesOnOneDirection) = partitionByMainLane(lanesOnOneDirection)
+    val (mainLanesOnOneDirectionTowards, mainLanesOnOneDirectionAgainst) = mainLanesOnOneDirection.partition(_.sideCode == SideCode.TowardsDigitizing.value)
 
     val (lanesBothDirections, lanesOneDirection) = lanesOnTwoDirection.partition(_.sideCode == SideCode.BothDirections.value)
     val (lanesTowards, lanesAgainst) = lanesOneDirection.partition(_.sideCode == SideCode.TowardsDigitizing.value)
@@ -35,7 +36,7 @@ object LanePartitioner extends GraphPartitioner {
     val (mainLanesTowards, additionalLanesTowards) = partitionByMainLane(lanesTowards)
     val (mainLanesAgainst, additionalLanesAgainst) = partitionByMainLane(lanesAgainst)
 
-    Seq(mainLanesOnOneDirection, additionalLanesOnOneDirection, mainLanesBothDirections,
+    Seq(mainLanesOnOneDirectionTowards, mainLanesOnOneDirectionAgainst, additionalLanesOnOneDirection, mainLanesBothDirections,
       mainLanesTowards, mainLanesAgainst, additionalLanesBothDirections,
       additionalLanesTowards, additionalLanesAgainst)
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -35,7 +35,8 @@ object LanePartitioner extends GraphPartitioner {
     val (mainLanesTowards, additionalLanesTowards) = partitionByMainLane(lanesTowards)
     val (mainLanesAgainst, additionalLanesAgainst) = partitionByMainLane(lanesAgainst)
 
-    Seq(mainLanesOnOneDirection, additionalLanesOnOneDirection, mainLanesBothDirections, mainLanesTowards, mainLanesAgainst, additionalLanesBothDirections,
+    Seq(mainLanesOnOneDirection, additionalLanesOnOneDirection, mainLanesBothDirections,
+      mainLanesTowards, mainLanesAgainst, additionalLanesBothDirections,
       additionalLanesTowards, additionalLanesAgainst)
 
   }
@@ -154,7 +155,8 @@ object LanePartitioner extends GraphPartitioner {
       LaneWithContinuingLanes(lane, continuingLanes)
     })).toSeq
 
-    lanesGroupedWithContinuing.flatMap(lanesOnRoad => handleLanes(lanesOnRoad, allLanes))++ laneGroupsWithNoIdentifier.values.flatten
+    lanesGroupedWithContinuing.flatMap(lanesOnRoad =>
+      handleLanes(lanesOnRoad, allLanes))++ laneGroupsWithNoIdentifier.values.flatten
   }
 
   def partition(allLanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink]): Seq[Seq[PieceWiseLane]] = {

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
@@ -3,8 +3,7 @@ package fi.liikennevirasto.digiroad2.lane
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, Motorway, State, TrafficDirection}
-import fi.liikennevirasto.digiroad2.lane.LaneNumberOneDigit.MainLane
-import fi.liikennevirasto.digiroad2.lane.LanePartitioner.{partition, partitionBySideCodeAndLaneCode}
+import fi.liikennevirasto.digiroad2.lane.LanePartitioner._
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import org.scalatest._
 
@@ -20,8 +19,8 @@ class LanePartitionerSpec extends FunSuite with Matchers {
       None, None, None, None, 0l, None, AdministrativeClass(1), Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1)))))
   }
 
-  def createRoadLink(id: Long, geometry: Seq[Point], roadIdentifier: String): RoadLink ={
-    RoadLink(id,geometry, 1.0, State, 1, BothDirections, Motorway, None, None, Map("ROADNAME_FI" -> roadIdentifier))
+  def createRoadLink(id: Long, geometry: Seq[Point], trafficDirection: TrafficDirection, roadIdentifier: String): RoadLink ={
+    RoadLink(id,geometry, 1.0, State, 1, trafficDirection, Motorway, None, None, Map("ROADNAME_FI" -> roadIdentifier))
   }
 
   def createLanes(): Seq[PieceWiseLane] = {
@@ -32,6 +31,19 @@ class LanePartitionerSpec extends FunSuite with Matchers {
     val firstRightAdditionalTowards = createPieceWiseLane(5l, 2, 3)
 
     Seq(mainLaneBothDirectionsA, mainLaneBothDirectionsB, mainLaneTowards, firstLeftAdditionalTowards, firstRightAdditionalTowards)
+  }
+
+  def createLanesWithGeometry(): Seq[PieceWiseLane] = {
+    val lane0 = createLaneWithGeometry(0, 1 ,3,Point(0.0,0.0), Point(1.0, 1.0))
+    val lane1 = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
+
+    val lane2 = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 2.0))
+    val lane3 = createLaneWithGeometry(3, 2 ,3,Point(1.0,1.0), Point(2.0, 2.0))
+
+    val lane4 = createLaneWithGeometry(4, 3 ,3,Point(2.0,2.0), Point(2.0, 3.0))
+    val lane5 = createLaneWithGeometry(5, 3 ,2,Point(2.0,2.0), Point(2.0, 3.0))
+
+    Seq(lane0, lane1,lane2,lane3,lane4,lane5)
   }
 
   test("Lanes should be partitioned by side code and lanecode") {
@@ -45,29 +57,65 @@ class LanePartitionerSpec extends FunSuite with Matchers {
   }
 
   test("Lanes should be partitioned to two groups according to correct sideCode") {
-    val lane0 = createLaneWithGeometry(0, 1 ,3,Point(0.0,0.0), Point(1.0, 1.0))
-    val lane1 = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
-    val lane2 = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 2.0))
-    val lane3 = createLaneWithGeometry(3, 2 ,3,Point(1.0,1.0), Point(2.0, 2.0))
-    val lane4 = createLaneWithGeometry(4, 3 ,3,Point(2.0,2.0), Point(2.0, 1.0))
-    val lane5 = createLaneWithGeometry(5, 3 ,2,Point(2.0,2.0), Point(2.0, 1.0))
-
-
-    val roadLink1 = createRoadLink(1, Seq(Point(0.0,0.0), Point(1.0, 1.0)), "testiKatu")
-    val roadLink2 = createRoadLink(2, Seq(Point(1.0,1.0), Point(2.0, 2.0)), "testiKatu")
-    val roadLink3 = createRoadLink(3, Seq(Point(2.0,2.0), Point(2.0, 1.0)), "testiKatu")
+    val roadLink1 = createRoadLink(1, Seq(Point(0.0,0.0), Point(1.0, 1.0)), BothDirections, "testiKatu")
+    val roadLink2 = createRoadLink(2, Seq(Point(1.0,1.0), Point(2.0, 2.0)), BothDirections, "testiKatu")
+    val roadLink3 = createRoadLink(3, Seq(Point(2.0,2.0), Point(2.0, 1.0)), BothDirections, "testiKatu")
 
     val roadLinksMapped = Seq(roadLink1, roadLink2, roadLink3).groupBy(_.linkId).mapValues(_.head)
-    val allLanes = Seq(lane0, lane1,lane2,lane3,lane4,lane5)
+    val lanes = createLanesWithGeometry()
 
-    val result = partition(allLanes, roadLinksMapped)
+    val result = partition(lanes, roadLinksMapped)
     result.size should equal(2)
-    result(0).contains(lane1) should equal(true)
-    result(0).contains(lane2) should equal(true)
-    result(0).contains(lane4) should equal(true)
+    result(0).contains(lanes(1)) should equal(true)
+    result(0).contains(lanes(2)) should equal(true)
+    result(0).contains(lanes(5)) should equal(true)
 
-    result(1).contains(lane3) should equal(true)
-    result(1).contains(lane0) should equal(true)
-    result(1).contains(lane5) should equal(true)
+    result(1).contains(lanes(3)) should equal(true)
+    result(1).contains(lanes(0)) should equal(true)
+    result(1).contains(lanes(4)) should equal(true)
   }
+
+  test("startingLane should be on oneway trafficDirection roadLink if possible") {
+    val lane0 = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
+    val lane1 = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 2.0))
+    val lane2 = createLaneWithGeometry(5, 3 ,2,Point(2.0,2.0), Point(2.0, 3.0))
+
+    val lanesWithContinuing = Seq(Map(lane0 -> Seq(lane1)), Map(lane1 -> Seq(lane2, lane0)), Map(lane2 -> Seq(lane1)))
+    val oneWayRoadLinkId = Seq(3l)
+    val startingLane = getStartingLaneTwoAndOneWay(lanesWithContinuing, oneWayRoadLinkId)
+    startingLane.keys.head should equal(lane2)
+  }
+
+  test("On a circular road startingLane should be first lane in Seq") {
+    val lane0 = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
+    val lane1 = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 2.0))
+    val lane2 = createLaneWithGeometry(5, 3 ,2,Point(2.0,2.0), Point(2.0, 3.0))
+    val lane3 = createLaneWithGeometry(5, 3 ,2,Point(2.0,3.0), Point(0.0, 0.0))
+
+
+    val lanesWithContinuing = Seq(Map(lane0 -> Seq(lane1, lane3)), Map(lane1 -> Seq(lane2, lane0)),
+      Map(lane2 -> Seq(lane1,lane3)), Map(lane3 -> Seq(lane2, lane0)))
+    val startingLane = getStartingLane(lanesWithContinuing)
+    startingLane should equal(lanesWithContinuing.head)
+  }
+
+  test("Lane with different sideCode but same linkId should be returned") {
+    val previousLane = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
+    val currentLane = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 0.0))
+    val differentSideCodeLane = createLaneWithGeometry(5, 2 ,3,Point(1.0,1.0), Point(2.0, 0.0))
+    val lanes = Seq(previousLane, currentLane, differentSideCodeLane)
+    val correctedLane = checkLane(previousLane, currentLane, lanes)
+
+    correctedLane should equal(differentSideCodeLane)
+  }
+
+  test("sideCodeCorrect should return false") {
+    val previousLane = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
+    val currentLane = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 0.0))
+    val connectionPoint = currentLane.endpoints.find(point =>
+      point.round() == previousLane.endpoints.head.round() || point.round() == previousLane.endpoints.last.round()).get
+
+    sideCodeCorrect(previousLane, currentLane, connectionPoint) should equal(false)
+  }
+
 }

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
@@ -1,8 +1,11 @@
 package fi.liikennevirasto.digiroad2.lane
 
 import fi.liikennevirasto.digiroad2.Point
-import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
-import fi.liikennevirasto.digiroad2.lane.LanePartitioner.partitionBySideCodeAndLaneCode
+import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
+import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, Motorway, State, TrafficDirection}
+import fi.liikennevirasto.digiroad2.lane.LaneNumberOneDigit.MainLane
+import fi.liikennevirasto.digiroad2.lane.LanePartitioner.{partition, partitionBySideCodeAndLaneCode}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import org.scalatest._
 
 class LanePartitionerSpec extends FunSuite with Matchers {
@@ -10,6 +13,15 @@ class LanePartitionerSpec extends FunSuite with Matchers {
   def createPieceWiseLane(id: Long, sideCode: Int, laneCode: Int): PieceWiseLane = {
     PieceWiseLane(id, 0l, sideCode, false, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 0d, 10d, Set(Point(0.0, 0.0),
       Point(10.0, 0.0)), None, None, None, None, 0l, None, AdministrativeClass(1), Seq(LaneProperty("lane_code", Seq(LanePropertyValue(laneCode)))))
+  }
+
+  def createLaneWithGeometry(id: Long, linkId: Long, sideCode: Int, startPoint: Point, endPoint: Point): PieceWiseLane = {
+    PieceWiseLane(id, linkId, sideCode, false, Seq(startPoint, endPoint), 0d, 1d, Set(startPoint,endPoint),
+      None, None, None, None, 0l, None, AdministrativeClass(1), Seq(LaneProperty("lane_code", Seq(LanePropertyValue(1)))))
+  }
+
+  def createRoadLink(id: Long, geometry: Seq[Point], roadIdentifier: String): RoadLink ={
+    RoadLink(id,geometry, 1.0, State, 1, BothDirections, Motorway, None, None, Map("ROADNAME_FI" -> roadIdentifier))
   }
 
   def createLanes(): Seq[PieceWiseLane] = {
@@ -30,5 +42,32 @@ class LanePartitionerSpec extends FunSuite with Matchers {
     lanesPartitioned(0).size should equal(2)
     lanesPartitioned(1).size should equal(1)
     lanesPartitioned(4).size should equal(2)
+  }
+
+  test("Lanes should be partitioned to two groups according to correct sideCode") {
+    val lane0 = createLaneWithGeometry(0, 1 ,3,Point(0.0,0.0), Point(1.0, 1.0))
+    val lane1 = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
+    val lane2 = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 2.0))
+    val lane3 = createLaneWithGeometry(3, 2 ,3,Point(1.0,1.0), Point(2.0, 2.0))
+    val lane4 = createLaneWithGeometry(4, 3 ,3,Point(2.0,2.0), Point(2.0, 1.0))
+    val lane5 = createLaneWithGeometry(5, 3 ,2,Point(2.0,2.0), Point(2.0, 1.0))
+
+
+    val roadLink1 = createRoadLink(1, Seq(Point(0.0,0.0), Point(1.0, 1.0)), "testiKatu")
+    val roadLink2 = createRoadLink(2, Seq(Point(1.0,1.0), Point(2.0, 2.0)), "testiKatu")
+    val roadLink3 = createRoadLink(3, Seq(Point(2.0,2.0), Point(2.0, 1.0)), "testiKatu")
+
+    val roadLinksMapped = Seq(roadLink1, roadLink2, roadLink3).groupBy(_.linkId).mapValues(_.head)
+    val allLanes = Seq(lane0, lane1,lane2,lane3,lane4,lane5)
+
+    val result = partition(allLanes, roadLinksMapped)
+    result.size should equal(2)
+    result(0).contains(lane1) should equal(true)
+    result(0).contains(lane2) should equal(true)
+    result(0).contains(lane4) should equal(true)
+
+    result(1).contains(lane3) should equal(true)
+    result(1).contains(lane0) should equal(true)
+    result(1).contains(lane5) should equal(true)
   }
 }

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
@@ -53,11 +53,11 @@ class LanePartitionerSpec extends FunSuite with Matchers {
     val roadLinks = Seq(roadLink0, roadLink1).groupBy(_.linkId).mapValues(_.head)
     val lanesPartitioned = partitionBySideCodeAndLaneCode(lanes, roadLinks)
 
-    lanesPartitioned.size should equal(7)
-    lanesPartitioned(0).size should equal(3)
+    lanesPartitioned.size should equal(8)
+    lanesPartitioned(0).size should equal(1)
     lanesPartitioned(1).size should equal(2)
-    lanesPartitioned(4).size should equal(0)
-    lanesPartitioned(5).size should equal(2)
+    lanesPartitioned(2).size should equal(2)
+    lanesPartitioned(5).size should equal(0)
   }
 
   test("Lanes should be partitioned to two groups according to correct sideCode") {
@@ -79,16 +79,15 @@ class LanePartitionerSpec extends FunSuite with Matchers {
     result(1).contains(lanes(4)) should equal(true)
   }
 
-  test("startingLane should be on oneway trafficDirection roadLink if possible") {
+  test("startingLane should be either one of the last lanes") {
     val lane0 = createLaneWithGeometry(1, 1, 2,Point(0.0,0.0), Point(1.0, 1.0))
     val lane1 = createLaneWithGeometry(2, 2, 2,Point(1.0,1.0), Point(2.0, 2.0))
     val lane2 = createLaneWithGeometry(5, 3 ,2,Point(2.0,2.0), Point(2.0, 3.0))
 
     val lanesWithContinuing = Seq(LaneWithContinuingLanes(lane0, Seq(lane1)), LaneWithContinuingLanes(lane1, Seq(lane2, lane0)),
       LaneWithContinuingLanes(lane2, Seq(lane1)))
-    val oneWayRoadLinkId = Seq(3l)
-    val startingLane = getStartingLaneTwoAndOneWay(lanesWithContinuing, oneWayRoadLinkId)
-    startingLane.lane should equal(lane2)
+    val startingLane = getStartingLane(lanesWithContinuing)
+    Seq(lane0, lane2).contains(startingLane.lane) should equal(true)
   }
 
   test("On a circular road startingLane should be first lane in Seq") {

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
@@ -53,10 +53,10 @@ class LanePartitionerSpec extends FunSuite with Matchers {
     val roadLinks = Seq(roadLink0, roadLink1).groupBy(_.linkId).mapValues(_.head)
     val lanesPartitioned = partitionBySideCodeAndLaneCode(lanes, roadLinks)
 
-    lanesPartitioned.size should equal(8)
+    lanesPartitioned.size should equal(9)
     lanesPartitioned(0).size should equal(1)
-    lanesPartitioned(1).size should equal(2)
     lanesPartitioned(2).size should equal(2)
+    lanesPartitioned(3).size should equal(2)
     lanesPartitioned(5).size should equal(0)
   }
 


### PR DESCRIPTION
Kaistajoukon muodostus korjattu toimimaan yksinumeroisella kaistakoodilla. Kaistajoukkoa muodostaessa tien kaistat käydään läpi ja tilanteen vaatiessa vaihtaa kaistan vastaavaan toisen sideCoden kaistaan. Teillä, joilla ei ole tienumeroa tai tiennimeä ei muodosteta joukkoa.