### PR TITLE
Droth 3061 delete updated traffic direction from db

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -239,11 +239,7 @@ object RoadLinkDAO{
 
     }
 
-    /*def getLinkIds(): Seq[Long] = {
-      sql"""select link_id from traffic_direction""".as[(Seq[Long])]
-    }*/
-
-    def getLinkIds2(): Seq[Long] = {
+    def getLinkIds(): Seq[Long] = {
       sql"""select link_id from traffic_direction""".as[Long].list
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.dao
 import fi.liikennevirasto.digiroad2.asset
 import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
 import fi.liikennevirasto.digiroad2.client.vvh.VVHRoadlink
-import fi.liikennevirasto.digiroad2.postgis.MassQuery
+import fi.liikennevirasto.digiroad2.postgis.{MassQuery, PostGISDatabase}
 import fi.liikennevirasto.digiroad2.service.LinkProperties
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.StaticQuery.interpolation
@@ -237,6 +237,14 @@ object RoadLinkDAO{
                    link_type = ${linkProperty.linkType.value}
                where link_id = ${linkProperty.linkId}""".execute
 
+    }
+
+    /*def getLinkIds(): Seq[Long] = {
+      sql"""select link_id from traffic_direction""".as[(Seq[Long])]
+    }*/
+
+    def getLinkIds2(): Seq[Long] = {
+      sql"""select link_id from traffic_direction""".as[Long].list
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2662,6 +2662,8 @@ object DataFixture {
         MainLanePopulationProcess.process()
       case Some("initial_main_lane_population") =>
         MainLanePopulationProcess.initialProcess()
+      case Some("redundant_traffic_direction_removal") =>
+        RedundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
       case _ => println("Usage: DataFixture test | import_roadlink_data |" +
         " split_speedlimitchains | split_linear_asset_chains | dropped_assets_csv | dropped_manoeuvres_csv |" +
         " unfloat_linear_assets | expire_split_assets_without_mml | generate_values_for_lit_roads | get_addresses_to_masstransitstops_from_vvh |" +

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2680,7 +2680,7 @@ object DataFixture {
         " load_municipalities_verification_info | import_private_road_info | normalize_user_roles | get_state_roads_with_overridden_functional_class | get_state_roads_with_undefined_functional_class |" +
         " add_obstacles_shapefile | merge_municipalities | transform_lorry_parking_into_datex2 | fill_new_roadLinks_info | update_last_modified_assets_info | import_cycling_walking_info |" +
         " create_roadWorks_using_traffic_signs | extract_csv_private_road_association_info | restore_expired_assets_from_TR_import | move_old_expired_assets | new_road_address_from_viite | change_lanes_according_to_VVH_changes |" +
-        " validate_lane_changes_according_to_VVH_changes | populate_new_link_with_main_lanes | initial_main_lane_population")
+        " validate_lane_changes_according_to_VVH_changes | populate_new_link_with_main_lanes | initial_main_lane_population | redundant_traffic_direction_removal")
 
 
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -201,6 +201,8 @@ object DataFixture {
 
   lazy val municipalityService: MunicipalityService = new MunicipalityService
 
+  lazy val redundantTrafficDirectionRemoval = new RedundantTrafficDirectionRemoval(roadLinkService)
+
   def importMunicipalityCodes() {
     println("\nCommencing municipality code import at time: ")
     println(DateTime.now())
@@ -2663,7 +2665,6 @@ object DataFixture {
       case Some("initial_main_lane_population") =>
         MainLanePopulationProcess.initialProcess()
       case Some("redundant_traffic_direction_removal") =>
-        val redundantTrafficDirectionRemoval = new RedundantTrafficDirectionRemoval(roadLinkService)
         redundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
       case _ => println("Usage: DataFixture test | import_roadlink_data |" +
         " split_speedlimitchains | split_linear_asset_chains | dropped_assets_csv | dropped_manoeuvres_csv |" +

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2663,7 +2663,8 @@ object DataFixture {
       case Some("initial_main_lane_population") =>
         MainLanePopulationProcess.initialProcess()
       case Some("redundant_traffic_direction_removal") =>
-        RedundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
+        val redundantTrafficDirectionRemoval = new RedundantTrafficDirectionRemoval(roadLinkService)
+        redundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
       case _ => println("Usage: DataFixture test | import_roadlink_data |" +
         " split_speedlimitchains | split_linear_asset_chains | dropped_assets_csv | dropped_manoeuvres_csv |" +
         " unfloat_linear_assets | expire_split_assets_without_mml | generate_values_for_lit_roads | get_addresses_to_masstransitstops_from_vvh |" +

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -20,7 +20,7 @@ object RedundantTrafficDirectionRemoval {
   def deleteRedundantTrafficDirectionFromDB(): Unit = {
     withDynTransaction {
       val linkIds = RoadLinkDAO.TrafficDirectionDao.getLinkIds().toSet
-      val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds = linkIds)
+      val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds)
       vvhRoadlinks.foreach(vvhRoadLink => findAndDeleteRedundant(vvhRoadLink))
     }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -4,10 +4,7 @@ import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
 import fi.liikennevirasto.digiroad2.client.vvh.{VVHClient, VVHRoadlink}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.dao.RoadLinkDAO
-import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import slick.jdbc.StaticQuery
-import slick.jdbc.StaticQuery.interpolation
 
 object RedundantTrafficDirectionRemoval {
   lazy val vvhClient: VVHClient = {
@@ -18,27 +15,26 @@ object RedundantTrafficDirectionRemoval {
     new RoadLinkService(vvhClient, new DummyEventBus, new DummySerializer)
   }
 
-  def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
   def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
 
   def deleteRedundantTrafficDirectionFromDB(): Unit = {
-    //withDynTransaction {
-      val linkIds = PostGISDatabase.withDynSession(RoadLinkDAO.TrafficDirectionDao.getLinkIds2())
-      //val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds = linkIds)
-      //vvhRoadlinks.foreach(vvhRoadLink => findAndDeleteRedundant(vvhRoadLink))
+    withDynTransaction {
+      val linkIds = RoadLinkDAO.TrafficDirectionDao.getLinkIds().toSet
+      val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds = linkIds)
+      vvhRoadlinks.foreach(vvhRoadLink => findAndDeleteRedundant(vvhRoadLink))
+    }
 
-      def findAndDeleteRedundant(vvhRoadlink: VVHRoadlink): Unit = {
-        val optionalExistingValue: Option[Int] = RoadLinkDAO.get("traffic_direction", vvhRoadlink.linkId)
-        val optionalVVHValue: Option[Int] = RoadLinkDAO.getVVHValue("traffic_direction", vvhRoadlink)
-        (optionalExistingValue, optionalVVHValue) match {
-          case (Some(existingValue), Some(vvhValue)) =>
-            if (existingValue == vvhValue) {
-              RoadLinkDAO.delete("traffic_direction", vvhRoadlink.linkId)
-            }
-          case (_, _) =>
+    def findAndDeleteRedundant(vvhRoadlink: VVHRoadlink): Unit = {
+      val optionalExistingValue: Option[Int] = RoadLinkDAO.get("traffic_direction", vvhRoadlink.linkId)
+      val optionalVVHValue: Option[Int] = RoadLinkDAO.getVVHValue("traffic_direction", vvhRoadlink)
+      (optionalExistingValue, optionalVVHValue) match {
+        case (Some(existingValue), Some(vvhValue)) =>
+          if (existingValue == vvhValue) {
+            RoadLinkDAO.delete("traffic_direction", vvhRoadlink.linkId)
+          }
+        case (_, _) =>
           //do nothing
-        }
       }
     }
-  //}
+  }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -1,19 +1,11 @@
 package fi.liikennevirasto.digiroad2.util
 
-import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
-import fi.liikennevirasto.digiroad2.client.vvh.{VVHClient, VVHRoadlink}
+import fi.liikennevirasto.digiroad2.client.vvh.VVHRoadlink
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.dao.RoadLinkDAO
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 
-object RedundantTrafficDirectionRemoval {
-  lazy val vvhClient: VVHClient = {
-    new VVHClient(Digiroad2Properties.vvhRestApiEndPoint)
-  }
-
-  lazy val roadLinkService: RoadLinkService = {
-    new RoadLinkService(vvhClient, new DummyEventBus, new DummySerializer)
-  }
+class RedundantTrafficDirectionRemoval(roadLinkService: RoadLinkService) {
 
   def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -1,0 +1,44 @@
+package fi.liikennevirasto.digiroad2.util
+
+import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
+import fi.liikennevirasto.digiroad2.client.vvh.{VVHClient, VVHRoadlink}
+import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.dao.RoadLinkDAO
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import slick.jdbc.StaticQuery
+import slick.jdbc.StaticQuery.interpolation
+
+object RedundantTrafficDirectionRemoval {
+  lazy val vvhClient: VVHClient = {
+    new VVHClient(Digiroad2Properties.vvhRestApiEndPoint)
+  }
+
+  lazy val roadLinkService: RoadLinkService = {
+    new RoadLinkService(vvhClient, new DummyEventBus, new DummySerializer)
+  }
+
+  def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
+  def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
+
+  def deleteRedundantTrafficDirectionFromDB(): Unit = {
+    //withDynTransaction {
+      val linkIds = PostGISDatabase.withDynSession(RoadLinkDAO.TrafficDirectionDao.getLinkIds2())
+      //val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds = linkIds)
+      //vvhRoadlinks.foreach(vvhRoadLink => findAndDeleteRedundant(vvhRoadLink))
+
+      def findAndDeleteRedundant(vvhRoadlink: VVHRoadlink): Unit = {
+        val optionalExistingValue: Option[Int] = RoadLinkDAO.get("traffic_direction", vvhRoadlink.linkId)
+        val optionalVVHValue: Option[Int] = RoadLinkDAO.getVVHValue("traffic_direction", vvhRoadlink)
+        (optionalExistingValue, optionalVVHValue) match {
+          case (Some(existingValue), Some(vvhValue)) =>
+            if (existingValue == vvhValue) {
+              RoadLinkDAO.delete("traffic_direction", vvhRoadlink.linkId)
+            }
+          case (_, _) =>
+          //do nothing
+        }
+      }
+    }
+  //}
+}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
@@ -19,22 +19,28 @@ class RedundantTrafficDirectionRemovalSpec extends FunSuite with Matchers {
   def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
 
   test("A redundant traffic direction is removed, but a valid is not") {
+    val linkSet = PostGISDatabase.withDynTransaction(roadLinkService.fetchVVHRoadlinks(Set(1681765,1611347,1611181,1611380,1611265,1610928,1611183,1611675,1610953,1611480)))
+    if (linkSet.isEmpty) {
+      cancel("No roadlinks found, so test canceled.")
+    }
+    val linkWithRedundantTrafficDirection = linkSet.head
     withDynTransaction {
-      RoadLinkDAO.insert("traffic_direction", 1681765, None, 2)
-      // the second traffic direction is set so that it can't incidentally match with VVH traffic direction value
+      // put the vvh value of the first received link to the traffic direction table, so that it's certainly redundant
+      RoadLinkDAO.insert("traffic_direction", linkWithRedundantTrafficDirection.linkId, None, linkWithRedundantTrafficDirection.trafficDirection.value)
+      // the second traffic direction is set as 10 that it can't incidentally match with any VVH traffic direction value
       RoadLinkDAO.insert("traffic_direction", 6510465, None, 10)
       val linkIdsBeforeRemoval = RoadLinkDAO.TrafficDirectionDao.getLinkIds()
-      linkIdsBeforeRemoval should contain(1681765)
+      linkIdsBeforeRemoval should contain(linkWithRedundantTrafficDirection.linkId)
       linkIdsBeforeRemoval should contain(6510465)
     }
     RedundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
     withDynTransaction {
       val linkIdsAfterRemoval = RoadLinkDAO.TrafficDirectionDao.getLinkIds()
-      linkIdsAfterRemoval should not contain(1681765)
+      linkIdsAfterRemoval should not contain  linkWithRedundantTrafficDirection.linkId
       linkIdsAfterRemoval should contain(6510465)
       RoadLinkDAO.delete("traffic_direction", 6510465)
       val linkIdsAfterCleanUp = RoadLinkDAO.TrafficDirectionDao.getLinkIds()
-      linkIdsAfterCleanUp should not contain(6510465)
+      linkIdsAfterCleanUp should not contain 6510465
     }
   }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
@@ -19,7 +19,7 @@ class RedundantTrafficDirectionRemovalSpec extends FunSuite with Matchers {
   def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
 
   test("A redundant traffic direction is removed, but a valid is not") {
-    val linkSet = PostGISDatabase.withDynTransaction(roadLinkService.fetchVVHRoadlinks(Set(1681765,1611347,1611181,1611380,1611265,1610928,1611183,1611675,1610953,1611480)))
+    val linkSet = roadLinkService.fetchVVHRoadlinks(Set(1681765,1611347,1611181,1611380,1611265,1610928,1611183,1611675,1610953,1611480))
     if (linkSet.isEmpty) {
       cancel("No roadlinks found, so test canceled.")
     }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
@@ -1,0 +1,40 @@
+package fi.liikennevirasto.digiroad2.util
+
+import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
+import fi.liikennevirasto.digiroad2.client.vvh.VVHClient
+import fi.liikennevirasto.digiroad2.dao.RoadLinkDAO
+import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import org.scalatest.{FunSuite, Matchers}
+
+class RedundantTrafficDirectionRemovalSpec extends FunSuite with Matchers {
+  lazy val vvhClient: VVHClient = {
+    new VVHClient(Digiroad2Properties.vvhRestApiEndPoint)
+  }
+
+  lazy val roadLinkService: RoadLinkService = {
+    new RoadLinkService(vvhClient, new DummyEventBus, new DummySerializer)
+  }
+
+  def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
+
+  test("A redundant traffic direction is removed, but a valid is not") {
+    withDynTransaction {
+      RoadLinkDAO.insert("traffic_direction", 1681765, None, 2)
+      // the second traffic direction is set so that it can't incidentally match with VVH traffic direction value
+      RoadLinkDAO.insert("traffic_direction", 6510465, None, 10)
+      val linkIdsBeforeRemoval = RoadLinkDAO.TrafficDirectionDao.getLinkIds()
+      linkIdsBeforeRemoval should contain(1681765)
+      linkIdsBeforeRemoval should contain(6510465)
+    }
+    RedundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
+    withDynTransaction {
+      val linkIdsAfterRemoval = RoadLinkDAO.TrafficDirectionDao.getLinkIds()
+      linkIdsAfterRemoval should not contain(1681765)
+      linkIdsAfterRemoval should contain(6510465)
+      RoadLinkDAO.delete("traffic_direction", 6510465)
+      val linkIdsAfterCleanUp = RoadLinkDAO.TrafficDirectionDao.getLinkIds()
+      linkIdsAfterCleanUp should not contain(6510465)
+    }
+  }
+}


### PR DESCRIPTION
Ensiksi haetaan kaikkien traffic_direction-taulussa olevien linkkien id:t ja linkkejä vastaavat vvh-linkit. Sitten verrataan, onko linkin liikennesuunta sama sekä traffic_direction-taulussa että vvh-linkissä. Jos liikennesuunta on sama, tieto poistetaan traffic_direction taulusta.

Testi lisää tietokantaan sekä poistettavan että validin liikennesuunnan, kutsuu poiston suorittavaa funktiota, varmistaa, että vain poistettava liikennesuunta on poistettu ja lopuksi siivoaa myös toisen lisätyn suunnan kannasta.