### PR TITLE
Droth 3167 Add env property for local development

### DIFF
--- a/conf/env.properties
+++ b/conf/env.properties
@@ -36,6 +36,7 @@ googlemapapi.crypto_key=ZYX321
 
 #aws properties
 apiS3BucketName=dev-vayla-digiroad2-api-store-bucket
+awsConnectionEnabled=false
 
 #smtp.properties
 ses.username=sesusername


### PR DESCRIPTION
Asetetaan lokaalissa kehityksessä awsConnectionEnabled falseksi, jotta ei turhaan tallenneta rajapintojen vastauksia s3.