### PR TITLE
 DROTH-3023 add exit command after akka system is turned off

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/util/UpdateIncompleteLinkList.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/util/UpdateIncompleteLinkList.scala
@@ -23,6 +23,7 @@ object UpdateIncompleteLinkList {
       UpdateIncompleteLinkList.runUpdate()
     } finally {
       Digiroad2Context.system.terminate()
+      exit()
     }
   }
 


### PR DESCRIPTION
Ohjelmisto jää pyörimään kun se aloitetaan palvelin tyyppisesti. Sammutetaan se manualisesti kun prosessi on loppunut.