### PR TITLE
DROTH-3307 Fixed oldTrafficCode field in integrationApi to display co…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -800,7 +800,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
 
     def showOldTrafficCode(trafficSign: PersistedTrafficSign): String = {
       if (trafficSignService.getProperty(trafficSign, "old_traffic_code").get.propertyValue == "1" ||  trafficSign.createdAt.get.isBefore(trafficSignService.newTrafficCodeStartDate)){
-        TrafficSignType.applyOTHValue(trafficSignService.getProperty(trafficSign, "trafficSigns_type").get.propertyValue.toInt).TRvalue.toString
+        TrafficSignType.applyOTHValue(trafficSignService.getProperty(trafficSign, "trafficSigns_type").get.propertyValue.toInt).OldLawCode
       }
       else ""
     }


### PR DESCRIPTION
Kalpa-apissa nyt näytetään oldTrafficCode kentällä oikein vanhan tieliikennelain mukainen liikennemerkki koodi. Oikeat arvot ovat taulukossa sarakkeessa LAKINRO sivulta 122 alkaen dokumentissa https://julkaisut.vayla.fi/tierekisteri/tierekisteri_tietosisallon_kuvaus.pdf 
LAKINRO vastaa Digiroadin koodissa liikennemerkki case objectien OldLawCode arvoa