### PR TITLE
DROTH-3028 corrected viite endpoint to use aws QA viite not on-prem QA

### DIFF
--- a/aws/task-definition/dev/task-definition.json
+++ b/aws/task-definition/dev/task-definition.json
@@ -64,7 +64,7 @@
           },
           {
             "name": "viiteRestApiEndPoint",
-            "value": "https://testiextranet.liikennevirasto.fi/viite/api/viite/"
+            "value": "https://api.testivaylapilvi.fi/viite/api/viite/"
           },
           {
             "name": "authenticationTestMode",


### PR DESCRIPTION
Korjattu vahingossa asetettu väärä endpoint. Vaihdettu on-prem QA viite aws QA viitteeseen.