### PR TITLE
Droth 3259 enable caching job def

### DIFF
--- a/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
@@ -106,7 +106,7 @@
       },
       {
         "name": "caching",
-        "value": "false"
+        "value": "true"
       },
       {
         "name": "cacheHostname",

--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -106,7 +106,7 @@
       },
       {
         "name": "caching",
-        "value": "false"
+        "value": "true"
       },
       {
         "name": "cacheHostname",


### PR DESCRIPTION
Caching päälle QA ja Prod job definitioneissa niin voidaan ajaa RefreshRoadLinkCache eräajoa. QA jobdef voi nyt päivittää kehitystilille,  mutta tuotantoa ei, pilvioperaattorin luodessa tuotanto job definition tuotantotilille tulee caching olla true