### PR TITLE
DROTH-3098 Added filter for problems in fillTopology

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
@@ -287,7 +287,10 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
         val newLanesFilteredFromMValueAdj = changeSet.adjustedMValues.filterNot(_.laneId == 0)
         val duplicatesFilteredFromMValueAdj = newLanesFilteredFromMValueAdj.groupBy(_.laneId).map(_._2.head).toSeq
         val newLanesFilteredFromExpiredIds = changeSet.expiredLaneIds.filterNot(_ == 0)
-        val changeSetFixed = changeSet.copy(adjustedMValues = duplicatesFilteredFromMValueAdj, expiredLaneIds = newLanesFilteredFromExpiredIds)
+        val newLanesFilteredFromVVHAdj = changeSet.adjustedVVHChanges.filterNot(_.laneId == 0)
+        val newLanesFilteredFromSideCodeAdj = changeSet.adjustedSideCodes.filterNot(_.laneId == 0)
+        val changeSetFixed = changeSet.copy(adjustedMValues = duplicatesFilteredFromMValueAdj,
+          expiredLaneIds = newLanesFilteredFromExpiredIds, adjustedVVHChanges = newLanesFilteredFromVVHAdj, adjustedSideCodes = newLanesFilteredFromSideCodeAdj)
 
         updateChangeSet(changeSetFixed)
         result


### PR DESCRIPTION
FillTopology haluaa historioida kaistoja joiden id = 0 (uusi kaista, ei vielä luotu). Aikaisemmasta toteutuksesta oli jäänyt pari filtteröintiä pois. FillTopology toimii muuten ok, mutta tässä yhteydessä tulee ongelma kun yrittää historioida kaistoja joiden ID = 0, joten sen takia muutos tässä CSV-importin yhteydessä, eikä suoraan fillTopology