### PR TITLE
DROTH-3207 Fixed mistake in cron day-of-the-month

### DIFF
--- a/aws/cloud-formation/batchSystem/batchSystem.yaml
+++ b/aws/cloud-formation/batchSystem/batchSystem.yaml
@@ -273,7 +273,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "Run daily Prod batches"
-      ScheduleExpression: "cron(30 22 * * 1-5 *)"
+      ScheduleExpression: "cron(30 22 ? * 1-5 *)"
       State: "ENABLED"
       Targets:
         -
@@ -323,7 +323,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "Run daily QA batches"
-      ScheduleExpression: "cron(30 22 * * 1-5 *)"
+      ScheduleExpression: "cron(30 22 ? * 1-5 *)"
       State: "ENABLED"
       Targets:
         -
@@ -372,7 +372,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       Description: "Run daily DEV batches"
-      ScheduleExpression: "cron(30 22 * * 1-5 *)"
+      ScheduleExpression: "cron(30 22 ? * 1-5 *)"
       State: "ENABLED"
       Targets:
         -


### PR DESCRIPTION
Jäi huomaamatta, että cron day-of-the-month pitää olla ? jos day-of-the-week on määritelty. Stacki päivitetty nyt tällä.