### PR TITLE
DROTH-3175 fixed bug with saving changed lanes. Only new lanes saved …

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
@@ -42,7 +42,8 @@ object ChangeLanesAccordingToVvhChanges {
     val latestHistoryRoadLinks = historyLinks.map(_._2.minBy(_.vvhTimeStamp)).toSeq
 
     val (changeSet, modifiedLanes) = handleChanges(roadLinks,latestHistoryRoadLinks, changes, existingAssets)
-    saveChanges(changeSet, modifiedLanes)
+    val onlyNewModifiedLanes = modifiedLanes.filter(lane => lane.id == 0)
+    saveChanges(changeSet, onlyNewModifiedLanes)
   }
 
   def handleChanges(roadLinks: Seq[RoadLink], historyRoadLinks: Seq[RoadLink], changes: Seq[ChangeInfo], existingAssets: Seq[PersistedLane]): (ChangeSet, Seq[PersistedLane]) = {


### PR DESCRIPTION
Samuutuksen lopputuloksen tallennuksessa virhe, persistModifiedLinearAssets tallennusfunktiolle vietiin jo olemassa olevien kaistojen muutoksia tallennettavaksi, updateChangeSet kuuluu hoitaa se. persistModifiedLinearAssets hoitaa nyt vain uusien samuutuksen seurauksena luotujen kaistojen tallennuksen.