### PR TITLE
DROTH-3313 Fixed construction type filtering in roadLinks

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -104,7 +104,7 @@ class RoadLinkDAO {
                  verticalaccuracy, created_date, last_edited_date, from_left, to_left, from_right, to_right, validfrom,
                  geometry_edited_date, surfacetype, subtype, objectid, startnode, endnode, sourceinfo, geometrylength
           from roadlink
-          where #$filter
+          where #$filter and constructiontype in (0,1,3)
           """.as[VVHRoadlink].list
   }
 


### PR DESCRIPTION
Lisätty filtteröinti InUse, UnderConstruction ja Planned linkin tiloille. Aikaisemmassa toteutuksessa filtteröinti tapahtui VVH vastauksen kenttien mappauksen yhteydessä. Jääyt toteuttamatta uudessa toteutuksessa.