### PR TITLE
DROTH-3142 filtered lanes which will be expired and deleted from modi…

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
@@ -74,8 +74,8 @@ object ChangeLanesAccordingToVvhChanges {
 
     val modifiedLanes = projectedLanes.filterNot(lane => {
       val generatedLane = generatedMappedById.getOrElse(lane.id, Seq())
-      if(generatedLane.isEmpty) logger.info("No generated lane found for key: " + lane.id)
-        generatedLane.nonEmpty || changeSetLanes.contains(lane.id)
+      if (generatedLane.isEmpty) logger.info("No generated lane found for key: " + lane.id)
+      generatedLane.nonEmpty || changeSetLanes.contains(lane.id)
     }) ++ changeSet.generatedPersistedLanes
 
     updateChangeSet(changeSet)


### PR DESCRIPTION
Kaistojen samuutus persistModifiedLinearAssets-tallennusfunktiossa historioida jo aikaisemmassa updateChangeSet-tallennusfunktiossa poistettuja kaistoja. Tämä estetty nyt filtteröinnillä