### PR TITLE
DROTH-3332 IntegrationApi added toString to modifiedDateTime field va…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -727,7 +727,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
         "validityPeriods" -> manoeuvre.validityPeriods.map(toTimeDomain),
         "validityPeriodMinutes" -> manoeuvre.validityPeriods.map(toTimeDomainWithMinutes),
         "additionalInfo" -> manoeuvre.additionalInfo,
-        "modifiedDateTime" -> manoeuvre.modifiedDateTime.getOrElse(manoeuvre.createdDateTime),
+        "modifiedDateTime" -> manoeuvre.modifiedDateTime.getOrElse(manoeuvre.createdDateTime).toString,
         lastModifiedBy(Some(manoeuvre.createdBy), manoeuvre.modifiedBy))
     }
   }


### PR DESCRIPTION
ModifiedDateTime kenttä jäänyt aikaisemmin tyhjäksi kääntymisrajoitus-tietolajin integration api vastauksessa, kun mäpätty DateTime luokan olio suoraan, nyt lisätty .toString. Ei käytetty latestModificationTime funktiota (tämä käytösssä jossain muissa tietolajien IntegrationApi arvojen mappayksessa) arvon mappaykseen, koska se käyttää eri nimeä kentälle.