### PR TITLE
DROTH-3198 Fixed bug with duplicate changes to link attributes

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -600,9 +600,11 @@ class RoadLinkService(val vvhClient: VVHClient, val eventbus: DigiroadEventBus, 
     } yield (f1Result, f2Result, f3Result)
 
     val (complementaryLinks, changes, links) = Await.result(fut, Duration.Inf)
+    val complementaryLinkIds = complementaryLinks.map(complementaryLink => Some(complementaryLink.linkId))
+    val (complementaryChanges, roadLinkChanges) = changes.partition(change => complementaryLinkIds.contains(change.oldId) || complementaryLinkIds.contains(change.newId))
 
       withDynTransaction {
-        (generateProperties(links, changes), changes, generateProperties(complementaryLinks, changes))
+        (generateProperties(links, roadLinkChanges), changes, generateProperties(complementaryLinks, complementaryChanges))
       }
   }
   


### PR DESCRIPTION
Korjaus bugiin, joka kaatanut UpdateIncompleteLinkList eräajoa välillä. Nyt täydentävien linkkien käsittelyyn viedään mukaan vain niihin kuuluvat muutostiedot, aikaisemmassa toteutuksessa muutosrivit käsiteltiin kahdesti, ja se tietyissä tapauksissa kaatoi batchin