### PR TITLE
Droth 3098 lane csv import fix

### DIFF
--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -588,7 +588,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
   test("Create valid lane", Tag("db")) {
     runWithRollback {
       when(lanesCsvImporter.laneUtils.processNewLanesByRoadAddress(any[Set[NewLane]], any[LaneRoadAddressInfo],
-        any[Int], any[String], any[Boolean])).thenReturn()
+        any[Int], any[String], any[Boolean])).thenReturn(Set(0L))
 
       lanesCsvImporter.laneService.expireAllAdditionalLanes(any[String])
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
@@ -1,18 +1,16 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
-import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.{DateParser, SideCode}
-import fi.liikennevirasto.digiroad2.lane.LaneFiller.ChangeSet
 import fi.liikennevirasto.digiroad2.lane._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.lane.LaneService
 import fi.liikennevirasto.digiroad2.user.User
-import fi.liikennevirasto.digiroad2.util.ChangeLanesAccordingToVvhChanges.{handleChanges, persistModifiedLinearAssets, updateChangeSet}
+import fi.liikennevirasto.digiroad2.util.ChangeLanesAccordingToVvhChanges.updateChangeSet
 import fi.liikennevirasto.digiroad2.util.{LaneUtils, Track}
 import org.apache.commons.lang3.StringUtils.isBlank
-
+import java.io.{InputStream, InputStreamReader}
 import scala.util.{Success, Try}
 
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
@@ -4,12 +4,15 @@ import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.{DateParser, SideCode}
+import fi.liikennevirasto.digiroad2.lane.LaneFiller.ChangeSet
 import fi.liikennevirasto.digiroad2.lane._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.lane.LaneService
 import fi.liikennevirasto.digiroad2.user.User
+import fi.liikennevirasto.digiroad2.util.ChangeLanesAccordingToVvhChanges.{handleChanges, persistModifiedLinearAssets, updateChangeSet}
 import fi.liikennevirasto.digiroad2.util.{LaneUtils, Track}
 import org.apache.commons.lang3.StringUtils.isBlank
+
 import scala.util.{Success, Try}
 
 
@@ -24,7 +27,7 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
   type ParsedCsv = (MalformedParameters, List[ParsedProperties])
   def laneUtils = LaneUtils()
   lazy val laneService: LaneService = new LaneService(roadLinkServiceImpl, eventBusImpl)
-
+  lazy val laneFiller: LaneFiller = new LaneFiller
   private val csvImportUser = "csv_importer"
 
   private val nonMandatoryFieldsMapping: Map[String, String] = Map(
@@ -176,9 +179,9 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
     s"<ul> notImportedData: ${notImportedData.mkString.replaceAll("[(|)]{1}", "")}</ul>"
   }
 
