### PR TITLE
Droth 3099 create lane split point marker

### DIFF
--- a/UI/images/center-marker-red.svg
+++ b/UI/images/center-marker-red.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="25px" height="25px" viewBox="0 181.5 612 610.5" enable-background="new 0 181.5 612 610.5" xml:space="preserve">
+<g>
+	<circle fill="#FFFFFF" cx="306.5" cy="487" r="274.2"/>
+	<path fill="#8b0000" d="M306.5,219.7c148.9,0,267.3,118.4,267.3,267.3S455.4,754.3,306.5,754.3S39.2,635.9,39.2,487
+		S157.6,219.7,306.5,219.7 M306.5,181.5C138.4,181.5,1,318.9,1,487s137.4,305.5,305.5,305.5S612,655.1,612,487
+		S474.6,181.5,306.5,181.5L306.5,181.5z"/>
+	<circle fill="#ff0000" cx="306.5" cy="487" r="238.6"/>
+</g>
+<circle display="none" fill="#171717" cx="306.5" cy="487" r="134.1"/>
+</svg>

--- a/UI/src/view/linear_asset/laneModellingLayer.js
+++ b/UI/src/view/linear_asset/laneModellingLayer.js
@@ -295,10 +295,43 @@
         features.push(marker);
       };
 
+      var drawSplitPoints = function (links) {
+        function findSplitPoints(links) {
+          var sortedPoints = _.flatMap(links, function (link) {
+            return link.points;
+          }).sort(function (a, b) {
+            return a.x - b.x;
+          });
+          var foundSplitPoints = [];
+          for(var i = 1; i < sortedPoints.length; i++) {
+            var distance = Math.sqrt(Math.pow((sortedPoints[i].x - sortedPoints[i - 1].x), 2) + Math.pow((sortedPoints[i].y - sortedPoints[i - 1].y), 2));
+            if (distance < 0.001) {
+              foundSplitPoints.push(sortedPoints[i]);
+            }
+          }
+          return foundSplitPoints;
+        }
+        var splitPoints = findSplitPoints(links);
+
+        var style = new ol.style.Style({
+          image : new ol.style.Icon({src: 'images/center-marker-red.svg'}),
+          text : new ol.style.Text({text : "X", fill: new ol.style.Fill({color: '#ffffff'}), font : '12px sans-serif'})
+        });
+
+        splitPoints.forEach(function (point) {
+          var splitMarker = new ol.Feature({
+            geometry : new ol.geom.Point([point.x, point.y])
+          });
+          splitMarker.setStyle(style);
+          features.push(splitMarker);
+        });
+      };
+
       var indicatorsForSplit = function() {
-        return me.mapOverLinkMiddlePoints(links, function(link, middlePoint) {
+        me.mapOverLinkMiddlePoints(links, function(link, middlePoint) {
           markerContainer(link, middlePoint);
         });
+        drawSplitPoints(links);
       };
 
       indicatorsForSplit();


### PR DESCRIPTION
Katkaisukohdan päälle piirretään rasti punaisella taustalla, jotta erottuu paremmin A ja B merkeistä. Tätä varten luotu punainen piste. Toteutuksen on tarkoitus mahdollistaa usean katkaisukohdan visualisointi sitten, kun kaista voidaan katkaista useasta kohdasta.
![katkaisu](https://user-images.githubusercontent.com/95400826/153825761-bf2c41d2-f7bc-4daa-a179-743a5bb94766.JPG)

