### PR TITLE
DROTH-3162 Added X-Api-Key parameter to Swagger definition for all APIs

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -36,7 +36,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
         queryParam[String]("until").description("The end date of the interval between two dates to obtain modifications for an asset."),
         queryParam[String]("withAdjust").description("With the field withAdjust, we allow or not the presence of records modified by vvh_generated and not modified yet on the response. The value is False by default").optional,
         queryParam[String]("withGeometry").description("With the field withGeometry, we allow or not to print the geometry values for lane_information. The value is False by default").optional,
-        pathParam[String]("assetType").description("Asset type name to get the changes")
+        pathParam[String]("assetType").description("Asset type name to get the changes"),
+        headerParam[String]("X-API-Key").description("Authentication Api key")
       )
       tags "Change API"
       summary "List all changes per assets type between two specific dates."
@@ -49,7 +50,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
     (apiOperation[Long]("getMassTransitStopsPrintedAtValluXML")
       .parameters(
         queryParam[String]("since").description("Initial date of the interval between two dates to obtain modifications for a particular asset."),
-        queryParam[String]("until").description("The end date of the interval between two dates to obtain modifications for an asset.")
+        queryParam[String]("until").description("The end date of the interval between two dates to obtain modifications for an asset."),
+        headerParam[String]("X-API-Key").description("Authentication Api key")
       )
       tags "Change API"
       summary "List all Mass Transit Stops printed on Vally XML file between two specific dates."

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -867,7 +867,8 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
         queryParam[String]("since").description("Initial date of the interval between two dates to obtain modifications for a particular asset."),
         queryParam[String]("until").description("The end date of the interval between two dates to obtain modifications for an asset.").optional,
         queryParam[String]("withAdjust").description("With the field withAdjust, we allow or not the presense of records modified by vvh_generated and not modified yet on the response. The value is True by default.").optional,
-        pathParam[String]("assetType").description("Asset type name to get the changes")
+        pathParam[String]("assetType").description("Asset type name to get the changes"),
+        headerParam[String]("X-API-Key").description("Authentication Api key")
       )
       tags "Integration API (Kalpa API)"
       summary "List all changes per assets type between two specific dates."
@@ -914,7 +915,8 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
     (apiOperation[Long]("getAssetsByTypeMunicipality")
       .parameters(
         queryParam[Int]("municipality").description("Municipality Code where we will execute the search by specific asset type"),
-        pathParam[String]("assetType").description("Asset type name to get all assets")
+        pathParam[String]("assetType").description("Asset type name to get all assets"),
+        headerParam[String]("X-API-Key").description("Authentication Api key")
       )
       tags "Integration API (Kalpa API)"
       summary "List all valid assets on a specific municipality."

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -37,7 +37,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
         queryParam[Int]("start_addrm").description("Starting distance on starting roadPart for search"),
         queryParam[Int]("end_part").description("Ending road part number for search"),
         queryParam[Int]("end_addrm").description("Ending distance on last road part for search"),
-        pathParam[String]("lanes_in_range").description("Path for getting lanes in given range")
+        headerParam[String]("X-API-Key").description("Authentication Api key")
       )
       tags "LaneApi"
       summary "Get lanes in given road address range in road address format"
@@ -49,7 +49,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     (apiOperation[Long]("getLanesInMunicipality")
       .parameters(
         queryParam[Int]("municipality").description("Municipality Code where we will get lanes from"),
-        pathParam[String]("lanes_in_municipality").description("Path for getting lanes in municipality")
+        headerParam[String]("X-API-Key").description("Authentication Api key")
       )
       tags "LaneApi"
       summary "Get lanes in given municipality"

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ServiceRoadAPI.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ServiceRoadAPI.scala
@@ -47,9 +47,12 @@ class ServiceRoadAPI(val maintenanceService: MaintenanceService, val roadLinkSer
 
   val getServiceRoadByBoundingBox =
     (apiOperation[List[serviceRoadApiResponseOnGetExample]]("getServiceRoadByBoundingBox")
+      .parameters(
+        queryParam[String]("boundingBox").description("The bounding box is used to search assets inside ít, is defined with coordinates of top left and bottom right corner."),
+        headerParam[String]("X-API-Key").description("Authentication Api key")
+      )
       tags "Service Road API (Huoltotie API)"
       summary "Returns all Service Road assets inside bounding box. Can be used to get all assets on the UI map area."
-      parameter queryParam[String]("boundingBox").description("The bounding box is used to search assets inside ít, is defined with coordinates of top left and bottom right corner.")
       description
       "Bounding box is defined with coordinates of top left and bottom right corner \n" +
         "URL: /digiroad/api/livi/huoltotiet/?boundingBox={x1},{y1},{x2},{y2} \n" +
@@ -66,9 +69,12 @@ class ServiceRoadAPI(val maintenanceService: MaintenanceService, val roadLinkSer
 
   val getServiceRoadByAreaId =
     (apiOperation[List[serviceRoadApiResponseOnGetExample]]("getServiceRoadByAreaId")
+      .parameters(
+      pathParam[String]("areaId").description("Area id refers to the area where the search is going to be done."),
+      headerParam[String]("X-API-Key").description("Authentication Api key")
+    )
       tags "Service Road API (Huoltotie API)"
       summary "Returns all Huoltotie assets inside service area."
-      parameter pathParam[String]("areaId").description("Area id refers to the area where the search is going to be done.")
       description
       "Service areas are a polygonal area defined in OTH. \n" +
         "ServiceAreaId is an integer between 1-12. \n" +


### PR DESCRIPTION
Lisätty X-Api-Key header parametri kaikkien DR rajapintojen Swaggeriin mukaan. Testatessa rajapintaa Swaggerilla voi siis syöttää Api avaimen, jolloin Swaggerin pitäisi toimia AWS-ympäristössä. Timeout tulee olemaan vielä ongelma joillain rajapinnoilla toistaiseksi.