-  def createAsset(laneAssetProperties: Seq[ParsedProperties], user: User, result: ImportResultData): ImportResultData = {
-    laneAssetProperties.groupBy(lane => getPropertyValue(lane, "road number")).foreach { lane =>
-      lane._2.foreach { props =>
+  def createAsset(laneAssetProperties: Seq[ParsedProperties], user: User, result: ImportResultData): (ImportResultData, Set[Long]) = {
+    val createdLaneIds = laneAssetProperties.groupBy(lane => getPropertyValue(lane, "road number")).flatMap { lane =>
+      lane._2.flatMap { props =>
         val roadPartNumber = getPropertyValue(props, "road part").toLong
         val laneCode = getPropertyValue(props, "lane")
 
@@ -204,8 +207,9 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
         val laneRoadAddressInfo = LaneRoadAddressInfo(lane._1.toLong, roadPartNumber, initialDistance, roadPartNumber, endDistance, track)
         laneUtils.processNewLanesByRoadAddress(Set(incomingLane), laneRoadAddressInfo, sideCode.value, user.username, false)
       }
-    }
-    result
+    }.toSet
+
+    (result, createdLaneIds)
   }
 
   def importAssets(inputStream: InputStream, fileName: String, user: User, logId: Long): Unit = {
@@ -231,7 +235,7 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
       override val delimiter: Char = ';'
     })
 
-    withDynTransaction {
+   val (result, createdLaneIds) = withDynTransaction {
       val result = csvReader.allWithHeaders().foldLeft(ImportResultLaneAsset()) {
         (result, row) =>
           val csvRow = row.map(r => (r._1.toLowerCase(), r._2))
@@ -269,5 +273,22 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
       // Create the new lanes
       createAsset(result.createdData, user, result)
     }
+
+    //Lanes created from CSV-import have to be processed through fill topology to combine overlapping lanes etc.
+    val createdLanes = laneService.getPersistedLanesByIds(createdLaneIds)
+    val groupedLanes = createdLanes.groupBy(_.linkId)
+    val linkIds = createdLanes.map(_.linkId).toSet
+    val roadLinks = roadLinkService.getRoadLinksByLinkIdsFromVVH(linkIds)
+    val changeSet = laneFiller.fillTopology(roadLinks, groupedLanes)._2
+
+    //For reasons unknown fillTopology creates duplicate mValue adjustments for some lanes and
+    // tries to expire new lanes when used with lanes created by CSV-import, so we have to filter them out
+    val noNewLanes = changeSet.adjustedMValues.filterNot(_.laneId == 0)
+    val noDuplicateMValue = noNewLanes.groupBy(_.laneId).map(_._2.head).toSeq
+    val noNewLanesExpired = changeSet.expiredLaneIds.filterNot(_ == 0)
+    val changeSetFixed = changeSet.copy(adjustedMValues = noDuplicateMValue, expiredLaneIds = noNewLanesExpired)
+
+    updateChangeSet(changeSetFixed)
+    result
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
@@ -281,10 +281,10 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
 
     //For reasons unknown fillTopology creates duplicate mValue adjustments for some lanes and
     // tries to expire new lanes when used with lanes created by CSV-import, so we have to filter them out
-    val noNewLanes = changeSet.adjustedMValues.filterNot(_.laneId == 0)
-    val noDuplicateMValue = noNewLanes.groupBy(_.laneId).map(_._2.head).toSeq
-    val noNewLanesExpired = changeSet.expiredLaneIds.filterNot(_ == 0)
-    val changeSetFixed = changeSet.copy(adjustedMValues = noDuplicateMValue, expiredLaneIds = noNewLanesExpired)
+    val newLanesFilteredFromMValueAdj = changeSet.adjustedMValues.filterNot(_.laneId == 0)
+    val duplicatesFilteredFromMValueAdj = newLanesFilteredFromMValueAdj.groupBy(_.laneId).map(_._2.head).toSeq
+    val newLanesFilteredFromExpiredIds = changeSet.expiredLaneIds.filterNot(_ == 0)
+    val changeSetFixed = changeSet.copy(adjustedMValues = duplicatesFilteredFromMValueAdj, expiredLaneIds = newLanesFilteredFromExpiredIds)
 
     updateChangeSet(changeSetFixed)
     result

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -19,7 +19,7 @@ import org.joda.time.DateTime
 case class LaneUtils(){
   // DROTH-3057: Remove after lanes csv import is disabled
   def processNewLanesByRoadAddress(newLanes: Set[NewLane], laneRoadAddressInfo: LaneRoadAddressInfo,
-                                   sideCode: Int, username: String, withTransaction: Boolean = true): Any = {
+                                   sideCode: Int, username: String, withTransaction: Boolean = true): Set[Long] = {
     LaneUtils.processNewLanesByRoadAddress(newLanes, laneRoadAddressInfo, sideCode, username, withTransaction)
   }
 }
@@ -33,13 +33,14 @@ object LaneUtils {
   lazy val vvhClient: VVHClient = { new VVHClient(Digiroad2Properties.vvhRestApiEndPoint) }
   lazy val viiteClient: SearchViiteClient = { new SearchViiteClient(Digiroad2Properties.viiteRestApiEndPoint, HttpClientBuilder.create().build()) }
   lazy val roadAddressService: RoadAddressService = new RoadAddressService(viiteClient)
+  lazy val laneFiller: LaneFiller = new LaneFiller
 
 
   lazy val MAIN_LANES = Seq(MainLane.towardsDirection, MainLane.againstDirection, MainLane.motorwayMaintenance)
 
   // DROTH-3057: Remove after lanes csv import is disabled
   def processNewLanesByRoadAddress(newLanes: Set[NewLane], laneRoadAddressInfo: LaneRoadAddressInfo,
-                                   sideCode: Int, username: String, withTransaction: Boolean = true): Any = {
+                                   sideCode: Int, username: String, withTransaction: Boolean = true): Set[Long] = {
     // Main process
     def process() = {
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -33,7 +33,6 @@ object LaneUtils {
   lazy val vvhClient: VVHClient = { new VVHClient(Digiroad2Properties.vvhRestApiEndPoint) }
   lazy val viiteClient: SearchViiteClient = { new SearchViiteClient(Digiroad2Properties.viiteRestApiEndPoint, HttpClientBuilder.create().build()) }
   lazy val roadAddressService: RoadAddressService = new RoadAddressService(viiteClient)
-  lazy val laneFiller: LaneFiller = new LaneFiller
 
 
   lazy val MAIN_LANES = Seq(MainLane.towardsDirection, MainLane.againstDirection, MainLane.motorwayMaintenance)


### PR DESCRIPTION
CSV-importilla tuodut tierekkarin kaistat ajetaan nyt fillTopologyn lävitse luonnin jälkeen, jotta voidaan korjata luonnissa syntyviä ongelmia, kuten päällekkäisyyksiä ja linkin pituuden ylittäviä kaistoja. Aikaisemmin kun on samuutettu lennossa käyttäjän siirtäessä karttaa niin tämä on tehty siinä vaiheessa.