### PR TITLE
DROTH-3192 Split viite requests into groups and increase vvh future d…

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -91,8 +91,11 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
     * @param linkIds The road link ids
     * @return
     */
+  //resolving_frozen_links batch keeps crashing here because of Viite API GW limits, temporary fix implemented
+  //TODO Rollback this grouping fix after Viite has implemented API GW limitation work-around
   def getAllByLinkIds(linkIds: Seq[Long]): Seq[RoadAddress] = {
-    viiteClient.fetchAllByLinkIds(linkIds)
+    val linkIdsSplit = linkIds.grouped(1000).toSeq
+    linkIdsSplit.flatMap(linkIdGroup => viiteClient.fetchAllByLinkIds(linkIdGroup))
   }
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -623,7 +623,7 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
     val links1F = vvhClient.roadLinkData.fetchByMunicipalitiesAndBoundsF(bounds, Set())
     val links2F = vvhClient.roadLinkData.fetchByMunicipalitiesAndBoundsF(bounds2, Set())
     val changeF = vvhClient.roadLinkChangeInfo.fetchByBoundsAndMunicipalitiesF(bounds, Set())
-    val ((links, links2), changes) = Await.result(links1F.zip(links2F).zip(changeF), atMost = Duration.apply(60, TimeUnit.SECONDS))
+    val ((links, links2), changes) = Await.result(links1F.zip(links2F).zip(changeF), atMost = Duration.apply(120, TimeUnit.SECONDS))
     if(newTransaction)
       withDynTransaction {
         (enrichRoadLinksFromVVH(links ++ links2, changes), changes)


### PR DESCRIPTION
resolving_frozen_links lokeista nähty, että kaatunut getAllByLinkIds kutsuihin Viite API GW rajoitusten vuoksi. Kutsut splitattu 1000 linkId joukkoihin. Batchissa haetaan myös VVH:sta bounding boxilla linkkejä ja Futuren 60s timeout oli paukkunut kerran: nostettu duration 120s varmuuden vuoksi, vaikka taisikin olla harvinaisempi ongelma ja toistunut vain kerran