### PR TITLE
Droth 3076 address space lane api

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -1,24 +1,16 @@
 package fi.liikennevirasto.digiroad2
 
-import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Digiroad2Context._
-import fi.liikennevirasto.digiroad2.Digiroad2Context.laneService.lanesWithConsistentRoadAddress
-import fi.liikennevirasto.digiroad2.Digiroad2Context.roadLinkService.{getRoadLinksAndChangesFromVVHWithPolygon, roadLinksWithConsistentAddress}
 import fi.liikennevirasto.digiroad2.asset.DateParser._
 import fi.liikennevirasto.digiroad2.asset.{HeightLimit => HeightLimitInfo, WidthLimit => WidthLimitInfo, _}
-import fi.liikennevirasto.digiroad2.client.VKMClient
 import fi.liikennevirasto.digiroad2.client.vvh.VVHRoadNodes
 import fi.liikennevirasto.digiroad2.dao.pointasset._
-import fi.liikennevirasto.digiroad2.lane.LanePartitioner.{LaneWithContinuingLanes, getConnectedLanes, getStartingLanes}
-import fi.liikennevirasto.digiroad2.lane.{LanePartitioner, PieceWiseLane}
 import fi.liikennevirasto.digiroad2.linearasset.ValidityPeriodDayOfWeek.{Saturday, Sunday}
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.linearasset.{ChangedSpeedLimit, LinearAssetOperations, Manoeuvre}
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.{MassTransitStopService, PersistedMassTransitStop}
 import fi.liikennevirasto.digiroad2.service.pointasset.{HeightLimit, _}
-import fi.liikennevirasto.digiroad2.util.{LaneUtils, LogUtils, PolygonTools, RoadAddress, Track}
 import org.joda.time.DateTime
