### PR TITLE
DROTH-3129 Problems with adding lanes using road address

### DIFF
--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -255,9 +255,9 @@
           sideCode: sideCode,
           laneRoadAddressInfo:{
             roadNumber: roadNumber,
-            initialRoadPartNumber: parseInt(startRoadPartNumber),
-            initialDistance: parseInt(startDistance),
-            endRoadPartNumber: parseInt(endRoadPartNumber),
+            startRoadPart: parseInt(startRoadPartNumber),
+            startDistance: parseInt(startDistance),
+            endRoadPart: parseInt(endRoadPartNumber),
             endDistance: parseInt(endDistance),
             track: track
           },

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1619,7 +1619,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
 
   private def validateUserRightsForRoadAddress(laneRoadAddressInfo: LaneRoadAddressInfo, user: User) : Unit = {
 
-    val roadParts = laneRoadAddressInfo.initialRoadPartNumber to laneRoadAddressInfo.endRoadPartNumber
+    val roadParts = laneRoadAddressInfo.startRoadPart to laneRoadAddressInfo.endRoadPart
 
     // Get the LinkIds from road address information from Viite
     val linkIds = roadAddressService.getAllByRoadNumberAndParts(laneRoadAddressInfo.roadNumber, roadParts, Seq(Track.apply(laneRoadAddressInfo.track)))

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -200,13 +200,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
       }).toSeq
 
 
