### PR TITLE
DROTH-3311 ignore temporarily vvh change info tests

### DIFF
--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/VVHClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/VVHClientSpec.scala
@@ -48,7 +48,9 @@ class VVHClientSpec extends FunSuite with Matchers{
     val result = vvhClient.historyData.fetchVVHRoadLinkByLinkIds(Set(440484,440606,440405,440489))
     result.nonEmpty should be (true)
   }
-  test("Fetch changes with polygon string ") {
+
+  //Ignored due to DROTH-3311, enable again when change info is fetched
+  ignore("Fetch changes with polygon string ") {
     val vvhClient= new VVHClient(Digiroad2Properties.vvhRestApiEndPoint)
     val result= vvhClient.roadLinkChangeInfo.fetchByPolygon(geomBuilder.polygon(528428,6977212,543648,6977212,543648,7002668,528428,7002668))
     result.size should be >1
@@ -58,7 +60,9 @@ class VVHClientSpec extends FunSuite with Matchers{
     val result= vvhClient.roadLinkChangeInfo.fetchByPolygon(geomBuilder.polygon())
     result.size should be (0)
   }
-  test("Fetch changes with by bounding box and municipalities") {
+
+  //Ignored due to DROTH-3311, enable again when change info is fetched
+  ignore("Fetch changes with by bounding box and municipalities") {
     val vvhClient= new VVHClient(Digiroad2Properties.vvhRestApiEndPoint)
     val result= vvhClient.roadLinkChangeInfo.fetchByBoundsAndMunicipalities(BoundingRectangle(Point(532578.3338013917,6993401.605560873,0.0),Point(532978.3338013917,6994261.605560873,0.0)), Set.empty[Int])
     result.size should be >1
@@ -77,7 +81,8 @@ class VVHClientSpec extends FunSuite with Matchers{
     }
   }
 
-  test("Test Change Info fetch by LinkId") {
+  //Ignored due to DROTH-3311, enable again when change info is fetched
+  ignore("Test Change Info fetch by LinkId") {
     val vvhClient= new VVHClient(Digiroad2Properties.vvhRestApiEndPoint)
     val result = vvhClient.roadLinkChangeInfo.fetchByLinkIds(Set(5176799))
     result.nonEmpty should be (true)


### PR DESCRIPTION
Ignorataan tilapäisesti testit, jossa testataan, että vvh palauttaa jonkin muutostiedon.