### PR TITLE
Droth 3109 lane split problems

### DIFF
--- a/UI/src/controller/laneModellingCollection.js
+++ b/UI/src/controller/laneModellingCollection.js
@@ -42,7 +42,7 @@
       right.points = split.secondSplitVertices;
       right.startMeasure = split.splitMeasure;
 
-      if (self.calculateMeasure(left) < self.calculateMeasure(right)) {
+      if (left.startMeasure < right.startMeasure) {
         self.splitLinearAssets.created = left;
         self.splitLinearAssets.existing = right;
       } else {
@@ -52,9 +52,6 @@
 
       self.splitLinearAssets.created.id = 0;
       self.splitLinearAssets.existing.id = 0;
-
-      self.splitLinearAssets.created.marker = 'A';
-      self.splitLinearAssets.existing.marker = 'B';
 
       self.dirty = true;
       callback(self.splitLinearAssets);

--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -387,7 +387,7 @@
 
       //expiredLane could be modified by the user so we need to fetch the original
       var originalExpiredLane = _.find(lanesFetched, {'id': expiredLane.id});
-      if (linksSelected.length > 1 && marker === undefined) {
+      if (linksSelected.length > 1 && _.isUndefined(marker)) {
         var expiredGroup = collection.getGroup(originalExpiredLane);
         expiredGroup.forEach(function (lane) {
           lane.isExpired = true;

--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -78,13 +78,16 @@
         return lane.endMeasure;
       });
 
-      var charCount = 0;
-      for (var i = 0; i < lanesSortedByEndMeasure.length; i++) {
-        if (_.includes(laneCodesToPutMarkers, getLaneCodeValue(lanesSortedByEndMeasure[i]).toString())) {
-          lanesSortedByEndMeasure[i].marker = String.fromCharCode(charCount + 65);
-          charCount += 1;
+      _.forEach(laneCodesToPutMarkers, function (laneCode) {
+        var characterCounterForLaneMarker = 0;
+        for (var i = 0; i < lanesSortedByEndMeasure.length; i++) {
+          if (laneCode == getLaneCodeValue(lanesSortedByEndMeasure[i]).toString()) {
+            //The integer value of 'A' is 65, so every increment in the counter gives the next letter of the alphabet.
+            lanesSortedByEndMeasure[i].marker = String.fromCharCode(characterCounterForLaneMarker + 65);
+            characterCounterForLaneMarker += 1;
+          }
         }
-      }
+      });
 
       return lanesSortedByEndMeasure;
     };

--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -74,28 +74,26 @@
         return numberOfLanesByLaneCode[key] > 1;
       });
 
-      var lanesSortedByLaneCode = _.sortBy(lanes, getLaneCodeValue);
-
-      var duplicateLaneCounter = 0;
-      return _.map(lanesSortedByLaneCode, function (lane) {
-        if(_.includes(laneCodesToPutMarkers, getLaneCodeValue(lane).toString())) {
-          if (duplicateLaneCounter === 0){
-            lane.marker = 'A';
-            duplicateLaneCounter++;
-          }else{
-            lane.marker = 'B';
-            duplicateLaneCounter--;
-          }
-        }
-        return lane;
+      var lanesSortedByEndMeasure = _.sortBy(lanes, function(lane) {
+        return lane.endMeasure;
       });
+
+      var charCount = 0;
+      for (var i = 0; i < lanesSortedByEndMeasure.length; i++) {
+        if (_.includes(laneCodesToPutMarkers, getLaneCodeValue(lanesSortedByEndMeasure[i]).toString())) {
+          lanesSortedByEndMeasure[i].marker = String.fromCharCode(charCount + 65);
+          charCount += 1;
+        }
+      }
+
+      return lanesSortedByEndMeasure;
     };
 
     //Outer lanes that are expired are to be considered, the other are updates so we need to take those out
     //Here a outer lane is a lane with lane code that existed in the original but not in the modified configuration
     function omitIrrelevantExpiredLanes() {
       var lanesToBeRemovedFromExpire = _.filter(assetsToBeExpired, function (lane) {
-        return !_.isUndefined(self.getLane(getLaneCodeValue(lane)));
+        return !self.isOuterLane(getLaneCodeValue(lane));
       });
 
       _.forEach(lanesToBeRemovedFromExpire, function (lane) {
@@ -103,15 +101,12 @@
       });
     }
 
-    self.splitLinearAsset = function(laneNumber, split) {
-      collection.splitLinearAsset(self.getLane(laneNumber), split, function(splitLinearAssets) {
-        if (self.getLane(laneNumber).id === 0) {
-          self.removeLane(laneNumber);
-        } else {
-          self.expireLane(laneNumber);
-        }
-
+    self.splitLinearAsset = function(laneNumber, split, laneMarker) {
+      collection.splitLinearAsset(self.getLane(laneNumber, laneMarker), split, function(splitLinearAssets) {
+        var laneIndex = getLaneIndex(laneNumber, laneMarker);
+        self.selection.splice(laneIndex,1);
         self.selection.push(splitLinearAssets.created, splitLinearAssets.existing);
+        self.selection = giveSplitMarkers(self.selection);
         self.dirty = true;
         eventbus.trigger('laneModellingForm: reload');
       });
@@ -198,18 +193,25 @@
 
     self.lanesCutAreEqual = function() {
       var laneNumbers = _.map(self.selection, getLaneCodeValue);
-      var cuttedLaneNumbers = _.transform(_.countBy(laneNumbers), function(result, count, value) {
+      var cutLaneNumbers = _.transform(_.countBy(laneNumbers), function(result, count, value) {
         if (count > 1) result.push(value);
       }, []);
 
-      return _.some(cuttedLaneNumbers, function (laneNumber){
+      return _.some(cutLaneNumbers, function (laneNumber){
         var lanes = _.filter(self.selection, function (lane){
           return _.find(lane.properties, function (property) {
             return property.publicId == "lane_code" && _.head(property.values).value == laneNumber;
           });
         });
-
-        return _.isEqual(lanes[0].properties, lanes[1].properties);
+        var sortedLanes = _.sortBy(lanes, function (lane) {
+          return lane.endMeasure;
+        });
+        for (var i = 1; i < sortedLanes.length; i++) {
+          if (_.isEqual(sortedLanes[i - 1].properties, sortedLanes[i].properties)) {
+            return true;
+          }
+        }
+        return false;
       });
     };
 
@@ -382,7 +384,7 @@
 
       //expiredLane could be modified by the user so we need to fetch the original
       var originalExpiredLane = _.find(lanesFetched, {'id': expiredLane.id});
-      if (linksSelected.length > 1) {
+      if (linksSelected.length > 1 && marker === undefined) {
         var expiredGroup = collection.getGroup(originalExpiredLane);
         expiredGroup.forEach(function (lane) {
           lane.isExpired = true;

--- a/UI/src/view/linear_asset/laneModellingForm.js
+++ b/UI/src/view/linear_asset/laneModellingForm.js
@@ -443,23 +443,20 @@
         });
       });
 
+      asset = _.sortBy(asset, function (lane) {
+        return lane.marker;
+      });
+
       var body = createBodyElement(selectedAsset.getCurrentLane());
 
       if(selectedAsset.isSplit()) {
-        //Render form A
-        renderFormElements(_.find(asset,{'marker': 'A'}), isReadOnly, 'A', selectedAsset.setValue, selectedAsset.getValue, false, body);
 
-        if(!isReadOnly)
-          renderExpireAndDeleteButtonsElement(selectedAsset, body, 'A');
+        _.forEach(asset, function (lane) {
+          renderFormElements(lane, isReadOnly, lane.marker, selectedAsset.setValue, selectedAsset.getValue, false, body);
+          if(!isReadOnly) renderExpireAndDeleteButtonsElement(selectedAsset, body, lane.marker);
+          body.find('.form').append('<hr class="form-break">');
+        });
 
-        body.find('.form').append('<hr class="form-break">');
-        //Render form B
-        renderFormElements(_.find(asset,{'marker': 'B'}), isReadOnly, 'B', selectedAsset.setValue, selectedAsset.getValue, false, body);
-
-        if(!isReadOnly)
-          renderExpireAndDeleteButtonsElement(selectedAsset, body, 'B');
-
-        body.find('.form').append('<hr class="form-break">');
       }else{
         renderFormElements(asset[0], isReadOnly, '', selectedAsset.setValue, selectedAsset.getValue, isDisabled, body);
 

--- a/UI/src/view/linear_asset/laneModellingLayer.js
+++ b/UI/src/view/linear_asset/laneModellingLayer.js
@@ -17,6 +17,7 @@
 
     var LinearAssetCutter = function(eventListener, vectorLayer) {
       var scissorFeatures = [];
+      //Max euclidean distance in geometry points allowed between mouse point and the closest linear asset point (the planned cut point).
       var CUT_THRESHOLD = 5;
       var vectorSource = vectorLayer.getSource();
 

--- a/UI/src/view/linear_asset/laneModellingLayer.js
+++ b/UI/src/view/linear_asset/laneModellingLayer.js
@@ -81,8 +81,17 @@
               return property.publicId === "lane_code";
             }).values).value;
 
-            return !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 || (!_.isUndefined(properties) &&
-                properties.selectedLinks.length > 1 && _.isUndefined(properties.marker)) || selectedLane.isAddByRoadAddress();
+            var uniqueSelectedRoadLinkIds = _.uniq(_.map(properties.selectedLinks, function (selectedLink) {
+              return selectedLink.linkId;
+            }));
+            if(_.isUndefined(uniqueSelectedRoadLinkIds)) {
+              return true;
+            }
+
+            var SelectedLaneCannotBeCut = !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 || laneNumber != selectedLane.getCurrentLaneNumber() ||
+                uniqueSelectedRoadLinkIds.length > 1 || selectedLane.isAddByRoadAddress();
+
+            return SelectedLaneCannotBeCut;
           })
           .map(function(feature) {
             var closestP = feature.getGeometry().getClosestPoint(point);
@@ -119,7 +128,8 @@
             return property.publicId === "lane_code";
           }).values).value;
 
-          return !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 || selectedLane.isAddByRoadAddress();
+          return !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 ||
+              laneNumber != selectedLane.getCurrentLaneNumber() || selectedLane.isAddByRoadAddress();
         });
 
         selected = _.sortBy(selected, function (lane) {

--- a/UI/src/view/linear_asset/laneModellingLayer.js
+++ b/UI/src/view/linear_asset/laneModellingLayer.js
@@ -17,7 +17,7 @@
 
     var LinearAssetCutter = function(eventListener, vectorLayer) {
       var scissorFeatures = [];
-      var CUT_THRESHOLD = 20;
+      var CUT_THRESHOLD = 5;
       var vectorSource = vectorLayer.getSource();
 
       var moveTo = function(x, y) {
@@ -81,8 +81,8 @@
               return property.publicId === "lane_code";
             }).values).value;
 
-            return !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 ||
-              !_.isUndefined(properties.marker) || properties.selectedLinks.length > 1 || selectedLane.isAddByRoadAddress();
+            return !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 || (!_.isUndefined(properties) &&
+                properties.selectedLinks.length > 1 && _.isUndefined(properties.marker)) || selectedLane.isAddByRoadAddress();
           })
           .map(function(feature) {
             var closestP = feature.getGeometry().getClosestPoint(point);
@@ -98,6 +98,43 @@
           })
           .head()
           .value();
+      };
+
+      var getLanePieceToCut = function (point) {
+
+        var minSquaredDistanceBetweenPointAndLane = function (lane, point) {
+          var min_x_dist = Math.abs(lane.points[0].x - point[0]);
+          var min_y_dist = Math.abs(lane.points[0].y - point[1]);
+          for(var i=1; i < lane.points.length; i++) {
+            min_x_dist = Math.min(min_x_dist, Math.abs(lane.points[i].x - point[0]));
+            min_y_dist = Math.min(min_y_dist, Math.abs(lane.points[i].y - point[1]));
+          }
+          return Math.pow(min_x_dist, 2) + Math.pow(min_y_dist, 2);
+        };
+
+        var selected = selectedLane.get();
+
+        selected = _.reject(selected, function (lane) {
+          var laneNumber = _.head(_.find(lane.properties, function(property){
+            return property.publicId === "lane_code";
+          }).values).value;
+
+          return !selectedLane.isOuterLane(laneNumber) || laneNumber == 1 || selectedLane.isAddByRoadAddress();
+        });
+
+        selected = _.sortBy(selected, function (lane) {
+          return minSquaredDistanceBetweenPointAndLane(lane, point);
+        });
+
+        var cutLanes = _.reject(selected, function (lane) {
+          return _.isUndefined(lane.marker);
+        });
+
+        if (_.isEmpty(cutLanes)) {
+          return _.head(selected);
+        }
+
+        return _.head(cutLanes);
       };
 
       this.updateByPosition = function(mousePoint) {
@@ -128,18 +165,14 @@
           return _.merge({ splitMeasure: splitMeasure }, splitVertices);
         };
 
-        var nearest = findNearestLinearAssetLink([mousePoint.x, mousePoint.y]);
+        var nearestLinearAsset = getLanePieceToCut([mousePoint.x, mousePoint.y]);
+        if (_.isUndefined(nearestLinearAsset)) return;
 
-        if (_.isUndefined(nearest) || !isWithinCutThreshold(nearest.distance)) {
-          return;
-        }
-
-        var nearestLinearAsset = nearest.feature.getProperties();
         if(authorizationPolicy.formEditModeAccess(nearestLinearAsset)) {
-          var splitProperties = calculateSplitProperties(laneUtils.offsetByLaneNumber(nearestLinearAsset, false, true), mousePoint);
+          var splitProperties = calculateSplitProperties(nearestLinearAsset, mousePoint);
           selectedLane.splitLinearAsset(_.head(_.find(nearestLinearAsset.properties, function(property){
             return property.publicId === "lane_code";
-          }).values).value, splitProperties);
+          }).values).value, splitProperties, nearestLinearAsset.marker);
 
           remove();
         }
