### PR TITLE
DROTH-3050 added two-digit laneCode calculation, getChanges returns o…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -10,6 +10,7 @@ import fi.liikennevirasto.digiroad2.service.ChangedVVHRoadlink
 import fi.liikennevirasto.digiroad2.service.lane.LaneChange
 import fi.liikennevirasto.digiroad2.service.linearasset.{ChangedLinearAsset, ChangedSpeedLimit}
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.PersistedMassTransitStop
+import fi.liikennevirasto.digiroad2.util.LaneUtils.{roadLinkService, persistedLaneToTwoDigitLaneCode}
 import fi.liikennevirasto.digiroad2.vallu.ValluStoreStopChangeMessage._
 import fi.liikennevirasto.digiroad2.vallu.ValluTransformer.{describeEquipments, describeReachability, transformToISODate}
 import org.joda.time.DateTime
@@ -89,7 +90,7 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
       case "obstacles"                   => pointAssetsToGeoJson(since, obstacleService.getChanged(since, until, token), pointAssetGenericProperties)
       case "warning_signs_group"         => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(trafficSignService.getTrafficSignTypeByGroup(TrafficSignTypeGroup.GeneralWarningSigns), since, until, token), pointAssetWarningSignsGroupProperties)
       case "stop_sign"                   => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(Set(Stop.OTHvalue), since, until, token), pointAssetStopSignProperties)
-      case "lane_information"            => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token), withGeometry)
+      case "lane_information"            => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token).flatMap(laneChange => laneChangeLaneToTwoDigitLaneCode(laneChange)), withGeometry)
     }
   }
 
@@ -523,6 +524,19 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
         }
     )
 
+  def laneChangeLaneToTwoDigitLaneCode(laneChange: LaneChange): Option[LaneChange] = {
+    val twoDigitLane = persistedLaneToTwoDigitLaneCode(laneChange.lane)
+    twoDigitLane match {
+      case Some(_) => laneChange.oldLane match {
+        case Some(_) =>
+          val twoDigitOldLane = persistedLaneToTwoDigitLaneCode(laneChange.oldLane.get)
+          Some(laneChange.copy(lane = twoDigitLane.get, oldLane = twoDigitOldLane))
+        case _ => Some(laneChange.copy(lane = twoDigitLane.get))
+      }
+      case _ => None
+    }
+  }
+
   def laneChangesToGeoJson(laneChanges: Seq[LaneChange], withGeometry: Boolean = false): Map[String, Any] = {
     def decodePropertyValue(value: Any): String = {
       value match {
@@ -542,8 +556,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
     }
 
     def mapLaneAddressInfo(lane: PersistedLane, roadLink: RoadLink) = {
-      val roadStartAddr = roadLink.attributes.getOrElse("VIITE_START_ADDR", roadLink.attributes.get("TEMP_START_ADDR")).toString.toDouble
-      val roadEndAddr = roadLink.attributes.getOrElse("VIITE_END_ADDR", roadLink.attributes.get("TEMP_END_ADDR")).toString.toDouble
+      val roadStartAddr = roadLink.attributes.getOrElse("VIITE_START_ADDR", roadLink.attributes.get("TEMP_START_ADDR").get).toString.toDouble
+      val roadEndAddr = roadLink.attributes.getOrElse("VIITE_END_ADDR", roadLink.attributes.get("TEMP_END_ADDR").get).toString.toDouble
 
       val laneStartAddr = roadStartAddr + lane.startMeasure
       val laneEndAddr = roadEndAddr - (roadLink.length - lane.endMeasure)

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -556,8 +556,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
     }
 
     def mapLaneAddressInfo(lane: PersistedLane, roadLink: RoadLink) = {
-      val roadStartAddr = roadLink.attributes.getOrElse("VIITE_START_ADDR", roadLink.attributes.get("TEMP_START_ADDR").get).toString.toDouble
-      val roadEndAddr = roadLink.attributes.getOrElse("VIITE_END_ADDR", roadLink.attributes.get("TEMP_END_ADDR").get).toString.toDouble
+      val roadStartAddr = roadLink.attributes.getOrElse("VIITE_START_ADDR", roadLink.attributes("TEMP_START_ADDR")).toString.toDouble
+      val roadEndAddr = roadLink.attributes.getOrElse("VIITE_END_ADDR", roadLink.attributes("TEMP_END_ADDR")).toString.toDouble
 
       val laneStartAddr = roadStartAddr + lane.startMeasure
       val laneEndAddr = roadEndAddr - (roadLink.length - lane.endMeasure)


### PR DESCRIPTION
ChangeApi laitettu toimimaan velho-yhteensopivaksi. Rajapinnalle tuodaan vain tieosoitteellisten kaistojen muutostiedot (tieosoitetiedot joko Viite tai temp_road_address_info taulusta), ja kaistoille lasketaan kaksinumeroinen kaistakoodi ennen muutossanoman lähettämistä VKM avulla.