### PR TITLE
Droth 3086 add direction marker to lanes

### DIFF
--- a/UI/images/link-properties/arrow-drop-red2.svg
+++ b/UI/images/link-properties/arrow-drop-red2.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="Layer_1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 258.4 387.6"
+   enable-background="new 0 0 960 560"
+   xml:space="preserve"
+   inkscape:version="0.48.3.1 r9886"
+   width="25px"
+   height="25px"
+   sodipodi:docname="arrow-drop-blue-fit.svg"><metadata
+   id="metadata3932"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+   id="defs3930" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="2560"
+   inkscape:window-height="1412"
+   id="namedview3928"
+   showgrid="false"
+   fit-margin-top="0"
+   fit-margin-left="0"
+   fit-margin-right="0"
+   fit-margin-bottom="0"
+   inkscape:zoom="1.0482143"
+   inkscape:cx="129.2"
+   inkscape:cy="193.8"
+   inkscape:window-x="1920"
+   inkscape:window-y="0"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="Layer_1" />
+<g
+   id="GREY"
+   transform="translate(-350.8,-86.2)">
+</g>
+<g
+   id="BLUE"
+   transform="translate(-350.8,-86.2)">
+</g>
+<g
+   id="GREEN"
+   transform="translate(-350.8,-86.2)">
+</g>
+<g
+   id="g3920"
+   transform="translate(-350.8,-86.2)">
+	<path
+   d="M 609.2,344.6 C 609.2,215.4 480,86.2 480,86.2 c 0,0 -129.2,129.2 -129.2,258.4 0,81.8 68.9,129.2 129.2,129.2 60.3,0 129.2,-47.3 129.2,-129.2 z M 480,441.5 c -53.8,0 -96.9,-43.1 -96.9,-96.9 0,-53.8 43.1,-96.9 96.9,-96.9 53.8,0 96.9,43.1 96.9,96.9 0,53.8 -43.1,96.9 -96.9,96.9 z"
+   id="path3922"
+   inkscape:connector-curvature="0"
+   style="fill:#ff0000" />
+	<path
+   d="M 582.7,341.9 C 582.7,234.9 480,128 480,128 c 0,0 -102.7,106.9 -102.7,213.9 0,67.7 54.8,106.9 102.7,106.9 47.9,0 102.7,-39.2 102.7,-106.9 z"
+   id="path3924"
+   inkscape:connector-curvature="0"
+   style="fill:#ffffff" />
+	<path
+   d="m 556.4,345.6 c 0,-40.9 -34.5,-75.4 -75.4,-75.4 -40.9,0 -75.4,34.5 -75.4,75.4 0,40.9 34.5,75.4 75.4,75.4 40.9,0 75.4,-34.5 75.4,-75.4 z"
+   id="path3926"
+   inkscape:connector-curvature="0"
+   style="fill:#ff0000" />
+</g>
+</svg>

--- a/UI/src/view/linear_asset/laneModellingLayer.js
+++ b/UI/src/view/linear_asset/laneModellingLayer.js
@@ -311,16 +311,15 @@
       var uniqueLinkIds = [...new Set(linkIds)];
       var modifiedLinks = [];
       for (var i = 0; i < uniqueLinkIds.length; i++) {
-        try {
-          var lanesOnSameRoadLink = links.filter(link => link.values_.linkId == uniqueLinkIds[i]);
-          var laneCodes = lanesOnSameRoadLink.map(link => parseInt(link.values_.lanes[0]));
-          var uniqueLanes = [...new Set(laneCodes)];
-          var linkToUpdate = lanesOnSameRoadLink[0];
-          linkToUpdate.values_.lanes = uniqueLanes;
-          modifiedLinks = modifiedLinks.concat(linkToUpdate);
-        } catch (exception) {
+        var lanesOnSameRoadLink = links.filter(link => link.values_.linkId == uniqueLinkIds[i]);
+        if (lanesOnSameRoadLink.length === 0) {
           continue;
         }
+        var laneCodes = lanesOnSameRoadLink.map(link => parseInt(link.values_.lanes[0]));
+        var uniqueLanes = [...new Set(laneCodes)];
+        var linkToUpdate = lanesOnSameRoadLink[0];
+        linkToUpdate.values_.lanes = uniqueLanes;
+        modifiedLinks = modifiedLinks.concat(linkToUpdate);
       }
       return modifiedLinks;
     }
@@ -412,12 +411,10 @@
             });
           })), offsetByLaneNumber));
         }
-        try {
-          var oneWaySignForSelection = me.getOneWaySignsForLanes(linearAssets);
+        var oneWaySignForSelection = me.getOneWaySignsForLanes(linearAssets);
+        if (oneWaySignForSelection.length > 0) {
           oneWaySignForSelection[0].values_.isSelected = true;
           me.vectorSource.addFeatures(oneWaySignForSelection);
-        } catch (exception) {
-          //continue execution normally without one way sign
         }
       }
     };

--- a/UI/src/view/linear_asset/laneModellingStyle.js
+++ b/UI/src/view/linear_asset/laneModellingStyle.js
@@ -128,12 +128,27 @@
       new StyleRule().where('zoomLevel').isIn([14,15]).use({stroke: {width: 9}})
     ];
 
