### PR TITLE
DROTH-3170 fixed bug and unit test

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ValidateLaneChangesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ValidateLaneChangesAccordingToVvhChanges.scala
@@ -80,13 +80,14 @@ object ValidateLaneChangesAccordingToVvhChanges {
 
   def validateMainLaneAmount(roadLinks: Seq[RoadLink], mainLanesOnRoadLinks: Seq[PersistedLane]): Seq[RoadLink] = {
     val lanesMapped = mainLanesOnRoadLinks.groupBy(_.linkId)
+    val roadLinksWithoutMainLanes = roadLinks.filterNot(rl => lanesMapped.keys.toSeq.contains(rl.linkId))
     lanesMapped.flatMap(pair => {
       val roadLink = roadLinks.find(_.linkId == pair._1)
       val lanesOnLink = pair._2
       roadLink match {
         case Some(rl) => checkLinksMainLanes(rl, lanesOnLink)
       }
-    }).toSeq
+    }).toSeq ++ roadLinksWithoutMainLanes
 
   }
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/ValidateLaneChangesAccordingToVvhChangesSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/ValidateLaneChangesAccordingToVvhChangesSpec.scala
@@ -56,7 +56,7 @@ class ValidateLaneChangesAccordingToVvhChangesSpec extends FunSuite with Matcher
     val lanes = createLanes()
 
     val roadLinksWithInvalidAmountOfMl = validateMainLaneAmount(roadLinks, lanes)
-    roadLinksWithInvalidAmountOfMl.size should equal(4)
+    roadLinksWithInvalidAmountOfMl.size should equal(3)
   }
 
   test("One inconsistent lane should be found"){


### PR DESCRIPTION
Buildi failasi, koska oli jäänyt bugi korjatessa samuutuksen lopputuloksen validointia, ei huomioitu linkkejä joilla ei ollenkaan pääkaistoja kun validoidaan pääkaistojen määrää. Validointieräajon koodi ja yksikkötestit käyty läpi, ei löytynyt muita ongelmia.