### PR TITLE
DROTH-3219 remove complementary geometry choice from lane modelling

### DIFF
--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -1012,7 +1012,7 @@
         },
         isSeparable: false,
         allowMapViewOnly: true,
-        allowComplementaryLinks: true,
+        allowComplementaryLinks: false,
         allowWalkingCyclingLinks: true,
         isVerifiable: false,
         showValidationErrorLabel: true,


### PR DESCRIPTION
Poistettu "Näytä täydentävä geometria" -valinta kaistatyökalusta.