### PR TITLE
Droth 3062 update lanes when traffic direction is updated

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
@@ -282,7 +282,7 @@ class LaneDao(val vvhClient: VVHClient, val roadLinkService: RoadLinkService ){
                         else laneProp.values.head.value.toString
 
     sqlu"""INSERT INTO lane_attribute (id, lane_id, name, value, created_date, created_by)
-         VALUES( $laneAttributeId, $laneId, ${laneProp.publicId}, $laneAttrValue, current_timestamp, $username)
+          VALUES( $laneAttributeId, $laneId, ${laneProp.publicId}, $laneAttrValue, current_timestamp, $username)
     """.execute
 
     laneAttributeId

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
@@ -282,7 +282,7 @@ class LaneDao(val vvhClient: VVHClient, val roadLinkService: RoadLinkService ){
                         else laneProp.values.head.value.toString
 
     sqlu"""INSERT INTO lane_attribute (id, lane_id, name, value, created_date, created_by)
-          VALUES( $laneAttributeId, $laneId, ${laneProp.publicId}, $laneAttrValue, current_timestamp, $username)
+         VALUES( $laneAttributeId, $laneId, ${laneProp.publicId}, $laneAttrValue, current_timestamp, $username)
     """.execute
 
     laneAttributeId
@@ -426,4 +426,24 @@ class LaneDao(val vvhClient: VVHClient, val roadLinkService: RoadLinkService ){
     """.execute
   }
 
+  def expireLaneByLaneId(laneId: Long, username: Option[String]) = {
+    sqlu"""
+       UPDATE LANE SET
+         VALID_TO = current_timestamp,
+         EXPIRED_DATE = current_timestamp,
+         EXPIRED_BY = $username
+       WHERE ID = $laneId
+    """.execute
+  }
+
+  def reuseExpiredLane(laneId: Long) = {
+    sqlu"""
+       UPDATE LANE SET
+         VALID_FROM = current_timestamp,
+         VALID_TO = NULL,
+         EXPIRED_DATE = NULL,
+         EXPIRED_BY = NULL
+       WHERE ID = $laneId
+    """.execute
+  }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -19,6 +19,7 @@ import fi.liikennevirasto.digiroad2.util._
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.client.Caching
 import fi.liikennevirasto.digiroad2.dao.RoadLinkDAO.LinkAttributesDao
+import fi.liikennevirasto.digiroad2.service.lane.LaneService
 import fi.liikennevirasto.digiroad2.util.ChangeLanesAccordingToVvhChanges.vvhClient
 import org.joda.time.format.{DateTimeFormat, ISODateTimeFormat}
 import org.joda.time.{DateTime, DateTimeZone}
@@ -122,6 +123,8 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
       RoadLinkAttributeInfo(id, linkId, name, value, createdDate, createdBy, modifiedDate, modifiedBy)
     }
   }
+
+  lazy val laneService = new LaneService(this, eventbus)
 
   /**
     * ATENTION Use this method always with transation not with session
@@ -739,6 +742,10 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
       case (None, Some(vvhValue)) =>
         if (vvhValue != RoadLinkDAO.getValue(propertyName, linkProperty)) // only save if it overrides VVH provided value
           insertLinkProperty(propertyName, linkProperty, vvhRoadLink, username, latestModifiedAt, latestModifiedBy)
+    }
+
+    if (propertyName == "traffic_direction") {
+      laneService.updateTrafficDirectionChange(linkProperty, username)
     }
   }
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -50,6 +50,7 @@ class LaneTestSupporter extends FunSuite with Matchers {
                                 LaneProperty("lane_type", Seq(LanePropertyValue("2"))),
                                 LaneProperty("start_date", Seq(LanePropertyValue(DateTime.now().toString("dd.MM.yyyy"))))
                               )
+
   val lanePropertiesValues4 = Seq(LaneProperty("lane_code", Seq(LanePropertyValue(4))),
                                    LaneProperty("lane_type", Seq(LanePropertyValue("3"))),
                                    LaneProperty("start_date", Seq(LanePropertyValue(DateTime.now().toString("dd.MM.yyyy"))))


### PR DESCRIPTION
Toiminto kaistojen päivittämiseen liikennesuunnan muutoksen jälkeen. Toimii yksi- ja kaksikaistaisilla teillä. Jos käytössä olevien kaistojen määrä on eri, niin toiminnallisuutta ei suoriteta.

Kaksikaistaiset tiet:

Muutos kaksisuuntaisesta yksisuuntaiseksi (muutettavien kaistojen määrä = 1): Vastakkaisen kaistan tilalle uuden liikennesuunnan mukainen lisäkaista.

Yksisuuntaisen suunnan kääntö (muutettavien kaistojen määrä = 2): Molempien kaistojen tilalle uuden suunnan mukaiset kaistat (pääkaista ja lisäkaista).

Yksisuuntaiset tiet: Vanhan kaistan tilalle uuden liikennesuunnan mukainen lisäkaista.

Kaistojen luonti:
* lisäkaistat lanecodella 2
* tarkistetaan, onko käyttötarkoitukseen sopivaa expiroitua kaistaa
* kaistan muut tiedot (alkupiste, loppupiste yms.) kopioidaan expiroitavasta kaistasta

Testit testaavat kuusi eri tapausta uuden kaistan luonnilla sekä kaksi tapausta kaistan uudelleen käyttöönotolla. Lisäksi testataan, että kaistamuutoksia ei tehdä, jos liikennesuuntaa ei muuteta (eli muutetaan hallinnollista luokkaa tms.)