@@ -296,6 +329,7 @@
       };
 
       var drawSplitPoints = function (links) {
+
         function findSplitPoints(links) {
           var sortedPoints = _.flatMap(links, function (link) {
             return link.points;
@@ -381,7 +415,7 @@
       var linearAssets = _.flatten(linearAssetChains);
       var allButSelected = _.filter(linearAssets, function(asset){ return !_.some(selectedLane.get(), function(selectedAsset){
         return selectedAsset.linkId === asset.linkId && selectedAsset.sideCode == asset.sideCode &&
-          selectedAsset.startMeasure === asset.startMeasure && selectedAsset.endMeasure === asset.endMeasure; }) ;
+            selectedAsset.startMeasure === asset.startMeasure && selectedAsset.endMeasure === asset.endMeasure; }) ;
       });
       me.vectorSource.addFeatures(style.renderFeatures(allButSelected));
       var oneWaySignsDraft = getOneWaySigns(allButSelected);
@@ -430,17 +464,17 @@
         var selectedFeatures = style.renderFeatures(linearAssets, laneNumber);
 
         if (assetLabel) {
-            var currentFeatures = _.filter(me.vectorSource.getFeatures(), function (layerFeature) {
-              return _.some(selectedFeatures, function (selectedFeature) {
-                return me.geometryAndValuesEqual(selectedFeature.values_, layerFeature.values_);
-              });
+          var currentFeatures = _.filter(me.vectorSource.getFeatures(), function (layerFeature) {
+            return _.some(selectedFeatures, function (selectedFeature) {
+              return me.geometryAndValuesEqual(selectedFeature.values_, layerFeature.values_);
             });
+          });
 
-            _.each(currentFeatures, me.removeFeature);
+          _.each(currentFeatures, me.removeFeature);
 
-            selectedFeatures = selectedFeatures.concat(assetLabel.renderFeaturesByLinearAssets(extractMiddleLinksOfChains([_.map(selectedFeatures, function (feature) {
-              return feature.getProperties();
-            })]), me.uiState.zoomLevel));
+          selectedFeatures = selectedFeatures.concat(assetLabel.renderFeaturesByLinearAssets(extractMiddleLinksOfChains([_.map(selectedFeatures, function (feature) {
+            return feature.getProperties();
+          })]), me.uiState.zoomLevel));
         }
 
         removeOldAssetFeatures();

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -895,7 +895,7 @@ trait LaneOperations {
     }
 
     //Get multiple lanes in one link
-    val resultWithMultiLanesInLink = newLanes.filter(lane => lane.isExpired != true && lane.id == 0).foldLeft(resultWithDeleteActions) {
+    val resultWithMultiLanesInLink = newLanes.filter(_.id == 0).foldLeft(resultWithDeleteActions) {
       (result, newLane) =>
         val newLaneCode: Int = getPropertyValue(newLane.properties, "lane_code").toString.toInt
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -920,7 +920,7 @@ trait LaneOperations {
     val laneCodesToModify = updateNewLanes.map { newLane => getLaneCode(newLane).toInt }
 
     //Fetch from db the existing lanes
-    val oldLanes = dao.fetchLanesByLinkIdsAndLaneCode(linkIds.toSeq, laneCodesToModify)
+    val oldLanes = dao.fetchLanesByLinkIdsAndLaneCode(linkIds.toSeq, laneCodesToModify).filter(_.sideCode == sideCode)
 
     val newLanesByLaneCode = updateNewLanes.groupBy(il => getLaneCode(il).toInt)
 


### PR DESCRIPTION
Toiminnallisuus kaistan katkaisemiseksi useampaan kertaan + testit. Lisäksi korjattu kaistojen tallennuksessa ollut api error, joka johtui siitä, että vanhojen kaistojen haussa ei käytetty ollenkaan sidecodea.