### PR TITLE
DROTH-3163 Added missing Lambda permissions for dev qa and prod batch…

### DIFF
--- a/aws/cloud-formation/batchSystem/batchSystem.yaml
+++ b/aws/cloud-formation/batchSystem/batchSystem.yaml
@@ -380,7 +380,104 @@ Resources:
           Input: "{ \"jobName\": \"DEV\", \"jobDefinition\": \"DEVBatchDefinition\", \"type\": \"daily\" }"
           Id: "DEVDailyLambda"
 
+  #Lambda permissions for prod events
+  ProdAnnualLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ProdRunAnnualBatch.Arn
 
+  ProdMonthlyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ProdRunMonthlyBatch.Arn
+
+  ProdWeeklyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ProdRunWeeklyBatch.Arn
+
+  ProdDailyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt ProdRunDailyBatch.Arn
+
+  #Lambda permissions for QA events
+  QAAnnualLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt QARunAnnualBatch.Arn
+
+  QAMonthlyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt QARunMonthlyBatch.Arn
+
+  QAWeeklyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt QARunWeeklyBatch.Arn
+
+  QADailyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt QARunDailyBatch.Arn
+
+  #Lambda permissions for DEV events
+  DEVAnnualLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DEVRunAnnualBatch.Arn
+
+  DEVMonthlyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DEVRunMonthlyBatch.Arn
+
+  DEVWeeklyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DEVRunWeeklyBatch.Arn
+
+  DEVDailyLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !Ref BatchLambdaArn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt DEVRunDailyBatch.Arn
 
 Outputs:
   BatchTaskRoleARN:


### PR DESCRIPTION
Lisätty kaikille batch ajastus eventeille lambda permission Batch-Add-Jobs-To-Queue lambdan kutsumiseen. Permissionin SourceArn:lle ei voinut antaa useaa ARN kerralla joten piti luoda joka eventille oma permission 