-import org.joda.time.format.DateTimeFormat
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.swagger.{Swagger, SwaggerSupport}

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -1,0 +1,198 @@
+package fi.liikennevirasto.digiroad2
+
+import fi.liikennevirasto.digiroad2.Digiroad2Context.laneService.lanesWithConsistentRoadAddress
+import fi.liikennevirasto.digiroad2.Digiroad2Context.roadLinkService.{getRoadLinksAndChangesFromVVHWithPolygon, roadLinksWithConsistentAddress}
+import fi.liikennevirasto.digiroad2.Digiroad2Context.{laneService, roadAddressService, roadLinkService}
+import fi.liikennevirasto.digiroad2.client.VKMClient
+import fi.liikennevirasto.digiroad2.lane.LanePartitioner.{LaneWithContinuingLanes, getConnectedLanes, getStartingLanes}
+import fi.liikennevirasto.digiroad2.lane.{LanePartitioner, PieceWiseLane}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import fi.liikennevirasto.digiroad2.util.{PolygonTools, RoadAddress, Track}
+import org.json4s.{DefaultFormats, Formats}
+import org.scalatra.ScalatraServlet
+import org.scalatra.json.JacksonJsonSupport
+import org.scalatra.swagger.{Swagger, SwaggerSupport}
+
+class LaneApi (val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupport with SwaggerSupport {
+  lazy val vkmClient = new VKMClient
+  lazy val polygonTools = new PolygonTools
+  case class ApiRoad(roadNumber: Long, roadParts: Seq[ApiRoadPart])
+  case class ApiRoadPart(roadNumber: Option[Long], roadPartNumber: Long, lanes: Seq[ApiLane])
+  case class ApiLane(laneCode: Int, startAddressM: Long, endAddressM: Long)
+  override protected def applicationDescription: String = "Lanes API"
+  override protected implicit def jsonFormats: Formats = DefaultFormats
+
+  //Description of Api entry point to get all lanes in specific road address range in road address format
+  val getLanesInRoadAddressRange =
+    (apiOperation[Long]("getLanesInRoadAddressRange")
+      .parameters(
+        queryParam[Int]("roadNumber").description("Road Number for the range"),
+        queryParam[Int]("track").description("Track code for search"),
+        queryParam[Int]("startRoadPartNumber").description("Starting road part number for search"),
+        queryParam[Int]("startAddrM").description("Starting distance on starting roadPart for search"),
+        queryParam[Int]("endRoadPartNumber").description("Ending road part number for search"),
+        queryParam[Int]("endAddrM").description("Ending distance on last road part for search"),
+        pathParam[String]("lanes_in_range").description("Get lanes in given range")
+      )
+      tags "LaneApi"
+      summary "Get lanes in given road address range in road address format"
+      authorizations "Contact your service provider for more information"
+      description "Example URL: /externalApi/lanes/lanes_in_range?road_number=9&track=1&star_part=208&start_addr=8500&end_part=208&end_addr=9000"
+      )
+
+  //Description of Api entry point to get all lanes in specific road address range
+  val getLanesInMunicipality =
+    (apiOperation[Long]("getLanesInMunicipality")
+      .parameters(
+        queryParam[Int]("municipality").description("Municipality Code where we will execute the search by specific asset type"),
+        pathParam[String]("lanes_in_municipality").description("Asset type name to get all assets")
+      )
+      tags "LaneApi"
+      summary "Get lanes in given municipality"
+      authorizations "Contact your service provider for more information"
+      description "Example URL: /externalApi/lanes/lanes_in_municipality?municipality=235"
+      )
+
+  get("/lanes_in_range", operation(getLanesInRoadAddressRange)) {
+    contentType = formats("json")+ "; charset=utf-8"
+    val roadNumber = params("road_number").toLong
+    val track = Track(params("track").toInt)
+    val startRoadPartNumber = params("star_part").toLong
+    val startAddrM = params("start_addr").toLong
+    val endRoadPartNumber = params("end_part").toLong
+    val endAddrM = params("end_addr").toLong
+
+    lanesInRoadAddressSpaceToApi(roadNumber, track, startRoadPartNumber,endRoadPartNumber ,startAddrM , endAddrM)
+  }
+
+  get("/lanes_in_municipality", operation(getLanesInMunicipality)) {
+    contentType = formats("json") + "; charset=utf-8"
+    params.get("municipality").map { municipality =>
+      val municipalityNumber = municipality.toInt
+      lanesToApi(municipalityNumber)
+    }
+  }
+
+
+  def lanesInRoadAddressSpaceToApi(roadNumber: Long, track: Track, startRoadPartNumber: Long, endRoadPartNumber: Long,
+                                   startAddrM: Long, endAddrM: Long): Seq[Map[String, Any]] = {
+    val roadAddresses = roadAddressService.getAllByRoadNumber(roadNumber).filter(_.track == track)
+    val roadPartMaxLengths = roadAddresses.groupBy(_.roadPartNumber).mapValues(_.maxBy(_.endAddrMValue)).values
+    val roadPartRange = startRoadPartNumber to endRoadPartNumber
+    val filteredMaxLengths = roadPartMaxLengths.filter(address => roadPartRange contains address.roadPartNumber)
+
+    val roadAddressesToTransform = filteredMaxLengths.flatMap(roadPart => {
+      val roadPartNumber = roadPart.roadPartNumber
+
+      val maxLength = if (roadPartNumber == endRoadPartNumber) endAddrM
+      else roadPart.endAddrMValue
+
+      val startLength = if (roadPartNumber == startRoadPartNumber) startAddrM
+      else roadPart.startAddrMValue
+
+      val transFormInterval = 50
+      val transformsForRoadPart = ((maxLength - startLength) / transFormInterval + 1).toInt
+
+      val roadAddresses = for (i <- 0 to transformsForRoadPart)
+        yield (i.toString, RoadAddress(None, roadNumber.toInt, roadPartNumber.toInt, track, (startLength + (i * transFormInterval)).toInt))
+      roadAddresses
+    }).toMap
+
+    val coordinatesAndIdentifiers = vkmClient.addressToCoordsMassQuery(roadAddressesToTransform).toMap
+    val polygon = polygonTools.createPolygonFromCoordinates(coordinatesAndIdentifiers)
+
+    val roadLinks = getRoadLinksAndChangesFromVVHWithPolygon(polygon)._1
+    val (roadLinksWithViiteAddress, noRoadAddress) = roadAddressService.roadLinkWithRoadAddress(roadLinks).partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
+    val roadLinksWithTempAddress = roadAddressService.roadLinkWithRoadAddressTemp(noRoadAddress).filter(_.attributes.contains("TEMP_ROAD_NUMBER"))
+    val roadLinksWithRoadAddress = roadLinksWithViiteAddress ++ roadLinksWithTempAddress
+    val roadLinksWithConsistentRoadAddress = roadLinksWithConsistentAddress(roadLinksWithRoadAddress)
+
+    val correctLinks = roadLinksWithConsistentRoadAddress.filter(roadLink => roadLink.attributes("VIITE_ROAD_NUMBER") == roadNumber
+      && (roadPartRange contains roadLink.attributes("VIITE_ROAD_PART_NUMBER")) && roadLink.attributes("VIITE_TRACK") == track.value)
+
+    val lanesOnRoadLinks = laneService.getLanesByRoadLinks(correctLinks)
+    val (lanesWithViiteAddress, lanesWithoutRoadAddress) = roadAddressService.laneWithRoadAddress(Seq(lanesOnRoadLinks))
+      .flatten.partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
+    val lanesWithTempAddress = roadAddressService.experimentalLaneWithRoadAddress(Seq(lanesWithoutRoadAddress)).flatten
+      .filter(_.attributes.contains("TEMP_ROAD_NUMBER"))
+    val lanesWithRoadAddress = lanesWithViiteAddress ++ lanesWithTempAddress
+
+    val lanesWithNormalRoadAddress = lanesWithConsistentRoadAddress(lanesWithRoadAddress)
+    val twoDigitLanes = laneService.pieceWiseLanesToTwoDigitWithMassQuery(lanesWithNormalRoadAddress).flatten
+
+    val apiLanes = lanesToApiFormat(twoDigitLanes, correctLinks.groupBy(_.linkId).mapValues(_.head))
+    apiLanes.map { apiLane =>
+      Map("roadNumber" -> apiLane.roadNumber,
+        "roadParts" -> apiLane.roadParts
+      )
+    }
+  }
+
+  def lanesToApiFormat(twoDigitLanes: Seq[PieceWiseLane], roadLinks: Map[Long, RoadLink]): Seq[ApiRoad] = {
+    val roadNumbers = twoDigitLanes.map(_.attributes("ROAD_NUMBER")).distinct.asInstanceOf[Seq[Long]]
+    val lanesGroupedByRoadNumber = twoDigitLanes.groupBy(_.attributes("ROAD_NUMBER")).values
+    val lanesGroupedByRoadNumberAndPartNumber = lanesGroupedByRoadNumber.flatMap(_.groupBy(_.attributes("ROAD_PART_NUMBER")).values)
+
+    val allRoadParts = lanesGroupedByRoadNumberAndPartNumber.map(lanes => {
+      val roadPartNumber = lanes.head.attributes("ROAD_PART_NUMBER").asInstanceOf[Long]
+      val roadNumber = Some(lanes.head.attributes("ROAD_NUMBER").asInstanceOf[Long])
+      val lanesGroupedByLaneCode = lanes.groupBy(_.laneAttributes.find(_.publicId == "lane_code")).values
+
+      val lanesWithContinuing = lanesGroupedByLaneCode.map(laneGroup => {
+        laneGroup.map(lane => {
+          val roadIdentifier = roadLinks(lane.linkId).roadIdentifier
+          val continuingLanes = LanePartitioner.getContinuingWithIdentifier(lane, roadIdentifier, laneGroup, roadLinks, true)
+          LaneWithContinuingLanes(lane, continuingLanes)
+        })
+      }).toSeq
+
+
+      val connectedGroups = lanesWithContinuing.flatMap(laneGroup => {
+        val startingLanes = getStartingLanes(laneGroup)
+        val connectedLanes = startingLanes.map(startingLane => {
+          getConnectedLanes(Seq(startingLane), laneGroup).sortBy(_.lane.id)
+        }).distinct
+        connectedLanes.map(_.map(_.lane))
+      })
+
+      val apiLanes = connectedGroups.map(group => {
+        val laneCode = group.head.laneAttributes.find(_.publicId == "lane_code").get.values.head.value.asInstanceOf[Int]
+        val startLane = group.minBy(_.attributes("START_ADDR").asInstanceOf[Long])
+        val startAddressM = startLane.attributes("START_ADDR").asInstanceOf[Long] + startLane.startMeasure.asInstanceOf[Long]
+
+        val endLane = group.maxBy(_.attributes("END_ADDR").asInstanceOf[Long])
+        val endLaneLength = (roadLinks(endLane.linkId).length - endLane.endMeasure).asInstanceOf[Long]
+        val endAddressM = endLane.attributes("END_ADDR").asInstanceOf[Long] - endLaneLength
+
+        ApiLane(laneCode, startAddressM, endAddressM)
+      })
+
+      ApiRoadPart(roadNumber, roadPartNumber, apiLanes)
+    }).toSeq
+
+    roadNumbers.map(roadNumber => {
+      val roadParts = allRoadParts.filter(_.roadNumber.get == roadNumber)
+      val roadPartsWithOutRoadNumber = roadParts.map(_.copy(roadNumber = None))
+      ApiRoad(roadNumber, roadPartsWithOutRoadNumber)
+    })
+  }
+
+  def lanesToApi(municipalityNumber: Int): Seq[Map[String, Any]] = {
+    val roadLinksInMunicipality = roadLinkService.getRoadLinksFromVVH(municipalityNumber)
+    val lanes = laneService.getLanesByRoadLinks(roadLinksInMunicipality)
+
+    val (lanesWithViiteAddress, noRoadAddress) = roadAddressService.laneWithRoadAddress(Seq(lanes)).flatten.partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
+    val lanesWithTempAddress =  roadAddressService.experimentalLaneWithRoadAddress(Seq(noRoadAddress)).flatten.filter(_.attributes.contains("TEMP_ROAD_NUMBER"))
+    val lanesWithRoadAddress = lanesWithViiteAddress ++ lanesWithTempAddress
+    val lanesWithNormalRoadAddress = lanesWithConsistentRoadAddress(lanesWithRoadAddress)
+
+    val twoDigitLanes = laneService.pieceWiseLanesToTwoDigitWithMassQuery(lanesWithNormalRoadAddress).flatten
+    val apiLanes = lanesToApiFormat(twoDigitLanes, roadLinksInMunicipality.groupBy(_.linkId).mapValues(_.head))
+
+    apiLanes.map { apiLane =>
+      Map("roadNumber" -> apiLane.roadNumber,
+        "roadParts" -> apiLane.roadParts
+      )
+    }
+  }
+}

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -35,7 +35,7 @@ class LaneApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupp
         queryParam[Int]("start_addrm").description("Starting distance on starting roadPart for search"),
         queryParam[Int]("end_part").description("Ending road part number for search"),
         queryParam[Int]("end_addrm").description("Ending distance on last road part for search"),
-        pathParam[String]("lanes_in_range").description("Get lanes in given range")
+        pathParam[String]("lanes_in_range").description("Path for getting lanes in given range")
       )
       tags "LaneApi"
       summary "Get lanes in given road address range in road address format"
