### PR TITLE
DROTH-3279 fix VVH error logging

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/VVHClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/VVHClient.scala
@@ -400,7 +400,10 @@ trait VVHClientOperations {
     
     val response = client.execute(request)
     try {
-      mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
+      response.getStatusLine.getStatusCode match {
+        case 200 => mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
+        case _ => throw new VVHClientException(response.toString)
+      }
     } finally {
       response.close()
       val fetchVVHTimeSec = (System.currentTimeMillis()-fetchVVHStartTime)*0.001
@@ -420,7 +423,10 @@ trait VVHClientOperations {
    
     val response = client.execute(request)
     try {
-      mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
+      response.getStatusLine.getStatusCode match {
+        case 200 => mapFields(parse(StreamInput(response.getEntity.getContent)).values.asInstanceOf[Map[String, Any]], url)
+        case _ => throw new VVHClientException(response.toString)
+      }
     } finally {
       response.close()
       val fetchVVHTimeSec = (System.currentTimeMillis()-fetchVVHStartTime)*0.001


### PR DESCRIPTION
Korjattu VVH lokitus. Ei yritä parse vastausta, ellei StatusCode ole OK. Irroitettu tämä nyt omaksi tiketikseen niin voida viedä tuotantojulkaisussa.