### PR TITLE
DROTH-3061 change test to run with rollback and convert string to enum

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2665,7 +2665,7 @@ object DataFixture {
       case Some("initial_main_lane_population") =>
         MainLanePopulationProcess.initialProcess()
       case Some("redundant_traffic_direction_removal") =>
-        redundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB()
+        withDynTransaction(redundantTrafficDirectionRemoval.deleteRedundantTrafficDirectionFromDB())
       case _ => println("Usage: DataFixture test | import_roadlink_data |" +
         " split_speedlimitchains | split_linear_asset_chains | dropped_assets_csv | dropped_manoeuvres_csv |" +
         " unfloat_linear_assets | expire_split_assets_without_mml | generate_values_for_lit_roads | get_addresses_to_masstransitstops_from_vvh |" +

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -3,26 +3,21 @@ package fi.liikennevirasto.digiroad2.util
 import fi.liikennevirasto.digiroad2.client.vvh.VVHRoadlink
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.dao.RoadLinkDAO
-import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 
 class RedundantTrafficDirectionRemoval(roadLinkService: RoadLinkService) {
 
-  def withDynTransaction(f: => Unit): Unit = PostGISDatabase.withDynTransaction(f)
-
   def deleteRedundantTrafficDirectionFromDB(): Unit = {
-    withDynTransaction {
-      val linkIds = RoadLinkDAO.TrafficDirectionDao.getLinkIds().toSet
-      val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds)
-      vvhRoadlinks.foreach(vvhRoadLink => findAndDeleteRedundant(vvhRoadLink))
-    }
+    val linkIds = RoadLinkDAO.TrafficDirectionDao.getLinkIds().toSet
+    val vvhRoadlinks = roadLinkService.fetchVVHRoadlinks(linkIds)
+    vvhRoadlinks.foreach(vvhRoadLink => findAndDeleteRedundant(vvhRoadLink))
 
     def findAndDeleteRedundant(vvhRoadlink: VVHRoadlink): Unit = {
-      val optionalExistingValue: Option[Int] = RoadLinkDAO.get("traffic_direction", vvhRoadlink.linkId)
-      val optionalVVHValue: Option[Int] = RoadLinkDAO.getVVHValue("traffic_direction", vvhRoadlink)
+      val optionalExistingValue: Option[Int] = RoadLinkDAO.get(RoadLinkDAO.TrafficDirection, vvhRoadlink.linkId)
+      val optionalVVHValue: Option[Int] = RoadLinkDAO.getVVHValue(RoadLinkDAO.TrafficDirection, vvhRoadlink)
       (optionalExistingValue, optionalVVHValue) match {
         case (Some(existingValue), Some(vvhValue)) =>
           if (existingValue == vvhValue) {
-            RoadLinkDAO.delete("traffic_direction", vvhRoadlink.linkId)
+            RoadLinkDAO.delete(RoadLinkDAO.TrafficDirection, vvhRoadlink.linkId)
           }
         case (_, _) =>
           //do nothing


### PR DESCRIPTION
Vaihdettu testi ajamaan rollbackilla ja suorat "traffic_direction" -merkkijonot enumiksi.