### PR TITLE
DROTH-3188 Parametrize s3 object ttl and change unit to seconds

### DIFF
--- a/aws/cloud-formation/taskdefinition/dev-create-taskdefinition.yaml
+++ b/aws/cloud-formation/taskdefinition/dev-create-taskdefinition.yaml
@@ -19,6 +19,10 @@ Parameters:
     Type: String
     Default: dev-vayla-digiroad2-api-store-bucket
     Description: Name of s3 bucket for apis
+  ApiS3ObjectTTLSeconds:
+    Type: Number
+    Default: 300
+    Description: Seconds, how long s3 object can be fetched after last modification
 
 Resources:
   ECSTaskExecutionRoleForTaskDefinitionDigiroad:
@@ -158,6 +162,8 @@ Resources:
               Value: 'https://api.vaylapilvi.fi/rasteripalvelu-mml'
             - Name: apiS3BucketName
               Value: !Sub '${ApiS3BucketName}'
+            - Name: apiS3ObjectTTLSeconds
+              Value: !Sub '${ApiS3ObjectTTLSeconds}'
           Secrets:
             - Name: bonecp.password
               ValueFrom: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/dev/bonecp.password'

--- a/aws/cloud-formation/taskdefinition/prod-create-taskdefinition.yaml
+++ b/aws/cloud-formation/taskdefinition/prod-create-taskdefinition.yaml
@@ -19,6 +19,10 @@ Parameters:
     Type: String
     Default: prod-vayla-digiroad2-api-store-bucket
     Description: Name of s3 bucket for apis
+  ApiS3ObjectTTLSeconds:
+    Type: Number
+    Default: 300
+    Description: Seconds, how long s3 object can be fetched after last modification
 
 Resources:
   ECSTaskExecutionRoleForTaskDefinitionDigiroad:
@@ -157,6 +161,8 @@ Resources:
               Value: 'https://api.vaylapilvi.fi/rasteripalvelu-mml'
             - Name: apiS3BucketName
               Value: !Sub '${ApiS3BucketName}'
+            - Name: apiS3ObjectTTLSeconds
+              Value: !Sub '${ApiS3ObjectTTLSeconds}'
           Secrets:
             - Name: bonecp.password
               ValueFrom: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/prod/bonecp.password'

--- a/aws/cloud-formation/taskdefinition/qa-create-taskdefinition.yaml
+++ b/aws/cloud-formation/taskdefinition/qa-create-taskdefinition.yaml
@@ -19,6 +19,10 @@ Parameters:
     Type: String
     Default: qa-vayla-digiroad2-api-store-bucket
     Description: Name of s3 bucket for apis
+  ApiS3ObjectTTLSeconds:
+    Type: Number
+    Default: 300
+    Description: Seconds, how long s3 object can be fetched after last modification
 
 Resources:
   ECSTaskExecutionRoleForTaskDefinitionDigiroad:
@@ -159,6 +163,8 @@ Resources:
               Value: 'https://api.vaylapilvi.fi/rasteripalvelu-mml'
             - Name: apiS3BucketName
               Value: !Sub '${ApiS3BucketName}'
+            - Name: apiS3ObjectTTLSeconds
+              Value: !Sub '${ApiS3ObjectTTLSeconds}'
           Secrets:
             - Name: bonecp.password
               ValueFrom: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/qa/bonecp.password'

--- a/conf/env.properties
+++ b/conf/env.properties
@@ -36,6 +36,7 @@ googlemapapi.crypto_key=ZYX321
 
 #aws properties
 apiS3BucketName=dev-vayla-digiroad2-api-store-bucket
+apiS3ObjectTTLSeconds=300
 awsConnectionEnabled=false
 
 #smtp.properties

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
@@ -50,15 +50,15 @@ class AwsService {
     }
 
     def isS3ObjectAvailable(s3Bucket: String, workId: String, waitTimeMillis: Long,
-                            modifiedWithinHours: Option[Int] = None): Boolean = {
+                            modifiedWithinSeconds: Option[Int] = None): Boolean = {
       try {
         val waiter = s3.waiter()
         val waitRequest = HeadObjectRequest.builder()
                                            .bucket(s3Bucket)
                                            .key(workId)
         val waitRequestBuilt =
-          if (modifiedWithinHours.nonEmpty)
-            waitRequest.ifModifiedSince(Instant.now().minus(modifiedWithinHours.get, ChronoUnit.HOURS)).build()
+          if (modifiedWithinSeconds.nonEmpty)
+            waitRequest.ifModifiedSince(Instant.now().minus(modifiedWithinSeconds.get, ChronoUnit.SECONDS)).build()
           else waitRequest.build()
         val waiterOverrides = WaiterOverrideConfiguration.builder()
                                                          .waitTimeout(java.time.Duration.ofMillis(waitTimeMillis))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/Digiroad2Properties.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/Digiroad2Properties.scala
@@ -49,6 +49,7 @@ trait Digiroad2Properties {
   val rasterServiceUrl: String
   val rasterServiceApiKey: String
   val apiS3BucketName: String
+  val apiS3ObjectTTLSeconds: String
   val awsConnectionEnabled: Boolean
   val bonecpProperties: Properties
   val batchMode:Boolean
@@ -88,6 +89,7 @@ class Digiroad2PropertiesFromEnv extends Digiroad2Properties {
   val rasterServiceUrl: String = scala.util.Properties.envOrElse("rasterServiceUrl", null)
   val rasterServiceApiKey: String = scala.util.Properties.envOrElse("rasterService.apikey", null)
   val apiS3BucketName: String = scala.util.Properties.envOrElse("apiS3BucketName", null)
+  val apiS3ObjectTTLSeconds: String = scala.util.Properties.envOrElse("apiS3ObjectTTLSeconds", null)
   val awsConnectionEnabled: Boolean = scala.util.Properties.envOrElse("awsConnectionEnabled", "true").toBoolean
   val batchMode: Boolean = scala.util.Properties.envOrElse("batchMode", "false").toBoolean
 
@@ -177,6 +179,7 @@ class Digiroad2PropertiesFromFile extends Digiroad2Properties {
   override val rasterServiceUrl: String = envProps.getProperty("rasterServiceUrl")
   override val rasterServiceApiKey: String = envOrProperties("rasterService.apikey")
   override val apiS3BucketName: String = envOrProperties("apiS3BucketName")
+  override val apiS3ObjectTTLSeconds: String = envOrProperties("apiS3ObjectTTLSeconds")
   override val awsConnectionEnabled: Boolean = envProps.getProperty("awsConnectionEnabled", "true").toBoolean
   override val batchMode: Boolean =  envProps.getProperty("batchMode", "false").toBoolean
 
@@ -258,6 +261,7 @@ object Digiroad2Properties {
   lazy val rasterServiceUrl: String = properties.rasterServiceUrl
   lazy val rasterServiceApiKey:String = properties.rasterServiceApiKey
   lazy val apiS3BucketName: String = properties.apiS3BucketName
+  lazy val apiS3ObjectTTLSeconds: String = properties.apiS3ObjectTTLSeconds
   lazy val awsConnectionEnabled: Boolean = properties.awsConnectionEnabled
   lazy val batchMode: Boolean = properties.batchMode
 


### PR DESCRIPTION
S3 objektin elinaika parametrisoitu ja yksiköksi vaihdettu sekunti. Default arvoksi laitettu nyt 300 sekuntia eli 5min.