@@ -43,12 +43,11 @@ class LaneApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupp
       description "Example URL: /externalApi/lanes/lanes_in_range?road_number=9&track=1&start_part=208&start_addrm=8500&end_part=208&end_addrm=9000"
       )
 
-  //Description of Api entry point to get all lanes in specific road address range
   val getLanesInMunicipality =
     (apiOperation[Long]("getLanesInMunicipality")
       .parameters(
         queryParam[Int]("municipality").description("Municipality Code where we will get lanes from"),
-        pathParam[String]("lanes_in_municipality").description("Get lanes from given municipality")
+        pathParam[String]("lanes_in_municipality").description("Path for getting lanes in municipality")
       )
       tags "LaneApi"
       summary "Get lanes in given municipality"

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -135,7 +135,8 @@ class LaneApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupp
       roadAddresses
     }).toMap
 
-    val coordinatesAndIdentifiers = vkmClient.addressToCoordsMassQuery(roadAddressesToTransform).toMap
+    val roadAddressesSplit = roadAddressesToTransform.grouped(1000).toSeq
+    val coordinatesAndIdentifiers = roadAddressesSplit.flatMap(roadAddressGroup => vkmClient.addressToCoordsMassQuery(roadAddressGroup)).toMap
     val polygon = polygonTools.createPolygonFromCoordinates(coordinatesAndIdentifiers)
 
     val roadLinks = getRoadLinksAndChangesFromVVHWithPolygon(polygon)._1

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -125,13 +125,13 @@ class LaneApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupp
       else roadPart.endAddrMValue
 
       val startLength = if (roadPartNumber == startRoadPartNumber) startAddrM
