### PR TITLE
DROTH-3094 Lanes which are left out in partitioning are added in indi…

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -190,7 +190,9 @@ object LanePartitioner {
     })
 
     val noRoadIdentifier = laneGroupsWithNoIdentifier.values.flatten.map(lane => Seq(lane))
-    connectedGroups ++ noRoadIdentifier
+    val laneGroups = connectedGroups ++ noRoadIdentifier
+    val lanesNotInGroup = lanes diff laneGroups.flatten
+    connectedGroups ++ noRoadIdentifier ++ lanesNotInGroup.map(lane => Seq(lane))
   }
 
   //Returns lanes grouped by corrected sideCode, laneCode, additional lanes and connection (lanes in group must


### PR DESCRIPTION
Kaistajoukoista osituksen aikana tippuneet kaistat lisätään nyt yksittäisinä joukkoina palautukseen. Näin ei jää kaistatietoa puuttumaan.  Joukoista tippuminen tapahtuu välillä esim. rampeilla tai muilla harvinaisemmilla tieosuuksilla. Kun kaistajoukon muodostukseen saadaan tarkemmat määrittelyt voidaan katsoa uudestaan saadaanko nämä kaistat jotenkin fiksummin joukkoihin mukaan.