### PR TITLE
DROTH-3040 fixed LanePartitioner

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -130,7 +130,8 @@ object LanePartitioner {
 
       val resultGroups = lanesGroupedWithContinuing.map(lanesOnRoad =>
         handleLanes(lanesOnRoad, allLanes))
-      resultGroups ++ laneGroupsWithNoIdentifier.values
+      val noRoadAddress =laneGroupsWithNoIdentifier.values.flatten.map(lane => Seq(lane))
+      resultGroups ++ noRoadAddress
     }
     val (lanesOnOneDirectionLink, lanesOnTwoDirectionLink) = allLanes.partition(lane =>
       roadLinks(lane.linkId).trafficDirection.value != BothDirections.value)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -2,12 +2,12 @@ package fi.liikennevirasto.digiroad2.lane
 
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
-import fi.liikennevirasto.digiroad2.linearasset.{GraphPartitioner, RoadLink}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 
 import scala.annotation.tailrec
 
 
-object LanePartitioner extends GraphPartitioner {
+object LanePartitioner {
 
   case class LaneWithContinuingLanes(lane: PieceWiseLane, continuingLanes: Seq[PieceWiseLane])
 
@@ -124,7 +124,7 @@ object LanePartitioner extends GraphPartitioner {
       val (laneGroupsWithNoIdentifier, laneGroupsWithIdentifier) = lanesGrouped.partition(group => group._1._1.isEmpty)
       val lanesGroupedWithContinuing = laneGroupsWithIdentifier.map(lanesOnRoad => lanesOnRoad._2.map(lane => {
         val roadIdentifier = lanesOnRoad._1._1
-        val continuingLanes = getContinuingWithIdentifier(lane, roadIdentifier, allLanes, roadLinks)
+        val continuingLanes = getContinuingWithIdentifier(lane, roadIdentifier, lanes, roadLinks)
         LaneWithContinuingLanes(lane, continuingLanes)
       })).toSeq
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -16,12 +16,12 @@ object LanePartitioner {
                                   lanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink]): Seq[PieceWiseLane] = {
     lanes.filter(potentialLane =>
       potentialLane.endpoints.map(point =>
-      point.round()).exists(lane.endpoints.map(point =>
-      point.round()).contains)
-      && potentialLane.id != lane.id &&
-      laneRoadIdentifier == roadLinks(potentialLane.linkId).roadIdentifier &&
+        point.round()).exists(lane.endpoints.map(point =>
+        point.round()).contains)
+        && potentialLane.id != lane.id &&
+        laneRoadIdentifier == roadLinks(potentialLane.linkId).roadIdentifier &&
         potentialLane.laneAttributes.find(_.publicId == "lane_code") == lane.laneAttributes.find(_.publicId == "lane_code") &&
-    potentialLane.sideCode == lane.sideCode)
+        potentialLane.sideCode == lane.sideCode)
   }
 
   //Checks if the lanes sideCode is correct compared to previous lane.
@@ -45,13 +45,13 @@ object LanePartitioner {
     val connectionPoint = currentLane.endpoints.find(point =>
       point.round() == previousLane.endpoints.head.round() || point.round() == previousLane.endpoints.last.round())
     if(connectionPoint.isEmpty) currentLane
-    else{
+    else {
       val isSideCodeCorrect = sideCodeCorrect(previousLane, currentLane, connectionPoint.get)
 
       if (!isSideCodeCorrect) {
         val replacement = allLanes.find(replacementLane =>
           replacementLane.linkId == currentLane.linkId && replacementLane.sideCode != currentLane.sideCode &&
-        replacementLane.laneAttributes.find(_.publicId == "lane_code") == currentLane.laneAttributes.find(_.publicId == "lane_code"))
+          replacementLane.laneAttributes.find(_.publicId == "lane_code") == currentLane.laneAttributes.find(_.publicId == "lane_code"))
         replacement match {
           case Some(replacement) =>
             replacement

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
@@ -46,20 +46,6 @@ class LanePartitionerSpec extends FunSuite with Matchers {
     Seq(lane0, lane1,lane2,lane3,lane4,lane5)
   }
 
-  test("Lanes should be partitioned by side code and lanecode and roadLink trafficDirection") {
-    val lanes = createLanes()
-    val roadLink0 = createRoadLink(0l, Seq(Point(0.0,0.0), Point(1.0,1.0)), BothDirections,"testiKatu")
-    val roadLink1 = createRoadLink(1l, Seq(Point(4.0,4.0), Point(2.0,2.0)), TowardsDigitizing,"testiKatu")
-    val roadLinks = Seq(roadLink0, roadLink1).groupBy(_.linkId).mapValues(_.head)
-    val lanesPartitioned = partitionBySideCodeAndLaneCode(lanes, roadLinks)
-
-    lanesPartitioned.size should equal(9)
-    lanesPartitioned(0).size should equal(1)
-    lanesPartitioned(2).size should equal(2)
-    lanesPartitioned(3).size should equal(2)
-    lanesPartitioned(5).size should equal(0)
-  }
-
   test("Lanes should be partitioned to two groups according to correct sideCode") {
     val roadLink1 = createRoadLink(1, Seq(Point(0.0,0.0), Point(1.0, 1.0)), BothDirections, "testiKatu")
     val roadLink2 = createRoadLink(2, Seq(Point(1.0,1.0), Point(2.0, 2.0)), BothDirections, "testiKatu")


### PR DESCRIPTION
LanePartitioner tehty uusiksi, ilman geoToolsin käyttöä niin nyt ei tarvitse kikkailla ja varoa gt GraphPartitionerin bugeja. Kaistajoukkojen muodostaminen toimii nyt paremmin, eikä lisäkaistat aiheuta enää ongelmia.