### PR TITLE
DROTH-3197 draw narrower lines for cycling and walking

### DIFF
--- a/UI/src/view/linear_asset/careClassStyle.js
+++ b/UI/src/view/linear_asset/careClassStyle.js
@@ -95,6 +95,15 @@
       new StyleRule().where('type').is('overlay').and('zoomLevel').is(15).and('expired').is(false).use({ stroke: {opacity: 1.0, color: '#ffffff', lineCap: 'square', width: 12, lineDash: [1,28] }})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).use({ stroke: {color: '#fff', lineCap: 'square', width: 4, lineDash: [1, 16] } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: {color: '#fff', lineCap: 'square', width: 1, lineDash: [1, 8] } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: {color: '#fff', lineCap: 'square', width: 2, lineDash: [1, 8] } })
+    ];
+
     this.getNewFeatureProperties = function(linearAssets){
       var linearAssetsWithType = _.map(linearAssets, function(linearAsset) {
         var hasAsset = me.hasValue(linearAsset);
@@ -122,11 +131,13 @@
     me.browsingStyleProvider.addRules(careClassSizeRules);
     me.browsingStyleProvider.addRules(overlayStyleRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
 
     me.greenCareStyle = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.greenCareStyle.addRules(greenCareClassRules);
     me.greenCareStyle.addRules(careClassSizeRules);
     me.greenCareStyle.addRules(greenCareClassImageSizeRules);
     me.greenCareStyle.addRules(featureTypeRules);
+    me.greenCareStyle.addRules(linkTypeSizeRules);
   };
 })(this);

--- a/UI/src/view/linear_asset/carryingCapacityStyle.js
+++ b/UI/src/view/linear_asset/carryingCapacityStyle.js
@@ -57,15 +57,23 @@
       new StyleRule().where('type').is('cutter').use({ icon: {  src: 'images/cursor-crosshair.svg'}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
+
     me.frostHeavingFactorStyle = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.frostHeavingFactorStyle.addRules(frostHeavingFactorRules);
     me.frostHeavingFactorStyle.addRules(carryingCapacityFeatureSizeRules);
     me.frostHeavingFactorStyle.addRules(featureTypeRules);
+    me.frostHeavingFactorStyle.addRules(linkTypeSizeRules);
 
     me.springCarryingCapacityStyle = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.springCarryingCapacityStyle.addRules(springCarryingCapacityRules);
     me.springCarryingCapacityStyle.addRules(carryingCapacityFeatureSizeRules);
     me.springCarryingCapacityStyle.addRules(featureTypeRules);
+    me.springCarryingCapacityStyle.addRules(linkTypeSizeRules);
 
   };
 })(this);

--- a/UI/src/view/linear_asset/cyclingAndWalkingStyle.js
+++ b/UI/src/view/linear_asset/cyclingAndWalkingStyle.js
@@ -118,12 +118,22 @@
             new StyleRule().where('zoomLevel').isIn([14,15]).use({stroke: {width: 14}})
         ];
 
+        var linkTypeSizeRules = [
+            new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+            new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+            new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } }),
+            new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).use({ stroke: {color: '#fff', lineCap: 'square', width: 4, lineDash: [1, 16] } }),
+            new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: {color: '#fff', lineCap: 'square', width: 1, lineDash: [1, 8] } }),
+            new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: {color: '#fff', lineCap: 'square', width: 2, lineDash: [1, 8] } })
+        ];
+
         me.browsingStyleProvider = new StyleRuleProvider({});
         me.browsingStyleProvider.addRules(linkStatusRules);
         me.browsingStyleProvider.addRules(cyclingAndWalkingSizeRules);
         me.browsingStyleProvider.addRules(featureTypeRules);
         me.browsingStyleProvider.addRules(cyclingAndWalkingStyleRules);
         me.browsingStyleProvider.addRules(overlayStyleRules);
+        me.browsingStyleProvider.addRules(linkTypeSizeRules);
 
     };
 })(this);

