### PR TITLE
 DROTH-3168 fix regresion

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -703,7 +703,9 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   protected def roadLinkToApiWithLaneInfo(roadLinks:Seq[RoadLink],withLaneInfo: Boolean = false): Seq[Map[String,Any]] = {
       roadLinks.map(rl=>{roadLinkToApi(rl,withLaneInfo)})
   }
-  
+  /**
+    * Enrich roadlink with lane information before turning withLaneInfo flag true
+    */
   def roadLinkToApi(roadLink: RoadLink, withLaneInfo: Boolean = false): Map[String, Any] = {
     val laneInfo = if(withLaneInfo) roadLink.lanes else Seq()
 
@@ -813,8 +815,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   get("/roadlinks/adjacents/:ids") {
     val user = userProvider.getCurrentUser()
     val ids = params("ids").split(',').map(_.toLong)
-    val links = roadLinkService.getAdjacents(ids.toSet).mapValues(_.filter(link => user.isAuthorizedToWrite(link.municipalityCode))).values.head
-    roadLinkToApiWithLaneInfo(links)
+    roadLinkService.getAdjacents(ids.toSet).mapValues(_.filter(link => user.isAuthorizedToWrite(link.municipalityCode))).mapValues(_.map(rl => roadLinkToApi(rl)))
   }
 
   get("/roadlinks/complementaries"){


### PR DESCRIPTION
Regresiota tuli kun muutettiin käyttämään .values.head, palautetaan vanha systeemi takaisin ja lisätään kommentti rikastaa kaista datalla ennen kuin laittaa päälle withLaneInfo.