### PR TITLE
Droth 3051 velho lane api

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -214,10 +214,10 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
     val lanesWithRoadAddress = lanesWithViiteAddress ++ lanesWithTempAddress
 
     val lanesWithNormalRoadAddress = lanesWithRoadAddress.map(lane => {
-      val roadNumber = lane.attributes.getOrElse("VIITE_ROAD_NUMBER", "TEMP_ROAD_NUMBER")
-      val roadPartNumber = lane.attributes.getOrElse("VIITE_ROAD_PART_NUMBER", "TEMP_ROAD_PART_NUMBER")
-      val startAddr = lane.attributes.getOrElse("VIITE_START_ADDR", "TEMP_START_ADDR")
-      val endAddr = lane.attributes.getOrElse("VIITE_END_ADDR", "TEMP_END_ADDR")
+      val roadNumber = lane.attributes.getOrElse("VIITE_ROAD_NUMBER", lane.attributes.get("TEMP_ROAD_NUMBER"))
+      val roadPartNumber = lane.attributes.getOrElse("VIITE_ROAD_PART_NUMBER", lane.attributes.get("TEMP_ROAD_PART_NUMBER"))
+      val startAddr = lane.attributes.getOrElse("VIITE_START_ADDR", lane.attributes.get("TEMP_START_ADDR"))
+      val endAddr = lane.attributes.getOrElse("VIITE_END_ADDR", lane.attributes.get("TEMP_END_ADDR"))
       lane.copy(attributes = lane.attributes + ("ROAD_NUMBER" -> roadNumber, "ROAD_PART_NUMBER" -> roadPartNumber,
         "START_ADDR" -> startAddr, "END_ADDR" -> endAddr))
     })
@@ -268,7 +268,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
   }
 
   private def roadLinkPropertiesToApi(roadLinks: Seq[RoadLink]): Seq[Map[String, Any]] = {
-    val result = roadLinks.map { roadLink =>
+    roadLinks.map { roadLink =>
       Map("linkId" -> roadLink.linkId,
         "mmlId" -> roadLink.attributes.get("MTKID"),
         "administrativeClass" -> roadLink.administrativeClass.value,
@@ -294,7 +294,6 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
                                                                                               .filterNot(_._1 == "PRIVATE_ROAD_ASSOCIATION")
                                                                                               .filterNot(_._1 == "ADDITIONAL_INFO")
     }
-    result
   }
 
   def toTimeDomain(validityPeriod: ValidityPeriod): String = {

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -268,4 +268,8 @@ class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter
 
   }
 
+  test("lanesToApi test"){
+    integrationApi.lanesToApi(Lanes.typeId, 235)
+  }
+
 }

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -269,7 +269,7 @@ class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter
   }
 
   test("lanesToApi test"){
-    integrationApi.lanesToApi(Lanes.typeId, 235)
+    integrationApi.lanesToApi(235)
   }
 
 }

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -268,8 +268,4 @@ class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter
 
   }
 
-  test("lanesToApi test"){
-    integrationApi.lanesToApi(235)
-  }
-
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -5,7 +5,7 @@ import java.security.cert.X509Certificate
 import fi.liikennevirasto.digiroad2.asset.SideCode
 import fi.liikennevirasto.digiroad2.util._
 import fi.liikennevirasto.digiroad2.{Feature, FeatureCollection, Point, Vector3d}
-import org.apache.http.NameValuePair
+import org.apache.http.{HttpStatus, NameValuePair}
 import org.apache.http.client.config.{CookieSpecs, RequestConfig}
 import org.apache.http.client.entity.UrlEncodedFormEntity
 
@@ -18,6 +18,7 @@ import org.apache.http.params.HttpParams
 import org.json4s.jackson.JsonMethods.parse
 import org.json4s.jackson.Serialization
 import org.json4s.{DefaultFormats, Formats, StreamInput}
+
 import java.util.ArrayList
 
 class VKMClient {
@@ -61,7 +62,7 @@ class VKMClient {
 
     val response = client.execute(request)
     try {
-      if (response.getStatusLine.getStatusCode >= 400)
+      if (response.getStatusLine.getStatusCode >= HttpStatus.SC_BAD_REQUEST)
         return Right(VKMError(Map("error" -> "Request returned HTTP Error %d".format(response.getStatusLine.getStatusCode)), url))
       val aux = response.getEntity.getContent
       val content: FeatureCollection = parse(StreamInput(aux)).extract[FeatureCollection]

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -1033,9 +1033,7 @@ trait LaneOperations {
           case 2 if startingPointM < endingPointM => 1
           case 3 if startingPointM > endingPointM => 1
           case 3 if startingPointM < endingPointM => 2
-          case _ => 9
         }
-        if(firstDigit == 9)println("ID: " + pwLane.id + "linkkiID: " + pwLane.linkId)
         val oldLaneCode = pwLane.laneAttributes.find(_.publicId == "lane_code").get.values.head.value.toString
         val newLaneCode = firstDigit.toString.concat(oldLaneCode).toInt
         Option(newLaneCode)


### PR DESCRIPTION
IntegraatioAPI:in toteutettu kaikki kunnan kaistat palauttava rajapinta Velholle. Kaksinumeroista kaistakoodimuunnosta varten luotu vkmClientille json-parametria käyttävä haku. Kaistatiedoista muodostetaan jatkuvat pätkät kaistakoodin mukaan tieosanumeron alueella, ja kaistatieto viedään Velholle vaihtoehto C:n mukaisessa muodossa https://extranet.vayla.fi/wiki/display/DROTH/Kalpa+API+-+kaistatietojen+lataus
VKM hitausongelmista päästy eroon json-parametri haun avulla.