--- a/UI/src/view/linear_asset/laneModellingStyle.js
+++ b/UI/src/view/linear_asset/laneModellingStyle.js
@@ -115,7 +115,9 @@
     var laneModellingStyleRules = [
       new StyleRule().where('hasAsset').is(false).use({ stroke : { opacity: 0.7, color: '#7f7f7c'}}),
       new StyleRule().where('hasAsset').is(true).and('isSelected').is(true).and(function (asset){return isMainLane(asset);}).is(true).use({ stroke : { opacity: 0.7, color: '#ff0000' }}),
-      new StyleRule().where('hasAsset').is(true).and('isSelected').is(true).and(function (asset){return isMainLane(asset);}).is(false).use({ stroke : { opacity: 0.7, color: '#11bb00' }})
+      new StyleRule().where('hasAsset').is(true).and('isSelected').is(true).and(function (asset){return isMainLane(asset);}).is(false).use({ stroke : { opacity: 0.7, color: '#11bb00' }}),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('hasAsset').is(true).and('isSelected').is(true).and(function (asset){return isMainLane(asset);}).is(true).use({ stroke : { opacity: 0.7, color: '#ff0000', width: 3 }}),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('hasAsset').is(true).and('isSelected').is(true).and(function (asset){return isMainLane(asset);}).is(false).use({ stroke : { opacity: 0.7, color: '#11bb00', width: 3 }})
     ];
 
     var laneModellingSizeRules = [
@@ -142,6 +144,15 @@
       new StyleRule().where('rotation').isDefined().and('isSelected').is(true).use({ icon: { src: 'images/link-properties/arrow-drop-red2.svg'}}),
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 3 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 1 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 2 } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).use({ stroke: {color: '#fff', lineCap: 'square', width: 3, lineDash: [1, 16] } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: {color: '#fff', lineCap: 'square', width: 1, lineDash: [1, 8] } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: {color: '#fff', lineCap: 'square', width: 2, lineDash: [1, 8] } })
+    ];
+
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.01, color: '#7f7f7c' }});
     me.browsingStyleProvider.addRules(laneModellingSizeRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
@@ -149,10 +160,12 @@
     me.browsingStyleProvider.addRules(laneModellingStyleRules);
     me.browsingStyleProvider.addRules(trafficDirectionRulesForUnselectedLanes);
     me.browsingStyleProvider.addRules(trafficDirectionRulesForSelectedLane);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
 
     me.browsingStyleProviderViewOnly = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.browsingStyleProviderViewOnly.addRules(viewOnlyLaneModellingStyleRules);
     me.browsingStyleProviderViewOnly.addRules(laneModellingSizeRules);
     me.browsingStyleProviderViewOnly.addRules(featureTypeRules);
+    me.browsingStyleProviderViewOnly.addRules(linkTypeSizeRules);
   };
 })(this);

--- a/UI/src/view/linear_asset/parkingProhibitionStyle.js
+++ b/UI/src/view/linear_asset/parkingProhibitionStyle.js
@@ -42,10 +42,17 @@
       new StyleRule().where('zoomLevel').isIn([14,15]).use({stroke: {width: 14}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
+
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.browsingStyleProvider.addRules(parkingProhibitionStyleRules);
     me.browsingStyleProvider.addRules(parkingProhibitionSizeRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
 
   };
 })(this);

--- a/UI/src/view/linear_asset/pavedRoadStyle.js
+++ b/UI/src/view/linear_asset/pavedRoadStyle.js
@@ -48,9 +48,16 @@
       new StyleRule().where('zoomLevel').isIn([14,15]).use({stroke: {width: 14}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
+
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.browsingStyleProvider.addRules(pavedRoadStyleRules);
     me.browsingStyleProvider.addRules(pavedRoadFeatureSizeRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
   };
 })(this);

