### PR TITLE
Droth 3039 additional lanes draw fix

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -5,7 +5,6 @@ import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 
 import scala.annotation.tailrec
-import scala.math.Ordering.Implicits.seqDerivedOrdering
 
 
 object LanePartitioner {
@@ -14,15 +13,15 @@ object LanePartitioner {
 
   //Returns lanes continuing from from given lane
   def getContinuingWithIdentifier(lane: PieceWiseLane, laneRoadIdentifier: Option[Either[Int,String]],
-                                  lanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink]): Seq[PieceWiseLane] = {
-    lanes.filter(potentialLane =>
-      potentialLane.endpoints.map(point =>
-        point.round()).exists(lane.endpoints.map(point =>
-        point.round()).contains)
+                                  lanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink],
+                                  SideCodesCorrected: Boolean = false): Seq[PieceWiseLane] = {
+    val continuingLanes = lanes.filter(potentialLane =>
+      potentialLane.endpoints.map(_.round()).exists(lane.endpoints.map(_.round()).contains)
         && potentialLane.id != lane.id &&
         laneRoadIdentifier == roadLinks(potentialLane.linkId).roadIdentifier &&
-        potentialLane.laneAttributes.find(_.publicId == "lane_code") == lane.laneAttributes.find(_.publicId == "lane_code") &&
-        potentialLane.sideCode == lane.sideCode)
+        potentialLane.laneAttributes.find(_.publicId == "lane_code") == lane.laneAttributes.find(_.publicId == "lane_code"))
+    if(SideCodesCorrected) continuingLanes
+    else continuingLanes.filter(_.sideCode == lane.sideCode)
   }
 
   //Checks if the lanes sideCode is correct compared to previous lane.
@@ -75,6 +74,18 @@ object LanePartitioner {
     else startingLanes
   }
 
