### PR TITLE
DROTH-3154 Integration test build error fix

### DIFF
--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -487,7 +487,12 @@
     return _(groupedPointAssets).find({ layerName: layerName }).selectedPointAsset;
   }
 
-  var isProduction = this.Environment.name() == 'production';
+  //Used to check if we are on prod environment, for now we hide Lane Modelling Tool in prod
+  function isProduction()  {
+    var url = window.location.href.split('/');
+    var urlParts = _.filter(url, function(urlPart) { return !_.isEmpty(urlPart); });
+    return urlParts[1] === 'digiroad.vaylapilvi.fi' || urlParts[1] === 'extranet.vayla.fi';
+  }
 
   function groupLinearAssets(assetConfiguration,
                        linearAssets,
@@ -507,7 +512,7 @@
     var pavedRoadBox = new PavedRoadBox(_.find(linearAssets, {typeId: assetType.pavedRoad}));
     var parkingProhibitionBox = new ParkingProhibitionBox(_.find(linearAssets, {typeId: assetType.parkingProhibition}));
     var cyclingAndWalking = new CyclingAndWalkingBox(_.find(linearAssets, {typeId: assetType.cyclingAndWalking}));
-    var laneModellingBox = !isProduction ? new LaneModellingBox(_.find(linearAssets, {typeId: assetType.laneModellingTool})) : [];
+    var laneModellingBox = !isProduction() ? new LaneModellingBox(_.find(linearAssets, {typeId: assetType.laneModellingTool})) : [];
     return [
       [roadLinkBox]
           .concat(laneModellingBox)

--- a/UI/test/run-integration-tests.js
+++ b/UI/test/run-integration-tests.js
@@ -39,8 +39,7 @@ require(['chai',
          'integration-tests/groupingInCreationSpec',
          'integration-tests/singleSegmentSpeedLimitSpec',
          'integration-tests/speedLimitSplitSpec',
-         'integration-tests/multiSegmentSpeedLimitSpec',
-         'utils/environment-utils'
+         'integration-tests/multiSegmentSpeedLimitSpec'
         ],
         function(chai, chaiJquery, testHelpers) {
   chai.use(chaiJquery);


### PR DESCRIPTION
Frontin Integraatio-testit menivät rikki edellisestä muutoksesta (ja sen korjausyrityksestä). Selvityksestä huolimatta en saanut testejä korjattua, joten alkuperäinen muutos nyt tehty käyttämättä this.Environment.name() arvoa. Toiminnallisuus pysyi nyt samana ja testit on OK, ympäristön tarkistus tehdään nyt vain application.js