--- a/UI/src/view/linear_asset/piecewiseLinearAssetStyle.js
+++ b/UI/src/view/linear_asset/piecewiseLinearAssetStyle.js
@@ -35,6 +35,12 @@
     var questionMarkerStyleRules = [
       new StyleRule().where('suggested').is(true).use({icon: {src: 'images/icons/questionMarker.png', scale: 0.7, anchor: [0.45, 1]}})
     ];
+
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
     
 
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
@@ -43,11 +49,13 @@
     me.browsingStyleProvider.addRules(oneWayRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
     me.browsingStyleProvider.addRules(questionMarkerStyleRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
 
     me.browsingStyleProviderReadOnly =  new StyleRuleProvider({ stroke : { opacity: 0.7 , color: '#439232'}});
     me.browsingStyleProviderReadOnly.addRules(zoomLevelRules);
     me.browsingStyleProviderReadOnly.addRules(oneWayRules);
-    me.browsingStyleProvider.addRules(questionMarkerStyleRules);
+    me.browsingStyleProviderReadOnly.addRules(questionMarkerStyleRules);
+    me.browsingStyleProviderReadOnly.addRules(linkTypeSizeRules);
   };
 })(this);
 

--- a/UI/src/view/linear_asset/roadDamagedByThawStyle.js
+++ b/UI/src/view/linear_asset/roadDamagedByThawStyle.js
@@ -58,10 +58,16 @@
       new StyleRule().where('type').is('cutter').use({ icon: {  src: 'images/cursor-crosshair.svg'}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
 
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.browsingStyleProvider.addRules(roadDamagedByThawStyleRules);
     me.browsingStyleProvider.addRules(roadDamagedByThawSizeRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
   };
 })(this);

--- a/UI/src/view/linear_asset/roadWorkStyle.js
+++ b/UI/src/view/linear_asset/roadWorkStyle.js
@@ -53,10 +53,17 @@
       new StyleRule().where('type').is('cutter').use({ icon: {  src: 'images/cursor-crosshair.svg'}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
+
 
     me.browsingStyleProvider = new StyleRuleProvider({ stroke : { opacity: 0.7 }});
     me.browsingStyleProvider.addRules(roadWorkStyleRules);
     me.browsingStyleProvider.addRules(roadWorkSizeRules);
     me.browsingStyleProvider.addRules(featureTypeRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
   };
 })(this);

