### PR TITLE
DROTH-3268 PutObjectAcl permission added to codebuild role

### DIFF
--- a/aws/cloud-formation/batchSystem/batchLambda/cicd/prod-batchLambdaPipeline.yaml
+++ b/aws/cloud-formation/batchSystem/batchLambda/cicd/prod-batchLambdaPipeline.yaml
@@ -152,6 +152,7 @@ Resources:
                   - "s3:GetObject"
                   - "s3:GetObjectVersion"
                   - "s3:PutObject"
+                  - "s3:PutObjectAcl"
               - Effect: "Allow"
                 Resource: "*"
                 Action:


### PR DESCRIPTION
Lisätty CodeBuildin käyttämälle roolille PutObjectAcl -luvitus. Korjauksen myötä eräajo-lambdan tuotanto pipeline toimii.