-      val connectedGroups = lanesWithContinuing.flatMap(laneGroup => {
-        val startingLanes = getStartingLanes(laneGroup)
-        val connectedLanes = startingLanes.map(startingLane => {
-          getConnectedLanes(Seq(startingLane), laneGroup).sortBy(_.lane.id)
-        }).distinct
-        connectedLanes.map(_.map(_.lane))
-      })
+      val connectedGroups = lanesWithContinuing.flatMap(LanePartitioner.getConnectedGroups)
 
       val lanes = connectedGroups.map(group => {
         val laneCode = group.head.laneAttributes.find(_.publicId == "lane_code").get.values.head.value.asInstanceOf[Int]

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
@@ -51,8 +51,8 @@ sealed trait LaneValue {
 case class LanePropertyValue(value: Any)
 case class LaneProperty(publicId: String,  values: Seq[LanePropertyValue])
 
-case class LaneRoadAddressInfo ( roadNumber: Long, initialRoadPartNumber: Long, initialDistance: Long,
-                                 endRoadPartNumber: Long, endDistance: Long, track: Int )
+case class LaneRoadAddressInfo ( roadNumber: Long, startRoadPart: Long, startDistance: Long,
+                                 endRoadPart: Long, endDistance: Long, track: Int )
 
 /**
   * Values for lane numbers

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
@@ -53,6 +53,7 @@ case class LaneProperty(publicId: String,  values: Seq[LanePropertyValue])
 
 case class LaneRoadAddressInfo ( roadNumber: Long, startRoadPart: Long, startDistance: Long,
                                  endRoadPart: Long, endDistance: Long, track: Int )
+case class LaneEndPoints ( start: Double, end: Double )
 
 /**
   * Values for lane numbers

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -320,4 +320,18 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
     }.toSeq
   }
 
+  def groupRoadAddressTEMP(roadAddresses: Set[RoadAddressTEMP]): Set[RoadAddressTEMP] = {
+    roadAddresses
+      .groupBy(address => (address.linkId, address.road, address.roadPart))
+      .mapValues(addresses => (addresses.minBy(_.startAddressM),addresses.maxBy(_.endAddressM)))
+      .map {
+        case (_, (startRoadAddress, endRoadAddress)) =>
+          val (adjustedStart, adjustedEnd) =
+            if (startRoadAddress.startMValue > endRoadAddress.startMValue)
+              (endRoadAddress.startMValue, startRoadAddress.endMValue)
+            else
+              (startRoadAddress.startMValue, endRoadAddress.endMValue)
+          startRoadAddress.copy(endAddressM = endRoadAddress.endAddressM, startMValue = adjustedStart, endMValue = adjustedEnd)
+    }.toSet
+  }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -853,17 +853,17 @@ trait LaneOperations {
           val startAndEndPoints = LaneUtils.calculateStartAndEndPoint(laneRoadAddressInfo, addressesOnLink, linkLength)
 
           (startAndEndPoints, fixedSideCode) match {
-            case (Some((start: Double, end: Double)), Some(sideCode: SideCode)) =>
+            case (Some(endPoints), Some(sideCode: SideCode)) =>
               val lanesExists = existingLanes.filter(pLane =>
                 pLane.linkId == linkId && pLane.sideCode == sideCode.value && pLane.laneCode == laneCode &&
-                ((start >= pLane.startMeasure && start < pLane.endMeasure) ||
-                  (end > pLane.startMeasure && end <= pLane.endMeasure))
+                ((endPoints.start >= pLane.startMeasure && endPoints.start < pLane.endMeasure) ||
+                  (endPoints.end > pLane.startMeasure && endPoints.end <= pLane.endMeasure))
               )
               if (lanesExists.nonEmpty)
                 throw new InvalidParameterException(s"Lane with given lane code already exists in the selection")
 
               Some(PersistedLane(0, linkId, sideCode.value, laneCode, addressesOnLink.head.municipalityCode.getOrElse(0).toLong,
-                start, end, Some(username), Some(DateTime.now()), None, None, None, None, expired = false,
+                endPoints.start, endPoints.end, Some(username), Some(DateTime.now()), None, None, None, None, expired = false,
                 vvhTimeStamp, None, lane.properties))
             case (Some(_), None) =>
               // Throw error if sideCode is not determined due to missing road addresses

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -827,42 +827,36 @@ trait LaneOperations {
   def processLanesByRoadAddress(newLanes: Set[NewLane], laneRoadAddressInfo: LaneRoadAddressInfo,
                                 username: String): Set[Long] = {
     withDynTransaction {
-      val (filteredRoadAddresses, roadLinks) = LaneUtils.getRoadAddressToProcess(laneRoadAddressInfo)
+      val linksWithAddresses = LaneUtils.getRoadAddressToProcess(laneRoadAddressInfo)
       //Get only the lanes to create
       val lanesToInsert = newLanes.filter(_.id == 0)
       val clickedMainLane = newLanes.filter(_.id != 0).head
       val selectedLane = getPersistedLanesByIds(Set(clickedMainLane.id), newTransaction = false).head
 
-      val addressesByLinks = filteredRoadAddresses.groupBy(_.linkId)
-      val roadLinkIds = addressesByLinks.keys.toSet
+      val roadLinkIds = linksWithAddresses.map(_.linkId)
       val linksWithSideCodes = getLinksWithCorrectSideCodes(selectedLane, roadLinkIds, newTransaction = false)
       val existingLanes = fetchAllLanesByLinkIds(roadLinkIds.toSeq, newTransaction = false)
 
-      val allLanesToCreate = addressesByLinks.flatMap { case (linkId, addressesOnLink) =>
+      val allLanesToCreate = linksWithAddresses.flatMap { link =>
         val vvhTimeStamp = vvhClient.roadLinkData.createVVHTimeStamp()
-
-        val linkLength = roadLinks.find(_.linkId == linkId) match {
-          case Some(roadLink) => roadLink.length
-          case _ => addressesOnLink.head.endMValue
-        }
 
         lanesToInsert.flatMap { lane =>
           val laneCode = getLaneCode(lane).toInt
           validateStartDate(lane, laneCode)
-          val fixedSideCode = linksWithSideCodes.get(linkId)
-          val startAndEndPoints = LaneUtils.calculateStartAndEndPoint(laneRoadAddressInfo, addressesOnLink, linkLength)
+          val fixedSideCode = linksWithSideCodes.get(link.linkId)
+          val startAndEndPoints = LaneUtils.calculateStartAndEndPoint(laneRoadAddressInfo, link.addresses, link.link.length)
 
           (startAndEndPoints, fixedSideCode) match {
             case (Some(endPoints), Some(sideCode: SideCode)) =>
               val lanesExists = existingLanes.filter(pLane =>
-                pLane.linkId == linkId && pLane.sideCode == sideCode.value && pLane.laneCode == laneCode &&
+                pLane.linkId == link.linkId && pLane.sideCode == sideCode.value && pLane.laneCode == laneCode &&
                 ((endPoints.start >= pLane.startMeasure && endPoints.start < pLane.endMeasure) ||
                   (endPoints.end > pLane.startMeasure && endPoints.end <= pLane.endMeasure))
               )
               if (lanesExists.nonEmpty)
                 throw new InvalidParameterException(s"Lane with given lane code already exists in the selection")
 
-              Some(PersistedLane(0, linkId, sideCode.value, laneCode, addressesOnLink.head.municipalityCode.getOrElse(0).toLong,
+              Some(PersistedLane(0, link.linkId, sideCode.value, laneCode, link.link.municipalityCode,
                 endPoints.start, endPoints.end, Some(username), Some(DateTime.now()), None, None, None, None, expired = false,
                 vvhTimeStamp, None, lane.properties))
             case (Some(_), None) =>
@@ -871,7 +865,7 @@ trait LaneOperations {
             case _ => None
           }
         }
-      }.toSet
+      }
 
       // Create lanes
       allLanesToCreate.map(createWithoutTransaction(_, username))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -844,10 +844,10 @@ trait LaneOperations {
           val laneCode = getLaneCode(lane).toInt
           validateStartDate(lane, laneCode)
           val fixedSideCode = linksWithSideCodes.get(road.linkId)
-          val (start, end) = LaneUtils.calculateStartAndEndPoint(road, laneRoadAddressInfo)
+          val endPoints = LaneUtils.calculateStartAndEndPoint(road, laneRoadAddressInfo)
 
-          (start, end, fixedSideCode) match {
-            case (start: Double, end: Double, Some(sideCode: SideCode)) =>
+          (endPoints, fixedSideCode) match {
+            case (Some((start: Double, end: Double)), Some(sideCode: SideCode)) =>
               val lanesExists = existingLanes.filter(pLane =>
                 pLane.linkId == road.linkId && pLane.sideCode == sideCode.value && pLane.laneCode == laneCode &&
                 ((start >= pLane.startMeasure && start < pLane.endMeasure) ||

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -118,9 +118,9 @@ object LaneUtils {
 
     val finalRoads = groupedAddresses.filter { elem =>  // Remove addresses which roadPart is not between our start and end
       val roadPartNumber = elem.roadPart
-      val inInitialAndEndRoadPart = roadPartNumber >= laneRoadAddressInfo.startRoadPart && roadPartNumber <= laneRoadAddressInfo.endRoadPart
+      val inStartAndEndRoadPart = roadPartNumber >= laneRoadAddressInfo.startRoadPart && roadPartNumber <= laneRoadAddressInfo.endRoadPart
 
-      inInitialAndEndRoadPart
+      inStartAndEndRoadPart
     }
 
     finalRoads.flatMap { road =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -176,13 +176,13 @@ object LaneUtils {
           Some(road.startMValue, road.endMValue)
 
         case part if part == selection.startRoadPart && part == selection.endRoadPart =>
-          if (!(road.endAddressM > selection.startDistance && road.startAddressM < selection.endDistance))
+          if (road.endAddressM <= selection.startDistance || road.startAddressM >= selection.endDistance)
             None
-          else if (road.startAddressM <= selection.startDistance && road.endAddressM >= selection.endDistance)
+          else if (road.startAddressM < selection.startDistance && road.endAddressM > selection.endDistance)
             Some( startPoint, endPoint )
-          else if (road.startAddressM <= selection.startDistance)
+          else if (road.startAddressM < selection.startDistance)
             if (towardsDigitizing) Some( startPoint, endMValue ) else Some( startMValue, endPoint )
-          else if (road.endAddressM >= selection.endDistance)
+          else if (road.endAddressM > selection.endDistance)
             if (towardsDigitizing) Some( startMValue, endPoint ) else Some( startPoint, endMValue )
           else
             Some( startMValue, endMValue)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -142,7 +142,7 @@ object LaneUtils {
    * Calculate lane start and end values from all road addresses on a link.
    * Returns one start and end value per link or None.
    */
-  def calculateStartAndEndPoint(laneRoadAddressInfo: LaneRoadAddressInfo, addressesOnLink: Set[RoadAddressTEMP],
+  def calculateStartAndEndPoint(selection: LaneRoadAddressInfo, addressesOnLink: Set[RoadAddressTEMP],
                                 linkLength: Double): Option[(Double, Double)] = {
     val (linkAddressM, linkMValue) = // Determine total address length and m value within link
       addressesOnLink.foldLeft(0L, 0.0){ (result, address) =>
@@ -156,8 +156,8 @@ object LaneUtils {
     val startAndEndValues = addressesOnLink.flatMap { road =>
       val startMValue = road.startMValue / viiteMeasure * adjustedMeasure
       val endMValue = road.endMValue / viiteMeasure * adjustedMeasure
-      val startDifferenceM = (laneRoadAddressInfo.startDistance - road.startAddressM) * adjustedMeasure
-      val endDifferenceM = (road.endAddressM - laneRoadAddressInfo.endDistance) * adjustedMeasure
+      val startDifferenceM = (selection.startDistance - road.startAddressM) * adjustedMeasure
+      val endDifferenceM = (road.endAddressM - selection.endDistance) * adjustedMeasure
       val towardsDigitizing = road.sideCode.getOrElse(SideCode.TowardsDigitizing) == SideCode.TowardsDigitizing
 
       val startPoint = // Calculated start point for cases when lane does not start from the start of road address
@@ -172,33 +172,33 @@ object LaneUtils {
       // Determine if what endpoint values to use or if road address should be skipped
       // If adjusted start or end point is used and road side code is againstDigitising, the opposite value is adjusted
       road.roadPart match {
-        case part if part > laneRoadAddressInfo.startRoadPart && part < laneRoadAddressInfo.endRoadPart =>
+        case part if part > selection.startRoadPart && part < selection.endRoadPart =>
           Some(road.startMValue, road.endMValue)
 
-        case part if part == laneRoadAddressInfo.startRoadPart && part == laneRoadAddressInfo.endRoadPart =>
-          if (!(road.endAddressM > laneRoadAddressInfo.startDistance && road.startAddressM < laneRoadAddressInfo.endDistance))
+        case part if part == selection.startRoadPart && part == selection.endRoadPart =>
+          if (!(road.endAddressM > selection.startDistance && road.startAddressM < selection.endDistance))
             None
-          else if (road.startAddressM <= laneRoadAddressInfo.startDistance && road.endAddressM >= laneRoadAddressInfo.endDistance)
+          else if (road.startAddressM <= selection.startDistance && road.endAddressM >= selection.endDistance)
             Some( startPoint, endPoint )
-          else if (road.startAddressM <= laneRoadAddressInfo.startDistance)
+          else if (road.startAddressM <= selection.startDistance)
             if (towardsDigitizing) Some( startPoint, endMValue ) else Some( startMValue, endPoint )
-          else if (road.endAddressM >= laneRoadAddressInfo.endDistance)
+          else if (road.endAddressM >= selection.endDistance)
             if (towardsDigitizing) Some( startMValue, endPoint ) else Some( startPoint, endMValue )
           else
             Some( startMValue, endMValue)
 
-        case part if part == laneRoadAddressInfo.startRoadPart =>
-          if (road.endAddressM <= laneRoadAddressInfo.startDistance)
+        case part if part == selection.startRoadPart =>
+          if (road.endAddressM <= selection.startDistance)
             None
-          else if (road.startAddressM < laneRoadAddressInfo.startDistance)
+          else if (road.startAddressM < selection.startDistance)
             if (towardsDigitizing) Some( startPoint, endMValue ) else Some( startMValue, endPoint)
           else
             Some(startMValue, endMValue)
 
-        case part if part == laneRoadAddressInfo.endRoadPart =>
-          if (road.startAddressM >= laneRoadAddressInfo.endDistance)
+        case part if part == selection.endRoadPart =>
+          if (road.startAddressM >= selection.endDistance)
             None
-          else if (road.endAddressM > laneRoadAddressInfo.endDistance)
+          else if (road.endAddressM > selection.endDistance)
             if (towardsDigitizing) Some( startMValue, endPoint ) else Some( startPoint, endMValue )
           else
             Some(startMValue, endMValue)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -180,7 +180,7 @@ object LaneUtils {
       // If adjusted start or end point is used and road side code is againstDigitising, the opposite value is adjusted
       road.roadPart match {
         case part if part > selection.startRoadPart && part < selection.endRoadPart =>
-          Some(road.startMValue, road.endMValue)
+          Some(startMValue, endMValue)
 
         case part if part == selection.startRoadPart && part == selection.endRoadPart =>
           if (roadEndsBeforeSelectionStart || roadStartsAfterSelectionEnd)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -136,59 +136,39 @@ object LaneUtils {
     val endDifferenceAddr = road.endAddressM - laneRoadAddressInfo.endDistance
     val endPoint = if (endDifferenceAddr <= 0) road.endMValue else road.endMValue - endDifferenceAddr
 
-    val endPoints = if (road.roadPart > laneRoadAddressInfo.initialRoadPartNumber && road.roadPart < laneRoadAddressInfo.endRoadPartNumber) {
-      Some( road.startMValue, road.endMValue)
+    val endPoints = road.roadPart match {
+      case part if part > laneRoadAddressInfo.initialRoadPartNumber && part < laneRoadAddressInfo.endRoadPartNumber =>
+        Some( road.startMValue, road.endMValue)
 
-    }
-    else if (road.roadPart == laneRoadAddressInfo.initialRoadPartNumber && road.roadPart == laneRoadAddressInfo.endRoadPartNumber) {
+      case part if part == laneRoadAddressInfo.initialRoadPartNumber && part == laneRoadAddressInfo.endRoadPartNumber =>
+        if (!(road.endAddressM > laneRoadAddressInfo.initialDistance && road.startAddressM < laneRoadAddressInfo.endDistance))
+          None
+        else if (road.startAddressM <= laneRoadAddressInfo.initialDistance && road.endAddressM >= laneRoadAddressInfo.endDistance)
+          Some( startPoint, endPoint )
+        else if (road.startAddressM <= laneRoadAddressInfo.initialDistance)
+          Some( startPoint, road.endMValue )
+        else if (road.endAddressM >= laneRoadAddressInfo.endDistance)
+          Some( road.startMValue, endPoint )
+        else
+          Some( road.startMValue, road.endMValue )
 
-      if (!(road.endAddressM > laneRoadAddressInfo.initialDistance && road.startAddressM < laneRoadAddressInfo.endDistance))
-        None
+      case part if part == laneRoadAddressInfo.initialRoadPartNumber =>
+        if (road.endAddressM <= laneRoadAddressInfo.initialDistance)
+          None
+        else if (road.startAddressM < laneRoadAddressInfo.initialDistance)
+          Some( startPoint, road.endMValue )
+        else
+          Some( road.startMValue, road.endMValue )
 
-      else if (road.startAddressM <= laneRoadAddressInfo.initialDistance && road.endAddressM >= laneRoadAddressInfo.endDistance) {
-        Some( startPoint, endPoint )
+      case part if part == laneRoadAddressInfo.endRoadPartNumber =>
+        if (road.startAddressM >= laneRoadAddressInfo.endDistance)
+          None
+        else if (road.endAddressM > laneRoadAddressInfo.endDistance)
+          Some( road.startMValue, endPoint )
+        else
+          Some( road.startMValue, road.endMValue )
 
-      }
-      else if (road.startAddressM <= laneRoadAddressInfo.initialDistance && road.endAddressM < laneRoadAddressInfo.endDistance) {
-        Some( startPoint, road.endMValue )
-
-      }
-      else if (road.startAddressM > laneRoadAddressInfo.initialDistance && road.endAddressM >= laneRoadAddressInfo.endDistance) {
-        Some( road.startMValue, endPoint )
-
-      }
-      else {
-        Some( road.startMValue, road.endMValue )
-
-      }
-
-    }
-    else if (road.roadPart == laneRoadAddressInfo.initialRoadPartNumber) {
-      if (road.endAddressM <= laneRoadAddressInfo.initialDistance) {
-        None
-
-      } else if (road.startAddressM < laneRoadAddressInfo.initialDistance) {
-        Some( startPoint, road.endMValue )
-
-      } else {
-        Some( road.startMValue, road.endMValue )
-      }
-
-    }
-    else if (road.roadPart == laneRoadAddressInfo.endRoadPartNumber) {
-      if (road.startAddressM >= laneRoadAddressInfo.endDistance) {
-        None
-
-      } else if (road.endAddressM > laneRoadAddressInfo.endDistance) {
-        Some( road.startMValue, endPoint )
-
-      } else {
-        Some( road.startMValue, road.endMValue )
-
-      }
-    }
-    else {
-      None
+      case _ => None
     }
 
     //Fix the start and end point when the roadAddress SideCode is AgainstDigitizing

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -109,11 +109,14 @@ object LaneUtils {
     // Remove from Viite the information we have updated in our DB and add ou information
     val allRoadAddress = (roadAddresses.filterNot( ra => vkmLinkIds.contains( ra.linkId)) ++ vkmRoadAddress).toSet
 
+    // Group road addresses that exist on same link and exist on same road and road part
+    val groupedAddresses = roadAddressService.groupRoadAddressTEMP(allRoadAddress)
+
     // Get all updated information from VVH
     val mappedRoadLinks = roadLinkService.fetchVVHRoadlinks(allRoadAddress.map(_.linkId))
       .groupBy(_.linkId)
 
-    val finalRoads = allRoadAddress.filter { elem =>       // Remove the links that are not in VVH and roadPart between our initial and end
+    val finalRoads = groupedAddresses.filter { elem =>       // Remove the links that are not in VVH and roadPart between our initial and end
       val existsInVVH = mappedRoadLinks.contains(elem.linkId)
       val roadPartNumber = elem.roadPart
       val inInitialAndEndRoadPart = roadPartNumber >= laneRoadAddressInfo.initialRoadPartNumber && roadPartNumber <= laneRoadAddressInfo.endRoadPartNumber

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -15,6 +15,7 @@ import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
 import org.apache.http.impl.client.HttpClientBuilder
 import org.joda.time.DateTime
 
+case class RoadLinkWithAddresses(linkId: Long, link: VVHRoadlink, addresses: Set[RoadAddressTEMP])
 
 case class LaneUtils(){
   // DROTH-3057: Remove after lanes csv import is disabled
@@ -43,39 +44,34 @@ object LaneUtils {
     // Main process
     def process() = {
 
-      val (filteredRoadAddresses, vvhRoadLinks) = getRoadAddressToProcess(laneRoadAddressInfo)
-      val addressesByLinks = filteredRoadAddresses.groupBy(_.linkId)
+      val linksWithAddresses = getRoadAddressToProcess(laneRoadAddressInfo)
 
       //Get only the lanes to create
       val lanesToInsert = newLanes.filter(_.id == 0)
 
 
-      val allLanesToCreate = addressesByLinks.flatMap { case (linkId, addressesOnLink) =>
+      val allLanesToCreate = linksWithAddresses.flatMap { link =>
         val vvhTimeStamp = vvhClient.roadLinkData.createVVHTimeStamp()
-        val linkLength = vvhRoadLinks.find(_.linkId == linkId) match {
-          case Some(roadLink) => roadLink.length
-          case _ => addressesOnLink.head.endMValue
-        }
 
         lanesToInsert.flatMap { lane =>
           val laneCode = laneService.getLaneCode(lane).toInt
           laneService.validateStartDate(lane, laneCode)
 
           val isTwoDigitLaneCode = laneCode.toString.length > 1
-          val finalSideCode = laneService.fixSideCode( addressesOnLink.head, laneCode.toString )
+          val finalSideCode = laneService.fixSideCode( link.addresses.head, laneCode.toString )
           val laneCodeOneDigit = if (isTwoDigitLaneCode) laneCode.toString.substring(1).toInt
                                  else laneCode
 
-          calculateStartAndEndPoint(laneRoadAddressInfo, addressesOnLink, linkLength) match {
+          calculateStartAndEndPoint(laneRoadAddressInfo, link.addresses, link.link.length) match {
             case Some(endPoints) =>
-              Some(PersistedLane(0, linkId, finalSideCode.value, laneCodeOneDigit, addressesOnLink.head.municipalityCode.getOrElse(0).toLong,
+              Some(PersistedLane(0, link.linkId, finalSideCode.value, laneCodeOneDigit, link.link.municipalityCode,
                 endPoints.start, endPoints.end, Some(username), Some(DateTime.now()), None, None, None, None, expired = false,
                 vvhTimeStamp, None, lane.properties))
 
             case _ => None
             }
         }
-      }.toSet
+      }
 
       //Create lanes
       allLanesToCreate.map(laneService.createWithoutTransaction(_, username))
@@ -92,7 +88,7 @@ object LaneUtils {
 
   }
 
-  def getRoadAddressToProcess(laneRoadAddressInfo: LaneRoadAddressInfo): (Set[RoadAddressTEMP], Seq[VVHRoadlink]) = {
+  def getRoadAddressToProcess(laneRoadAddressInfo: LaneRoadAddressInfo): Set[RoadLinkWithAddresses] = {
 
     // Generate a sequence from startRoadPart to endRoadPart
     // If startRoadPart = 1 and endRoadPart = 4
@@ -119,23 +115,22 @@ object LaneUtils {
 
     // Get all updated information from VVH
     val roadLinks = roadLinkService.fetchVVHRoadlinks(allRoadAddress.map(_.linkId))
-    val mappedRoadLinks = roadLinks.groupBy(_.linkId)
 
-    val finalRoads = groupedAddresses.filter { elem =>       // Remove the links that are not in VVH and roadPart between our initial and end
-      val existsInVVH = mappedRoadLinks.contains(elem.linkId)
+    val finalRoads = groupedAddresses.filter { elem =>  // Remove addresses which roadPart is not between our start and end
       val roadPartNumber = elem.roadPart
       val inInitialAndEndRoadPart = roadPartNumber >= laneRoadAddressInfo.startRoadPart && roadPartNumber <= laneRoadAddressInfo.endRoadPart
 
-      existsInVVH && inInitialAndEndRoadPart
+      inInitialAndEndRoadPart
     }
-      .map{ elem =>             //In case we don't have municipalityCode we will get it from VVH info
-        if (elem.municipalityCode.getOrElse(0) == 0)
-          elem.copy( municipalityCode = Some( mappedRoadLinks(elem.linkId).head.municipalityCode) )
-        else
-          elem
-      }
 
-    (finalRoads, roadLinks)
+    finalRoads.flatMap { road =>
+      roadLinks.find(_.linkId == road.linkId) match {
+        case Some(link) =>
+          val allAddressesOnLink = allRoadAddress.filter(_.linkId == road.linkId)
+          Some(RoadLinkWithAddresses(road.linkId, link, allAddressesOnLink))
+        case _ => None // Remove links (and addresses) that are not in VVH
+      }
+    }
   }
 
   /**

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/LaneUtilsSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/LaneUtilsSpec.scala
@@ -1,0 +1,133 @@
+package fi.liikennevirasto.digiroad2.util
+
+import fi.liikennevirasto.digiroad2.asset.SideCode
+import fi.liikennevirasto.digiroad2.dao.RoadAddressTEMP
+import fi.liikennevirasto.digiroad2.lane.{LaneEndPoints, LaneRoadAddressInfo}
+import org.scalatest.{FunSuite, Matchers}
+
+class LaneUtilsSpec extends FunSuite with Matchers {
+  val addLaneToAddress1: LaneRoadAddressInfo = LaneRoadAddressInfo(1, 1, 10, 1, 120, 1)
+  val addLaneToAddress2: LaneRoadAddressInfo = LaneRoadAddressInfo(1, 1, 10, 4, 120, 1)
+  val addLaneToAddress3: LaneRoadAddressInfo = LaneRoadAddressInfo(1, 2, 10, 2, 120, 1)
+
+  test("Return None for link with road addresses outside of scope") {
+    val linkLength = 50.214
+    val addressesOnLink1 = Set( // At same road part but start after selection ends
+      RoadAddressTEMP(1234567, 1, 1, Track.RightSide, 120, 320, 0.0, 49.281, Seq(), None, None, None)
+    )
+    val addressesOnLink2 = Set( // At same road part but ends before selection starts
+      RoadAddressTEMP(1234567, 1, 1, Track.RightSide, 0, 10, 0.0, 49.281, Seq(), None, None, None)
+    )
+    val addressesOnLink3 = Set( // road part > selection.endRoadPart
+      RoadAddressTEMP(1234567, 1, 2, Track.RightSide, 10, 120, 0.0, 49.281, Seq(), None, None, None)
+    )
+    val addressesOnLink4 = Set( // road part < selection.startRoadPart
+      RoadAddressTEMP(1234567, 1, 1, Track.RightSide, 10, 120, 0.0, 49.281, Seq(), None, None, None)
+    )
+    val addressesOnLink5 = Set( // multiple addresses on link and all outside scope
+      RoadAddressTEMP(1234567, 1, 1, Track.RightSide, 120, 220, 0.0, 49.281, Seq(), None, None, None),
+      RoadAddressTEMP(1234567, 1, 1, Track.RightSide, 220, 320, 0.0, 49.281, Seq(), None, None, None)
+    )
+
+    val endPoints1 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1, linkLength)
+    val endPoints2 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink2, linkLength)
+    val endPoints3 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink3, linkLength)
+    val endPoints4 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress3, addressesOnLink4, linkLength)
+    val endPoints5 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink5, linkLength)
+
+    endPoints1.isEmpty should be(true)
+    endPoints2.isEmpty should be(true)
+    endPoints3.isEmpty should be(true)
+    endPoints4.isEmpty should be(true)
+    endPoints5.isEmpty should be(true)
+  }
+
+  test("Return start and end point for link with one road address") {
+    val linkId = 1234567
+    val linkLength = 50.214
+    val addressesOnLink1 = Set( // road part == selection.startRoadPart && road part == selection.endRoadPart
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 10, 120, 0.0, 49.281, Seq(), None, None, None)
+    )
+    val addressesOnLink2 = Set( // road part > selection.startRoadPart && road part < selection.endRoadPart
+      RoadAddressTEMP(linkId, 1, 3, Track.RightSide, 10, 120, 0.0, 49.281, Seq(), None, None, None)
+    )
+
+    val endPoints1 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1, linkLength)
+    val endPoints2 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress2, addressesOnLink2, linkLength)
+
+    endPoints1.isEmpty should be(false)
+    endPoints2.isEmpty should be(false)
+
+    endPoints1.get should be(LaneEndPoints(0.0, 50.214))
+    endPoints2.get should be(LaneEndPoints(0.0, 50.214))
+  }
+
+  test("Selection ends before address ends") {
+    val linkId = 1234567
+    val linkLength = 50.214
+    val addressesOnLink1a = Set( // TowardsDigitizing
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 10, 130, 0.0, 49.281, Seq(), Some(SideCode.TowardsDigitizing), None, None)
+    )
+    val addressesOnLink1b = Set( // AgainstDigitizing
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 10, 130, 0.0, 49.281, Seq(), Some(SideCode.AgainstDigitizing), None, None)
+    )
+
+    val endPoints1a = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1a, linkLength)
+    val endPoints1b = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1b, linkLength)
+
+    endPoints1a.isEmpty should be(false)
+    endPoints1b.isEmpty should be(false)
+
+    endPoints1a.get should be(LaneEndPoints(0.0, 46.03))     // End adjusted
+    endPoints1b.get should be(LaneEndPoints(4.185, 50.214))  // Start adjusted
+  }
+
+  test("Selection starts after start of address") {
+    val linkId = 1234567
+    val linkLength = 50.214
+    val addressesOnLink1a = Set( // TowardsDigitizing
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 0, 120, 0.0, 49.281, Seq(), Some(SideCode.TowardsDigitizing), None, None)
+    )
+    val addressesOnLink1b = Set( // AgainstDigitizing
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 0, 120, 0.0, 49.281, Seq(), Some(SideCode.AgainstDigitizing), None, None)
+    )
+
+    val endPoints1a = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1a, linkLength)
+    val endPoints1b = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1b, linkLength)
+
+    endPoints1a.isEmpty should be(false)
+    endPoints1b.isEmpty should be(false)
+
+    endPoints1a.get should be(LaneEndPoints(4.185, 50.214)) // Start adjusted
+    endPoints1b.get should be(LaneEndPoints(0.0, 46.03))    // End adjusted
+  }
+
+  test("Multiple addresses on link") {
+    val linkId = 1234567
+    val linkLength = 150.214
+    val addressesOnLink1a = Set( // TowardsDigitizing
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 10, 50, 0.0, 49.281, Seq(), Some(SideCode.TowardsDigitizing), None, None),
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 50, 120, 49.281, 182.984, Seq(), Some(SideCode.TowardsDigitizing), None, None)
+    )
+    val addressesOnLink1b = Set( // AgainstDigitizing
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 10, 50, 49.281, 182.984, Seq(), Some(SideCode.AgainstDigitizing), None, None),
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 50, 120, 0.0, 49.281, Seq(), Some(SideCode.AgainstDigitizing), None, None)
+    )
+    val addressesOnLink2 = Set( // Road part changes during link
+      RoadAddressTEMP(linkId, 1, 1, Track.RightSide, 10, 50, 0.0, 49.281, Seq(), None, None, None),
+      RoadAddressTEMP(linkId, 1, 2, Track.RightSide, 0, 70, 49.281, 182.984, Seq(), None, None, None)
+    )
+
+    val endPoints1a = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1a, linkLength)
+    val endPoints1b = LaneUtils.calculateStartAndEndPoint(addLaneToAddress1, addressesOnLink1b, linkLength)
+    val endPoints2 = LaneUtils.calculateStartAndEndPoint(addLaneToAddress2, addressesOnLink2, linkLength)
+
+    endPoints1a.isEmpty should be(false)
+    endPoints1b.isEmpty should be(false)
+    endPoints2.isEmpty should be(false)
+
+    endPoints1a.get should be(LaneEndPoints(0.0, 150.214))
+    endPoints1b.get should be(LaneEndPoints(0.0, 150.214))
+    endPoints2.get should be(LaneEndPoints(0.0, 150.214))
+  }
+}


### PR DESCRIPTION
- Tieosoitteet ryhmitellään jatkossa linkeittäin ja alku- ja loppu m-arvojen päättely tapahtuu linkin ja kaikkien sen sisällä olevien tieosoitteiden perusteella. Ts. ei enää luoda "pätkittyjä" kaistoja jos linkillä on useampi tieosoitepätkä vaan luodaan yksi kaista per linkki.
- Digitointisuuntaa vastaan olevien kaistojen alku- ja loppu m-arvojen päättelyä muutettu. Tämä korjaa ongelman, jossa useamman tieosoite pätkän sisältävän linkin kaistojen lisääminen synnytti päällekkäisiä kaistoja, joiden sijainnit olivat virheellisiä.
- Ei käytetä enää suoraan tieosoitteen mukaisia alku- ja loppu m-arvoja vaan lasketaan niitä vastaavat sijainnit linkin nykyisen pituuden perusteella.
- Korjattu säädettyjen (lyhennettyjen) päätepisteiden päättelyä. Aiemmin tieosoitteen m-arvoista vähennettiin osoitepituuksien erotus.