--- a/UI/src/view/linear_asset/winterSpeedLimitStyle.js
+++ b/UI/src/view/linear_asset/winterSpeedLimitStyle.js
@@ -70,6 +70,15 @@
       new StyleRule().where('type').is('cutter').use({icon: {src: 'images/cursor-crosshair.svg'}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).use({ stroke: {color: '#fff', lineCap: 'square', width: 4, lineDash: [1, 16] } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: {color: '#fff', lineCap: 'square', width: 1, lineDash: [1, 8] } }),
+      new StyleRule().where('type').is('overlay').and('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: {color: '#fff', lineCap: 'square', width: 2, lineDash: [1, 8] } })
+    ];
+
     me.browsingStyleProvider = new StyleRuleProvider({});
     me.browsingStyleProvider.addRules(speedLimitStyleRules);
     me.browsingStyleProvider.addRules(speedLimitFeatureSizeRules);
@@ -77,6 +86,7 @@
     me.browsingStyleProvider.addRules(overlayStyleRules);
     me.browsingStyleProvider.addRules(validityDirectionStyleRules);
     me.browsingStyleProvider.addRules(oneWayOverlayStyleRules);
+    me.browsingStyleProvider.addRules(linkTypeSizeRules);
 
     this.renderOverlays = function(linearAssets){
       var speedLimitsWithType = _.map(linearAssets, function(linearAsset) { return _.merge({}, linearAsset, { type: 'other' }); });

--- a/UI/src/view/point_asset/pointAssetLayerStyles.js
+++ b/UI/src/view/point_asset/pointAssetLayerStyles.js
@@ -27,6 +27,12 @@
       new StyleRule().where('type').is('pointer').use({ icon: {  src: 'images/cursor-crosshair.svg'}})
     ];
 
+    var linkTypeSizeRules = [
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).use({ stroke: { width: 6 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').isIn([10, 9, 8]).use({ stroke: { width: 2 } }),
+      new StyleRule().where('linkType').isIn([8, 9, 12, 21]).and('zoomLevel').is(11).use({ stroke: { width: 4 } })
+    ];
+
 
     var administrativeClassDefaultStyleProvider = new StyleRuleProvider({stroke : { color: "#a4a4a2", opacity: 0.7, width: 5 } });
 
@@ -34,6 +40,7 @@
     administrativeClassDefaultStyleProvider.addRules(zoomLevelRules);
     administrativeClassDefaultStyleProvider.addRules(linkStatusRules);
     administrativeClassDefaultStyleProvider.addRules(featureTypeRules);
+    administrativeClassDefaultStyleProvider.addRules(linkTypeSizeRules);
 
     var administrativeClassSelectStyleProvider = new StyleRuleProvider({stroke : { color: "#5eaedf", opacity: 1, width: 6 } });
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1149,7 +1149,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
           "track" -> lane.attributes.getOrElse("VIITE_TRACK",  lane.attributes.get("TEMP_TRACK")),
           "startAddrMValue" -> lane.attributes.getOrElse("VIITE_START_ADDR", lane.attributes.get("TEMP_START_ADDR")),
           "endAddrMValue" ->  lane.attributes.getOrElse("VIITE_END_ADDR", lane.attributes.get("TEMP_END_ADDR")),
-          "administrativeClass" -> lane.administrativeClass.value
+          "administrativeClass" -> lane.administrativeClass.value,
+          "linkType" -> lane.attributes.getOrElse("linkType", 99)
         )
       }
     }
