### PR TITLE
DROTH-3310 Fixed complementary link properties radio button not worki…

### DIFF
--- a/UI/src/view/navigationpanel/roadLinkBox.js
+++ b/UI/src/view/navigationpanel/roadLinkBox.js
@@ -190,7 +190,7 @@
 
         linkPropertiesModel.setDataset(datasetName);
 
-        bindEventHandlers(legendContainer);
+        bindEventHandlers(elements.expanded);
       });
     };
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
@@ -4,6 +4,7 @@ import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Point
+import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.ComplimentaryLinkInterface
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, ConstructionType, LinkGeomSource}
 import fi.liikennevirasto.digiroad2.client.vvh.VVHRoadlink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
@@ -85,7 +86,7 @@ class ComplementaryLinkDAO extends RoadLinkDAO {
 
       VVHRoadlink(linkId, municipality, geometry, AdministrativeClass.apply(administrativeClass),
         extractTrafficDirection(directionType), featureClass, modifiedAt, attributes,
-        ConstructionType.apply(constructionType), LinkGeomSource.apply(sourceInfo), length)
+        ConstructionType.apply(constructionType), ComplimentaryLinkInterface, length)
     }
   }
 


### PR DESCRIPTION
Korjattu tiketissä https://extranet.vayla.fi/jira/browse/DROTH-3310 tielinkit - ja nopeusrajoitukset-tietolajeilla ilmenneet ongelmat. Hoitoluokat toimivat täydentävien linkkien osalta niin kuin pitkin, ei ollut bugi.