-      else roadPart.startAddrMValue
+      else 0
 
       val transFormInterval = 50
       val transformsForRoadPart = ((maxLength - startLength) / transFormInterval + 1).toInt
 
       val roadAddresses = for (i <- 0 to transformsForRoadPart)
-        yield (i.toString, RoadAddress(None, roadNumber.toInt, roadPartNumber.toInt, track, (startLength + (i * transFormInterval)).toInt))
+        yield (roadPartNumber + "/" + i, RoadAddress(None, roadNumber.toInt, roadPartNumber.toInt, track, (startLength + (i * transFormInterval)).toInt))
       roadAddresses
     }).toMap
 

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -5,6 +5,7 @@ import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.linearasset.{ChangedSpeedLimit, ElementTypes, LinearLengthLimitService, Manoeuvre, ManoeuvreElement}
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.{MassTransitStopService, PersistedMassTransitStop}
+import fi.liikennevirasto.digiroad2.util.Track
 import org.json4s.{DefaultFormats, Formats}
 import org.mockito.Mockito.{when, _}
 import org.scalatest.mockito.MockitoSugar

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -3,21 +3,15 @@ package fi.liikennevirasto.digiroad2
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.linearasset._
-import fi.liikennevirasto.digiroad2.service.linearasset.{ChangedSpeedLimit, ElementTypes, LinearLengthLimitService, Manoeuvre, ManoeuvreElement}
+import fi.liikennevirasto.digiroad2.service.linearasset._
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.{MassTransitStopService, PersistedMassTransitStop}
-import fi.liikennevirasto.digiroad2.util.Track
-import org.json4s.{DefaultFormats, Formats}
-import org.mockito.Mockito.{when, _}
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSuite, Tag}
-import org.scalatra.test.scalatest.ScalatraSuite
-import org.apache.commons.codec.binary.Base64
 import org.joda.time.DateTime
 import org.json4s.jackson.JsonMethods._