@@ -2329,7 +2330,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     params.get("bbox").map { bbox =>
       val boundingRectangle = constructBoundingRectangle(bbox)
       validateBoundingBox(boundingRectangle)
-      val viewOnlyLanes = laneService.getViewOnlyByBoundingBox(boundingRectangle, withWalkingCycling = params.getAsOrElse[Boolean]("withWalkingCycling", false))
+      val (viewOnlyLanes, roadLinks) = laneService.getViewOnlyByBoundingBox(boundingRectangle, withWalkingCycling = params.getAsOrElse[Boolean]("withWalkingCycling", false))
       viewOnlyLanes.map { lane =>
         Map (
           "linkId" -> lane.linkId,
@@ -2339,7 +2340,11 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
           "endMeasure" -> lane.endMeasure,
           "points" -> lane.geometry,
           "lanes" -> lane.lanes,
-          "isViewOnly" -> true
+          "isViewOnly" -> true,
+          roadLinks.find(_.linkId == lane.linkId).headOption match {
+            case Some(roadLink) => "linkType" -> roadLink.linkType.value
+            case _ => "linkType" -> 99
+          }
         )
       }
     } getOrElse {

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -2341,10 +2341,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
           "points" -> lane.geometry,
           "lanes" -> lane.lanes,
           "isViewOnly" -> true,
-          roadLinks.find(_.linkId == lane.linkId).headOption match {
-            case Some(roadLink) => "linkType" -> roadLink.linkType.value
-            case _ => "linkType" -> 99
-          }
+          "linkType" -> lane.linkType
         )
       }
     } getOrElse {

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -2330,7 +2330,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     params.get("bbox").map { bbox =>
       val boundingRectangle = constructBoundingRectangle(bbox)
       validateBoundingBox(boundingRectangle)
-      val (viewOnlyLanes, roadLinks) = laneService.getViewOnlyByBoundingBox(boundingRectangle, withWalkingCycling = params.getAsOrElse[Boolean]("withWalkingCycling", false))
+      val viewOnlyLanes = laneService.getViewOnlyByBoundingBox(boundingRectangle, withWalkingCycling = params.getAsOrElse[Boolean]("withWalkingCycling", false))
       viewOnlyLanes.map { lane =>
         Map (
           "linkId" -> lane.linkId,

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
@@ -40,7 +40,7 @@ case class PersistedHistoryLane(id: Long, newId: Long, oldId: Long, linkId: Long
 case class NewLane(id: Long, startMeasure: Double, endMeasure: Double, municipalityCode : Long,
                    isExpired: Boolean = false, isDeleted: Boolean = false, properties: Seq[LaneProperty], sideCode:Option[Int]=None )
 
-case class ViewOnlyLane(linkId: Long, startMeasure: Double, endMeasure: Double, sideCode: Int, trafficDirection: TrafficDirection, geometry: Seq[Point], lanes: Seq[Int])
+case class ViewOnlyLane(linkId: Long, startMeasure: Double, endMeasure: Double, sideCode: Int, trafficDirection: TrafficDirection, geometry: Seq[Point], lanes: Seq[Int], linkType: Int)
 
 case class SideCodesForLinkIds(linkId: Long, sideCode: Int)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -96,14 +96,14 @@ trait LaneOperations {
    * Returns lanes for Digiroad2Api /lanes/viewOnlyLanes GET endpoint.
    * This is only to be used for visualization purposes after the getByBoundingBox ran first
    */
-  def getViewOnlyByBoundingBox (bounds :BoundingRectangle, municipalities: Set[Int] = Set(), withWalkingCycling: Boolean = false): (Seq[ViewOnlyLane], Seq[RoadLink]) = {
+  def getViewOnlyByBoundingBox (bounds :BoundingRectangle, municipalities: Set[Int] = Set(), withWalkingCycling: Boolean = false): Seq[ViewOnlyLane] = {
     val roadLinks = roadLinkService.getRoadLinksFromVVH(bounds, municipalities,asyncMode = false)
     val filteredRoadLinks = if (withWalkingCycling) roadLinks else roadLinks.filter(_.functionalClass != WalkingAndCyclingPath.value)
 
     val linkIds = filteredRoadLinks.map(_.linkId)
     val allLanes = fetchExistingLanesByLinkIds(linkIds)
 
-    (getSegmentedViewOnlyLanes(allLanes, filteredRoadLinks), filteredRoadLinks)
+    getSegmentedViewOnlyLanes(allLanes, filteredRoadLinks)
   }
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -130,7 +130,7 @@ trait LaneOperations {
           val consideredLanes = lanes.filter(lane => lane.startMeasure <= startMeasure && lane.endMeasure >= endMeasure).map(_.laneCode)
           val geometry = GeometryUtils.truncateGeometry3D(roadLink.geometry, startMeasure, endMeasure)
 
-          ViewOnlyLane(linkId, startMeasure, endMeasure, sideCode, roadLink.trafficDirection, geometry, consideredLanes)
+          ViewOnlyLane(linkId, startMeasure, endMeasure, sideCode, roadLink.trafficDirection, geometry, consideredLanes, roadLink.linkType.value)
         }
     }.toSeq
   }


### PR DESCRIPTION
Piirretään niille asseteille, joissa piirretään käpy-väylät, ohuempi viiva käpy-väylän kohdalle (pl. rautateiden huoltotie). Toteutustapa sama kuin tielinkin hallinnollisen luokan tyyleissä. Kaistoissa hieman poikkeava toteutus, koska muutenkin vähän poikkeavat tyylisäännöt.

Lisäksi korjattu yksi oletettu typobugi (piecewiseLinearAssetissa kysymysmerkkityyli on kahteen kertaan normityyleissä, joista toinen on readonly-tyylien joukossa, joten tämän pitäisi varmaan olla readonly).

![Päällyste jälkeen](https://user-images.githubusercontent.com/95400826/178002163-45699bf9-0cfd-4db4-bdb9-923b5d4f4671.JPG)

