### PR TITLE
DROTH-3157 Increased qa job definition memory to max 30gb

### DIFF
--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -15,7 +15,7 @@
     "resourceRequirements" : [
       {
         "type": "MEMORY",
-        "value": "25600"
+        "value": "30000"
       },
       {
         "type": "VCPU",

--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -15,7 +15,7 @@
     "resourceRequirements" : [
       {
         "type": "MEMORY",
-        "value": "30000"
+        "value": "30720"
       },
       {
         "type": "VCPU",


### PR DESCRIPTION
Lisätty qa job definitionin muistia maximiin 30gb