+    var trafficDirectionRulesForUnselectedLanes = [
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).is(0).use({ icon: { src: 'images/link-properties/arrow-drop-red2.svg' }}),
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).is(1).use({ icon: { src: 'images/link-properties/arrow-drop-cyan.svg' }}),
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).is(2).use({ icon: { src: 'images/link-properties/arrow-drop-blue.svg' }}),
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).is(3).use({ icon: { src: 'images/link-properties/arrow-drop-lilac.svg' }}),
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).is(4).use({ icon: { src: 'images/link-properties/arrow-drop-pink.svg' }}),
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).is(5).use({ icon: { src: 'images/link-properties/arrow-drop-green.svg' }}),
+      new StyleRule().where('rotation').isDefined().and(function (asset) { return numberOfAdditionalLanes(asset);}).isGreaterOrEqual(6).use({ icon: { src: 'images/link-properties/arrow-drop-black.svg' }})
+    ];
+
+    var trafficDirectionRulesForSelectedLane = [
+      new StyleRule().where('rotation').isDefined().and('isSelected').is(true).use({ icon: { src: 'images/link-properties/arrow-drop-red2.svg'}}),
+    ];
+
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.01, color: '#7f7f7c' }});
     me.browsingStyleProvider.addRules(laneModellingSizeRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
     me.browsingStyleProvider.addRules(overlayStyleRules);
     me.browsingStyleProvider.addRules(laneModellingStyleRules);
-
+    me.browsingStyleProvider.addRules(trafficDirectionRulesForUnselectedLanes);
+    me.browsingStyleProvider.addRules(trafficDirectionRulesForSelectedLane);
 
     me.browsingStyleProviderViewOnly = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.browsingStyleProviderViewOnly.addRules(viewOnlyLaneModellingStyleRules);

--- a/UI/src/view/providers/layer.js
+++ b/UI/src/view/providers/layer.js
@@ -65,9 +65,21 @@
         var attributes = _.merge({}, link, { rotation: rotation  });
         return new ol.Feature(_.merge(attributes,{ geometry: new ol.geom.Point([middlePoint.x, middlePoint.y])}));
       });
-
       layer.getSource().addFeatures(oneWaySigns);
     };
+
+    this.getOneWaySignsForLanes = function(lanes) {
+      var filteredLinks = _.filter(lanes, function(link) {
+        return link.trafficDirection === 'AgainstDigitizing' || link.trafficDirection === 'TowardsDigitizing';
+      });
+      var oneWaySigns = mapOverLinkMiddlePoints(filteredLinks, function(link, middlePoint) {
+        var rotation = link.trafficDirection === 'AgainstDigitizing' ? middlePoint.angleFromNorth + Math.PI : middlePoint.angleFromNorth;
+        var attributes = _.merge({}, link, { rotation: rotation  });
+        return new ol.Feature(_.merge(attributes,{ geometry: new ol.geom.Point([middlePoint.x, middlePoint.y])}));
+      });
+      return oneWaySigns;
+    };
+
     this.mapOverLinkMiddlePoints = mapOverLinkMiddlePoints;
     this.show = function(map) {
       eventbus.on('map:moved', me.handleMapMoved);

--- a/UI/src/view/providers/layer.js
+++ b/UI/src/view/providers/layer.js
@@ -68,18 +68,6 @@
       layer.getSource().addFeatures(oneWaySigns);
     };
 
-    this.getOneWaySignsForLanes = function(lanes) {
-      var filteredLinks = _.filter(lanes, function(link) {
-        return link.trafficDirection === 'AgainstDigitizing' || link.trafficDirection === 'TowardsDigitizing';
-      });
-      var oneWaySigns = mapOverLinkMiddlePoints(filteredLinks, function(link, middlePoint) {
-        var rotation = link.trafficDirection === 'AgainstDigitizing' ? middlePoint.angleFromNorth + Math.PI : middlePoint.angleFromNorth;
-        var attributes = _.merge({}, link, { rotation: rotation  });
-        return new ol.Feature(_.merge(attributes,{ geometry: new ol.geom.Point([middlePoint.x, middlePoint.y])}));
-      });
-      return oneWaySigns;
-    };
-
     this.mapOverLinkMiddlePoints = mapOverLinkMiddlePoints;
     this.show = function(map) {
       eventbus.on('map:moved', me.handleMapMoved);


### PR DESCRIPTION
Toiminto piirtää nuolet yksisuuntaisten tielinkkien kaistoille samalla tavoin kuin tielinkeillä. Erona tielinkkitoteutukseen on, että nuoli renderöidään erillisenä komponenttina, jolloin nuoli ja kaistaviiva piirtyvät ensimmäisellä kerralla hieman eri aikaan.

Lisätty isompi punainen nuoli, koska alkuperäinen nuoli oli pienempi kuin muun väriset.

HUOM! Jos lisäkaistoja lisää ensin kaksisuuntaiselle ja sen jälkeen vaihtaa tielinkin yksisuuntaiseksi, kaistan ja nuolen väri ei täsmää (vasen alakulma). Tämä johtuu kuitenkin kaistaviivan ominaisuuksista, ei nuolen (kyseisellä linkillä on kaksi kaistaa, joten myös kaistaviivan tulisi olla syaani, eikä punainen). Asiaan kannattanee palata muiden kaistamuutostaskien yhteydessä.

![kaistat](https://user-images.githubusercontent.com/95400826/152312598-2281a2f0-806d-441b-9fd6-c838e5cd8b91.JPG)