-import org.mockito.ArgumentMatchers.any
-import org.slf4j.LoggerFactory
-
-import scala.collection.immutable.Stream.Empty
+import org.json4s.{DefaultFormats, Formats}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSuite}
+import org.scalatra.test.scalatest.ScalatraSuite
 
 
 class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter{

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -54,7 +54,6 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
     apiLane21.startAddressM should equal(0)
     apiLane11.endAddressM should equal(200)
     apiLane21.endAddressM should equal(200)
-    print("jejej")
   }
 
   test("Lanes in municipality API requires municipality number") {

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -1,0 +1,84 @@
+package fi.liikennevirasto.digiroad2
+
+import fi.liikennevirasto.digiroad2.asset.{Motorway, State}
+import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
+import fi.liikennevirasto.digiroad2.lane.{LaneProperty, LanePropertyValue, PieceWiseLane}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import org.scalatest.FunSuite
+import org.scalatra.test.scalatest.ScalatraSuite
+
+class LaneApiSpec extends FunSuite with ScalatraSuite {
+  private val laneApi = new LaneApi(new OthSwagger)
+  addServlet(laneApi, "/*")
+
+  //Creates two road links geometrically next to each other
+  def createRoadLinks(): Seq[RoadLink] = {
+    val roadLink1 = RoadLink(1, Seq(Point(0.0, 0.0), Point(1.0, 1.0)), 1, State, 1, BothDirections, Motorway, None, None, Map())
+    val roadLink2 = RoadLink(2, Seq(Point(1.0, 1.0), Point(2.0, 2.0)), 1, State, 1, BothDirections, Motorway, None, None, Map())
+    Seq(roadLink1, roadLink2)
+  }
+
+  //Creates 11 and 21 lanes on two road links with road address information
+  def createLanes(): Seq[PieceWiseLane] = {
+    val laneAttributes11 = Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))))
+    val laneAttributes21 = Seq(LaneProperty("lane_code", Seq(LanePropertyValue(21))))
+
+    val attributes1 = Map("ROAD_NUMBER" -> 1L, "ROAD_PART_NUMBER" -> 1L, "TRACK" -> 0, "START_ADDR" -> 0L, "END_ADDR" -> 100L)
+    val attributes2 = Map("ROAD_NUMBER" -> 1L, "ROAD_PART_NUMBER" -> 1L, "TRACK" -> 0, "START_ADDR" -> 100L, "END_ADDR" -> 200L)
+
+    val lane11a = PieceWiseLane(111, 1, 2, false, Seq(Point(0.0, 0.0), Point(1.0, 1.0)), 0, 1, Set(Point(0.0, 0.0), Point(1.0, 1.0)),
+      None, None, None, None, 0L, None, State, laneAttributes11, attributes1)
+    val lane11b = PieceWiseLane(112, 2, 2, false, Seq(Point(1.0, 1.0), Point(2.0, 2.0)), 0, 1, Set(Point(1.0, 1.0), Point(2.0, 2.0)),
+      None, None, None, None, 0L, None, State, laneAttributes11, attributes2)
+
+    val lane21a = PieceWiseLane(211, 1, 3, false, Seq(Point(1.0, 1.0), Point(2.0, 2.0)), 0, 1, Set(Point(1.0, 1.0), Point(2.0, 2.0)),
+      None, None, None, None, 0L, None, State, laneAttributes21, attributes2)
+    val lane21b = PieceWiseLane(212, 2, 3, false, Seq(Point(0.0, 0.0), Point(1.0, 1.0)), 0, 1, Set(Point(0.0, 0.0), Point(1.0, 1.0)),
+      None, None, None, None, 0L, None, State, laneAttributes21, attributes1)
+
+    Seq(lane11a, lane11b, lane21a, lane21b)
+  }
+
+  test("Two equal ApiLanes should be formed") {
+    val roadLinks = createRoadLinks().groupBy(_.linkId).mapValues(_.head)
+    val lanes = createLanes()
+
+    val apiRoad = laneApi.lanesToApiFormat(lanes, roadLinks).head
+    val apiLanes = apiRoad.roadParts.head.apiLanes
+
+    val apiLane11 = apiLanes.find(_.laneCode == 11).get
+    val apiLane21 = apiLanes.find(_.laneCode == 21).get
+
+    apiLanes.size should equal(2)
+    apiLane11.startAddressM should equal(0)
+    apiLane21.startAddressM should equal(0)
+    apiLane11.endAddressM should equal(200)
+    apiLane21.endAddressM should equal(200)
+    print("jejej")
+  }
+
+  test("Lanes in municipality API requires municipality number") {
+    get("/lanes_in_municipality") {
+      status should equal(400)
+    }
+    get("/lanes_in_municipality?municipality=abcd") {
+      status should equal(400)
+    }
+    get("/lanes_in_municipality?municipality=235") {
+      status should equal(200)
+    }
+  }
+
+  test("lanes in road address range Api requires valid parameters"){
+    get("/lanes_in_range"){
+      status should equal(400)
+    }
+    get("/lanes_in_range?road_number=a&track=b&start_part=c&start_addrm=d&end_part=e&end_addrm=f"){
+      status should equal(400)
+    }
+    get("/lanes_in_range?road_number=9&track=1&start_part=208&start_addrm=8500&end_part=208&end_addrm=9000"){
+      status should equal(200)
+    }
+  }
+
+}

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -101,7 +101,7 @@ case class Vector3d(x: Double, y: Double, z: Double) {
 
 case class Point(x: Double, y: Double, z: Double = 0.0) {
   def round(): Point = {
-    Point(Math.round(this.x), Math.round(this.y), Math.round(this.z))
+    Point(Math.round(this.x * 100d) / 100d, Math.round(this.y * 100d) / 100d, Math.round(this.z * 100d) / 100d)
   }
 
   def distance2DTo(point: Point): Double =

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/Point.scala
@@ -101,7 +101,7 @@ case class Vector3d(x: Double, y: Double, z: Double) {
 
 case class Point(x: Double, y: Double, z: Double = 0.0) {
   def round(): Point = {
-    Point(Math.round(this.x * 100d) / 100d, Math.round(this.y * 100d) / 100d, Math.round(this.z * 100d) / 100d)
+    Point(Math.round(this.x * 100.0) / 100.0, Math.round(this.y * 100.0) / 100.0, Math.round(this.z * 100.0) / 100.0)
   }
 
   def distance2DTo(point: Point): Double =

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -1654,4 +1654,15 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
   def getChangeInfo(linkIds: Set[Long]): Seq[ChangeInfo] ={
     vvhClient.roadLinkChangeInfo.fetchByLinkIds(linkIds)
   }
+
+  def roadLinksWithConsistentAddress(roadLinksWithRoadAddress: Seq[RoadLink]): Seq[RoadLink] = {
+    roadLinksWithRoadAddress.map(roadLink => {
+      val roadNumber = roadLink.attributes.getOrElse("VIITE_ROAD_NUMBER", roadLink.attributes.get("TEMP_ROAD_NUMBER"))
+      val roadPartNumber = roadLink.attributes.getOrElse("VIITE_ROAD_PART_NUMBER", roadLink.attributes.get("TEMP_ROAD_PART_NUMBER"))
+      val startAddr = roadLink.attributes.getOrElse("VIITE_START_ADDR", roadLink.attributes.get("TEMP_START_ADDR"))
+      val endAddr = roadLink.attributes.getOrElse("VIITE_END_ADDR", roadLink.attributes.get("TEMP_END_ADDR"))
+      roadLink.copy(attributes = roadLink.attributes + ("ROAD_NUMBER" -> roadNumber, "ROAD_PART_NUMBER" -> roadPartNumber,
+        "START_ADDR" -> startAddr, "END_ADDR" -> endAddr))
+    })
+  }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -983,6 +983,17 @@ trait LaneOperations {
     }
   }
 
+  def lanesWithConsistentRoadAddress(lanesWithRoadAddress: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
+    lanesWithRoadAddress.map(lane => {
+      val roadNumber = lane.attributes.getOrElse("VIITE_ROAD_NUMBER", lane.attributes.getOrElse("TEMP_ROAD_NUMBER", None))
+      val roadPartNumber = lane.attributes.getOrElse("VIITE_ROAD_PART_NUMBER", lane.attributes.getOrElse("TEMP_ROAD_PART_NUMBER", None))
+      val startAddr = lane.attributes.getOrElse("VIITE_START_ADDR", lane.attributes.getOrElse("TEMP_START_ADDR", None))
+      val endAddr = lane.attributes.getOrElse("VIITE_END_ADDR", lane.attributes.getOrElse("TEMP_END_ADDR", None))
+      lane.copy(attributes = lane.attributes + ("ROAD_NUMBER" -> roadNumber, "ROAD_PART_NUMBER" -> roadPartNumber,
+        "START_ADDR" -> startAddr, "END_ADDR" -> endAddr))
+    })
+  }
+
   def pieceWiseLanesToTwoDigitWithMassQuery(pwLanes: Seq[PieceWiseLane]): Seq[Option[PieceWiseLane]] = {
     val vkmParameters = pwLanes.map(lane => {
       MassQueryParams(lane.id.toString + "/starting", lane.endpoints.minBy(_.y), lane.attributes("ROAD_NUMBER").asInstanceOf[Long], lane.attributes("ROAD_PART_NUMBER").asInstanceOf[Long])

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -986,11 +986,12 @@ trait LaneOperations {
   def lanesWithConsistentRoadAddress(lanesWithRoadAddress: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
     lanesWithRoadAddress.map(lane => {
       val roadNumber = lane.attributes.getOrElse("VIITE_ROAD_NUMBER", lane.attributes.getOrElse("TEMP_ROAD_NUMBER", None))
+      val trackNumber = lane.attributes.getOrElse("VIITE_TRACK", lane.attributes.getOrElse("TEMP_TRACK", None))
       val roadPartNumber = lane.attributes.getOrElse("VIITE_ROAD_PART_NUMBER", lane.attributes.getOrElse("TEMP_ROAD_PART_NUMBER", None))
       val startAddr = lane.attributes.getOrElse("VIITE_START_ADDR", lane.attributes.getOrElse("TEMP_START_ADDR", None))
       val endAddr = lane.attributes.getOrElse("VIITE_END_ADDR", lane.attributes.getOrElse("TEMP_END_ADDR", None))
       lane.copy(attributes = lane.attributes + ("ROAD_NUMBER" -> roadNumber, "ROAD_PART_NUMBER" -> roadPartNumber,
-        "START_ADDR" -> startAddr, "END_ADDR" -> endAddr))
+        "START_ADDR" -> startAddr, "END_ADDR" -> endAddr, "TRACK" -> trackNumber))
     })
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/PolygonTools.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/PolygonTools.scala
@@ -22,9 +22,23 @@ class PolygonTools {
     Class.forName(Digiroad2Properties.userProvider).newInstance().asInstanceOf[UserProvider]
   }
 
-  def createPolygonFromCoordinates(coords: Map[String, Point]): Polygon = {
-    val sortedCoords = coords.toSeq.sortBy(_._1.toInt)
-    val lines = sortedCoords.grouped(2).toSeq
+  def createPolygonFromCoordinates(pointsWithIdentifiers: Map[String, Point]): Polygon = {
+    val sortedPoints = pointsWithIdentifiers.toSeq.sortBy(identifierAndPoint => {
+      val identifier = identifierAndPoint._1
+      val split = identifier.split("/", 2)
+      val roadPartNumber = split.head
+      val orderNumber = split.last
+      (roadPartNumber.toInt, orderNumber.toInt)
+    })
+    val lines = if(sortedPoints.length % 2 == 0) {
+      sortedPoints.grouped(2).toSeq
+    }
+    else{
+      val pointsGrouped = sortedPoints.grouped(2).toSeq
+      val lastElement = Seq(pointsGrouped.init.last.last,pointsGrouped.last.head)
+      pointsGrouped.init :+ lastElement
+    }
+
     val offsets = Seq(200, -200)
     val parallelLines = offsets.map(offset => {
       lines.flatMap(line => {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/PolygonTools.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/PolygonTools.scala
@@ -1,13 +1,13 @@
 package fi.liikennevirasto.digiroad2.util
 
 import java.util.Properties
-
 import com.vividsolutions.jts.geom._
 import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
 import fi.liikennevirasto.digiroad2.user.UserProvider
 import org.geotools.geometry.jts.GeometryBuilder
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import com.vividsolutions.jts.io.WKTReader
+import fi.liikennevirasto.digiroad2.client.PointWithIdentifier
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures
 
 import scala.collection.mutable.ListBuffer
@@ -22,12 +22,12 @@ class PolygonTools {
     Class.forName(Digiroad2Properties.userProvider).newInstance().asInstanceOf[UserProvider]
   }
 
-  def createPolygonFromCoordinates(pointsWithIdentifiers: Map[String, Point]): Polygon = {
-    val sortedPoints = pointsWithIdentifiers.toSeq.sortBy(identifierAndPoint => {
-      val identifier = identifierAndPoint._1
-      val split = identifier.split("/", 2)
-      val roadPartNumber = split.head
-      val orderNumber = split.last
+  def createPolygonFromCoordinates(pointsWithIdentifiers: Seq[PointWithIdentifier]): Polygon = {
+    val sortedPoints = pointsWithIdentifiers.sortBy(identifierAndPoint => {
+      val identifier = identifierAndPoint.identifier
+      val identifierSplit = identifier.split("/", 2)
+      val roadPartNumber = identifierSplit.head
+      val orderNumber = identifierSplit.last
       (roadPartNumber.toInt, orderNumber.toInt)
     })
     val lines = if(sortedPoints.length % 2 == 0) {
@@ -42,10 +42,10 @@ class PolygonTools {
     val offsets = Seq(200, -200)
     val parallelLines = offsets.map(offset => {
       lines.flatMap(line => {
-        val x1 = line.head._2.x
-        val x2 = line.last._2.x
-        val y1 = line.head._2.y
-        val y2 = line.last._2.y
+        val x1 = line.head.point.x
+        val x2 = line.last.point.x
+        val y1 = line.head.point.y
+        val y2 = line.last.point.y
         val length = scala.math.sqrt((x1 - x2) * (x1 - x2) + (y1 - y2) * (y1 - y2))
 
         val x1p = x1 + offset * (y2 - y1) / length

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -55,5 +55,6 @@ ScalatraBootstrap extends LifeCycle {
     context.mount(new ServiceRoadAPI( Digiroad2Context.maintenanceRoadService, 
                                       Digiroad2Context.roadLinkService, swagger),
                                       "/externalApi/livi/*")
+    context.mount(new LaneApi(swagger), "/externalApi/lanes/*")
   }
 }


### PR DESCRIPTION
Luotu LaneApi, josta voi kysyä Digiroadin kaistatietoja kunnan alueella tai tieosoitevälillä. Siirretty aikaisempi kunnan alueelta kaistatiedot kertova rajapinta Integraatio apista osaksi LaneApia, ja luotu uusi tieosoiteväliltä kaistatiedot kertova rajapinta.  Rajapintojen toiminnan ja parametrien kuvaus confluencessa ja Swaggerissa.