+  //replaces lane if its sideCode is not correct. SideCode is tied to digitizing direction,
+  //so two adjacent lanes with same sideCode can be on the opposite sides of the road
+  //Algorithm for replacing incorrect lanes:
+  // 1. Group lanes by roadIdentifier and sideCode
+  // 2. Find continuing lanes for each lane
+  // 3. Find starting lane (Lane which has only one continuing lane)
+  // 4. Compare starting lane to it's continuing lane
+  // 5. If sideCodes are equal and lanes' connection point is previous lane's ending point and
+  // current lane's starting point or vice versa then sideCode is OK
+  // 6. If not OK, find lane with same linkId and different sideCode compared to current lane
+  // and replace currentLane with it
+  // 7. Repeat steps 4 to 6 until there is no next lane
   def handleLanes(lanesOnRoad:Seq[LaneWithContinuingLanes], allLanes: Seq[PieceWiseLane]):Seq[PieceWiseLane] = {
       //Goes through roads lanes in order recursively. checkLane switches lane to other sideCode lane if necessary
       @tailrec
@@ -105,8 +116,9 @@ object LanePartitioner {
   }
 
   def getConnectedLanes(connectedLanes: Seq[LaneWithContinuingLanes], usedLanes: Seq[Long], laneGroup: Seq[LaneWithContinuingLanes]): Seq[LaneWithContinuingLanes] = {
+    val connectedIds = connectedLanes.map(_.lane.id)
     val nextLane = laneGroup.find(laneWithContinuing => { laneWithContinuing.continuingLanes.contains(connectedLanes.last.lane) &&
-      !usedLanes.contains(laneWithContinuing.lane.id)
+      !connectedIds.contains(laneWithContinuing.lane.id)
     })
     nextLane match {
       case Some(nextLane) => getConnectedLanes(connectedLanes :+ nextLane, usedLanes :+ nextLane.lane.id, laneGroup)
@@ -114,35 +126,18 @@ object LanePartitioner {
     }
   }
 
-  //replaces lane if its sideCode is not correct. SideCode is tied to digitizing direction,
-  //so two adjacent lanes with same sideCode can be on the opposite sides of the road
-  //Algorithm for replacing incorrect lanes:
-  // 1. Group lanes by roadIdentifier and sideCode
-  // 2. Find continuing lanes for each lane
-  // 3. Find starting lane (Lane which has only one continuing lane)
-  // 4. Compare starting lane to it's continuing lane
-  // 5. If sideCodes are equal and lanes' connection point is previous lane's ending point and
-  // current lane's starting point or vice versa then sideCode is OK
-  // 6. If not OK, find lane with same linkId and different sideCode compared to current lane
-  // and replace currentLane with it
-  // 7. Repeat steps 4 to 6 until there is no next lane
+  //Returns lanes grouped by corrected sideCode, laneCode, additional lanes and connection (lanes in group must
+  // be geometrically connected together)
   def partition(allLanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink]): Seq[Seq[PieceWiseLane]] = {
 
     //Groups lanes by roadIdentifier, sideCode, LaneCode, and other lanes on link.
-    //Makes sure that the selection is continuing and there are no gaps in lanes
+    //Makes sure that all the lanes in group are connected and there are no gaps in lane selection
     def groupLanes(lanes: Seq[PieceWiseLane]): Seq[Seq[PieceWiseLane]] = {
       val lanesGrouped = lanes.groupBy(lane => {
         val roadLink = roadLinks.get(lane.linkId)
         val roadIdentifier = roadLink.flatMap(_.roadIdentifier)
         val laneCode = lane.laneAttributes.find(_.publicId == "lane_code")
-
-        val lanesOnLink = lanes.filter(potentialLane => potentialLane.linkId == lane.linkId &&
-        potentialLane.sideCode == lane.sideCode)
-        val laneProperties = lanesOnLink.flatMap(_.laneAttributes.find(_.publicId == "lane_code"))
-        val lanePropValues = laneProperties.map(_.values)
-        val laneCodesOnLink = lanePropValues.flatten.map(_.value.asInstanceOf[Int]).sorted.distinct
-
-        (roadIdentifier, lane.sideCode, laneCode, laneCodesOnLink)
+        (roadIdentifier, lane.sideCode, laneCode)
       })
       val (laneGroupsWithNoIdentifier, laneGroupsWithIdentifier) = lanesGrouped.partition(group => group._1._1.isEmpty)
       val lanesGroupedWithContinuing = laneGroupsWithIdentifier.map(lanesOnRoad => lanesOnRoad._2.map(lane => {
@@ -151,19 +146,34 @@ object LanePartitioner {
         LaneWithContinuingLanes(lane, continuingLanes)
       })).toSeq
 
-      val connectedGroups = lanesGroupedWithContinuing.flatMap(laneGroup => {
+      val lanesGroupedWithCorrectSideCode = lanesGroupedWithContinuing.map(lanesOnRoad =>
+        handleLanes(lanesOnRoad, allLanes))
+
+      val partitionedByAdditional = lanesGroupedWithCorrectSideCode.flatMap(_.groupBy(lane => {
+        val lanesOnLink = lanes.filter(potentialLane => potentialLane.linkId == lane.linkId &&
+          potentialLane.sideCode == lane.sideCode)
+        val laneProperties = lanesOnLink.flatMap(_.laneAttributes.find(_.publicId == "lane_code"))
+        val lanePropValues = laneProperties.map(_.values)
+        val laneCodesOnLink = lanePropValues.flatten.map(_.value.asInstanceOf[Int]).sorted.distinct
+        laneCodesOnLink
+      }).values)
+
+      val partitionedLanesWithContinuing = partitionedByAdditional.map(laneGroup => laneGroup.map(lane => {
+        val roadIdentifier = roadLinks(lane.linkId).roadIdentifier
+        val continuingLanes = getContinuingWithIdentifier(lane, roadIdentifier, laneGroup, roadLinks, true)
+        LaneWithContinuingLanes(lane, continuingLanes)
+      }))
+
+      val connectedGroups = partitionedLanesWithContinuing.flatMap(laneGroup => {
         val startingLanes = getStartingLanes(laneGroup)
         val connectedLanes = startingLanes.map(startingLane => {
           getConnectedLanes(Seq(startingLane), Seq(startingLane.lane.id), laneGroup).sortBy(_.lane.id)
         }).distinct
-        connectedLanes
+        connectedLanes.map(_.map(_.lane))
       })
 
-      val resultGroup = connectedGroups.map(lanesOnRoad =>
-        handleLanes(lanesOnRoad, allLanes))
-
       val noRoadIdentifier = laneGroupsWithNoIdentifier.values.flatten.map(lane => Seq(lane))
-      resultGroup ++ noRoadIdentifier
+      connectedGroups ++ noRoadIdentifier
     }
     val (lanesOnOneDirectionLink, lanesOnTwoDirectionLink) = allLanes.partition(lane =>
       roadLinks(lane.linkId).trafficDirection.value != BothDirections.value)

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LanePartitionerSpec.scala
@@ -72,7 +72,7 @@ class LanePartitionerSpec extends FunSuite with Matchers {
 
     val lanesWithContinuing = Seq(LaneWithContinuingLanes(lane0, Seq(lane1)), LaneWithContinuingLanes(lane1, Seq(lane2, lane0)),
       LaneWithContinuingLanes(lane2, Seq(lane1)))
-    val startingLane = getStartingLane(lanesWithContinuing)
+    val startingLane = getStartingLanes(lanesWithContinuing).head
     Seq(lane0, lane2).contains(startingLane.lane) should equal(true)
   }
 
@@ -84,7 +84,7 @@ class LanePartitionerSpec extends FunSuite with Matchers {
 
     val lanesWithContinuing = Seq(LaneWithContinuingLanes(lane0, Seq(lane1, lane3)), LaneWithContinuingLanes(lane1, Seq(lane2, lane0)),
       LaneWithContinuingLanes(lane2, Seq(lane1, lane3)), LaneWithContinuingLanes(lane3, Seq(lane2, lane0)))
-    val startingLane = getStartingLane(lanesWithContinuing)
+    val startingLane = getStartingLanes(lanesWithContinuing).head
     startingLane should equal(lanesWithContinuing.head)
   }
 


### PR DESCRIPTION
Kaistajoukot muodostuvat nyt myös linkillä olevien lisäkaistojen mukaan, jotta lisäkaistojen muokkaus käyttöliittymässä olisi yksinkertaisempaa ja helpompaa. Valitussa joukossa on siis samat lisäkaistat. Parannettu kommentointia myös.
LanePartitioner toiminta:
1. Jaetaan kaistat kahteen joukkoon sen mukaan onko ne kaksi- vai yksisuuntaisella linkillä
2. Jaetaan kaistat joukkoihin tienumeron(tai nimen), sideCoden ja laneCoden mukaan
3. Päätellään joukon kaistoille oikeat sideCodet ja vaihdetaan tarvittaessa kaista oikean sideCoden kaistaan
4. Jaetaan kaistat lisäkaistojen mukaan joukkoihin (Luo mahdollisia "aukkoja" kaistajoukkoon)
5. Jaetaan kaistajoukko geometrialtaan vierekkäin oleviin, jotta aukkoja ei ole