### PR TITLE
Droth 3096 promote to mainlane

### DIFF
--- a/UI/src/view/linear_asset/laneModellingForm.js
+++ b/UI/src/view/linear_asset/laneModellingForm.js
@@ -504,6 +504,7 @@
 
       var promoteToMainLane = $('<li>').append($('<button class="btn btn-secondary">Muuta kaista pääkaistaksi</button>').click(function() {
         selectedAsset.promoteToMainLane(currentLaneNumber);
+        currentLaneNumber = 1
         prepareLanesStructure();
         reloadForm($('#feature-attributes'));
       }).prop("disabled", false));

--- a/UI/src/view/linear_asset/laneModellingForm.js
+++ b/UI/src/view/linear_asset/laneModellingForm.js
@@ -502,6 +502,12 @@
         GenericConfirmPopup(confirmationMessage, confirmationPopUpOptions);
       });
 
+      var promoteToMainLane = $('<li>').append($('<button class="btn btn-secondary">Muuta kaista pääkaistaksi</button>').click(function() {
+        selectedAsset.promoteToMainLane(currentLaneNumber);
+        prepareLanesStructure();
+        reloadForm($('#feature-attributes'));
+      }).prop("disabled", false));
+
       var prepareLanesStructure = function () {
         if(_.isUndefined(selectedAsset.getLane(currentLaneNumber))){
           if(currentLaneNumber == "2"){
@@ -525,7 +531,7 @@
       deleteLane.prop('disabled', lane.id !== 0);
 
       if(currentLaneNumber !== 1)
-        body.find('.form').append($('<div class="lane-buttons">').append(expireLane).append(deleteLane));
+        body.find('.form').append($('<div class="lane-buttons">').append(promoteToMainLane).append(expireLane).append(deleteLane));
     }
 
     function renderFormElements(asset, isReadOnly, sideCode, setValueFn, getValueFn, isDisabled, body) {

--- a/UI/src/view/linear_asset/laneModellingForm.js
+++ b/UI/src/view/linear_asset/laneModellingForm.js
@@ -502,7 +502,7 @@
         GenericConfirmPopup(confirmationMessage, confirmationPopUpOptions);
       });
 
-      var promoteToMainLane = $('<button class="btn btn-secondary">Muuta kaista pääkaistaksi</button>').click(function() {
+      var promoteToMainLaneButton = $('<button class="btn btn-secondary">Muuta kaista pääkaistaksi</button>').click(function() {
         var laneToPromote = selectedAsset.getLane(currentLaneNumber);
         var selectedLaneGroup = selectedAsset.selection;
         var passedValidations = validatePromotion(laneToPromote, selectedLaneGroup);
@@ -571,10 +571,10 @@
 
       expireLane.prop('disabled', lane.id === 0);
       deleteLane.prop('disabled', lane.id !== 0);
-      promoteToMainLane.prop('disabled', selectedAsset.isDirty());
+      promoteToMainLaneButton.prop('disabled', selectedAsset.isDirty());
 
       if(currentLaneNumber !== 1)
-        body.find('.form').append($('<div class="lane-buttons">').append(promoteToMainLane).append(expireLane).append(deleteLane));
+        body.find('.form').append($('<div class="lane-buttons">').append(promoteToMainLaneButton).append(expireLane).append(deleteLane));
     }
 
     function renderFormElements(asset, isReadOnly, sideCode, setValueFn, getValueFn, isDisabled, body) {

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -97,7 +97,7 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
         case "obstacles" => pointAssetsToGeoJson(since, obstacleService.getChanged(since, until, token), pointAssetGenericProperties)
         case "warning_signs_group" => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(trafficSignService.getTrafficSignTypeByGroup(TrafficSignTypeGroup.GeneralWarningSigns), since, until, token), pointAssetWarningSignsGroupProperties)
         case "stop_sign" => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(Set(Stop.OTHvalue), since, until, token), pointAssetStopSignProperties)
-        case "lane_information" => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token).flatMap(laneChange => laneChangeLaneToTwoDigitLaneCode(laneChange)), withGeometry)
+        case "lane_information" => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token), withGeometry)
       }
     }
   }
@@ -533,19 +533,6 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
           )
         }
     )
-
-  def laneChangeLaneToTwoDigitLaneCode(laneChange: LaneChange): Option[LaneChange] = {
-    val twoDigitLane = laneService.persistedLaneToTwoDigitLaneCode(laneChange.lane)
-    twoDigitLane match {
-      case Some(_) => laneChange.oldLane match {
-        case Some(_) =>
-          val twoDigitOldLane = laneService.persistedLaneToTwoDigitLaneCode(laneChange.oldLane.get)
-          Some(laneChange.copy(lane = twoDigitLane.get, oldLane = twoDigitOldLane))
-        case _ => Some(laneChange.copy(lane = twoDigitLane.get))
-      }
-      case _ => None
-    }
-  }
 
   def laneChangesToGeoJson(laneChanges: Seq[LaneChange], withGeometry: Boolean = false): Map[String, Any] = {
     def decodePropertyValue(value: Any): String = {

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -97,7 +97,7 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
         case "obstacles" => pointAssetsToGeoJson(since, obstacleService.getChanged(since, until, token), pointAssetGenericProperties)
         case "warning_signs_group" => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(trafficSignService.getTrafficSignTypeByGroup(TrafficSignTypeGroup.GeneralWarningSigns), since, until, token), pointAssetWarningSignsGroupProperties)
         case "stop_sign" => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(Set(Stop.OTHvalue), since, until, token), pointAssetStopSignProperties)
-        case "lane_information" => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token), withGeometry)
+        case "lane_information" => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token, twoDigitLaneCodesInResult = true), withGeometry)
       }
     }
   }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -637,9 +637,11 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
 
           case LaneChangeType.LaneCodeTransfer | LaneChangeType.AttributesChanged =>
             val oldLane = laneChange.oldLane.get
+            val oldLaneType = laneService.getPropertyValue(oldLane.attributes, "lane_type")
 
             Seq(Map("OldId" -> oldLane.id,
               "OldLaneNumber" -> laneChange.oldLane.get.laneCode,
+              "OldlaneType" -> oldLaneType,
               "newId" -> lane.id,
               "NewlaneNumber" -> lane.laneCode,
               "NewlaneType" -> laneType)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
@@ -38,7 +38,7 @@ case class PersistedHistoryLane(id: Long, newId: Long, oldId: Long, linkId: Long
                                 historyCreatedDate: DateTime, historyCreatedBy: String)
 
 case class NewLane(id: Long, startMeasure: Double, endMeasure: Double, municipalityCode : Long,
-                   isExpired: Boolean = false, isDeleted: Boolean = false, properties: Seq[LaneProperty], sideCode:Option[Int]=None )
+                   isExpired: Boolean = false, isDeleted: Boolean = false, properties: Seq[LaneProperty], sideCode:Option[Int]=None, newLaneCode: Option[Int] = None )
 
 case class ViewOnlyLane(linkId: Long, startMeasure: Double, endMeasure: Double, sideCode: Int, trafficDirection: TrafficDirection, geometry: Seq[Point], lanes: Seq[Int])
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
@@ -427,11 +427,6 @@ class LaneDao(val vvhClient: VVHClient, val roadLinkService: RoadLinkService ){
 
   def updateLane(lane: PersistedLane, username: String ): Unit = {
 
-    val oldLaneCode = sql"""SELECT lane_code FROM LANE WHERE id = ${lane.id}""".as[Int].first
-
-    if (LaneNumberOneDigit.isMainLane(oldLaneCode) && oldLaneCode != lane.laneCode)
-      throw new IllegalArgumentException("Cannot change the code of main lane!")
-
     sqlu"""UPDATE LANE
           SET LANE_CODE = ${lane.laneCode}, MODIFIED_BY = $username, MODIFIED_DATE = current_timestamp, MUNICIPALITY_CODE = ${lane.municipalityCode}
           WHERE id = ${lane.id}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -665,7 +665,8 @@ trait LaneOperations {
     * @param username Username of the user is doing the changes
     * @return
     */
-  def update(updateNewLane: Seq[NewLane], linkIds: Set[Long], sideCode: Int, username: String, sideCodesForLinks: Seq[SideCodesForLinkIds], allExistingLanes: Seq[PersistedLane]): Seq[Long] = {
+  def update(updateNewLane: Seq[NewLane], linkIds: Set[Long], sideCode: Int, username: String,
+             sideCodesForLinks: Seq[SideCodesForLinkIds], allExistingLanes: Seq[PersistedLane]): Seq[Long] = {
     if (updateNewLane.isEmpty || linkIds.isEmpty)
       return Seq()
 
@@ -1004,7 +1005,8 @@ trait LaneOperations {
     }
   }
 
-  def separateNewLanesInActions(newLanes: Set[NewLane], linkIds: Set[Long], sideCode: Int, allExistingLanes: Seq[PersistedLane], sideCodesForLinkIds: Seq[SideCodesForLinkIds]): ActionsPerLanes = {
+  def separateNewLanesInActions(newLanes: Set[NewLane], linkIds: Set[Long], sideCode: Int,
+                                allExistingLanes: Seq[PersistedLane], sideCodesForLinkIds: Seq[SideCodesForLinkIds]): ActionsPerLanes = {
 
     val lanesOnLinksBySideCodes = sideCodesForLinkIds.flatMap(sideCodeForLink => {
       allExistingLanes.filter(lane => lane.linkId == sideCodeForLink.linkId && lane.sideCode == sideCodeForLink.sideCode)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -498,16 +498,57 @@ trait LaneOperations {
     val relevantLanesChanged = (upToDateLaneChanges ++ expiredLanes ++ historyLaneChanges).filter(_.roadLink.isDefined)
     val sortedLanesChanged = customSort(relevantLanesChanged)
 
-    token match {
+    val lanesChangedResult = token match {
       case Some(tk) =>
         val (start, end) = Decode.getPageAndRecordNumber(tk)
 
         sortedLanesChanged.slice(start - 1, end)
       case _ => sortedLanesChanged
     }
+
+    laneChangesToTwoDigitLaneCode(lanesChangedResult, roadLinks)
   }
 
-  def pieceWiseLanestoPersistedLane(pwLanes: Seq[PieceWiseLane]): Seq[PersistedLane] = {
+  def laneChangesToTwoDigitLaneCode(laneChanges: Seq[LaneChange], roadLinks: Seq[RoadLink]): Seq[LaneChange] = {
+    val existingPersistedLanes = laneChanges.map(_.lane)
+    val oldPersistedLanes = laneChanges.flatMap(_.oldLane)
+
+    val existingLanesWithConsistentAddress = lanesWithConsistentRoadAddress(pwLanesToPersistedLanesWithAddress(existingPersistedLanes, roadLinks))
+    val oldLanesWithConsistentAddress = lanesWithConsistentRoadAddress(pwLanesToPersistedLanesWithAddress(oldPersistedLanes, roadLinks))
+
+    val twoDigitExistingPwLanes = pieceWiseLanesToTwoDigitWithMassQuery(existingLanesWithConsistentAddress).flatten
+    val twoDigitOldPwLanes = pieceWiseLanesToTwoDigitWithMassQuery(oldLanesWithConsistentAddress).flatten
+
+    val twoDigitExistingPersistedLanes = pieceWiseLanesToPersistedLane(twoDigitExistingPwLanes)
+    val twoDigitOldPersistedLanes = pieceWiseLanesToPersistedLane(twoDigitOldPwLanes)
+
+    laneChanges.flatMap(laneChange => {
+      val twoDigitExistingPersistedLane = twoDigitExistingPersistedLanes.find(_.id == laneChange.lane.id)
+      val twoDigitOldPersistedLane = twoDigitOldPersistedLanes.find(_.id == laneChange.lane.id)
+
+      twoDigitExistingPersistedLane match {
+        case Some(twoDigitExistingLane) =>
+          twoDigitOldPersistedLane match {
+            case Some(twoDigitOldLane) =>
+              Some(laneChange.copy(lane = twoDigitExistingLane, oldLane = Some(twoDigitOldLane)))
+            case _ => Some(laneChange.copy(lane = twoDigitExistingLane))
+          }
+        case _ => None
+      }
+    })
+
+  }
+
+  def pwLanesToPersistedLanesWithAddress(lanes: Seq[PersistedLane], roadLinks: Seq[RoadLink]): Seq[PieceWiseLane] = {
+    val lanesWithRoadLinks = roadLinks.map(roadLink => (lanes.filter(_.linkId == roadLink.linkId), roadLink))
+    val pwLanes = lanesWithRoadLinks.flatMap(pair => laneFiller.toLPieceWiseLane(pair._1, pair._2))
+
+    val updatedInfo = LogUtils.time(logger, "TEST LOG Get Viite road address for lanes")(roadAddressService.laneWithRoadAddress(Seq(pwLanes)))
+    val frozenInfo = LogUtils.time(logger, "TEST LOG Get temp road address for lanes ")(roadAddressService.experimentalLaneWithRoadAddress( updatedInfo.map(_.filterNot(_.attributes.contains("VIITE_ROAD_NUMBER")))))
+    (updatedInfo.flatten ++ frozenInfo.flatten).distinct
+  }
+
+  def pieceWiseLanesToPersistedLane(pwLanes: Seq[PieceWiseLane]): Seq[PersistedLane] = {
     pwLanes.map { pwLane =>
       val municipalityCode = pwLane.attributes.getOrElse("municipality", 99).asInstanceOf[Long]
       val laneCode = getLaneCode(pwLane)
@@ -625,29 +666,33 @@ trait LaneOperations {
     val allExistingLanes = dao.fetchLanesByLinkIdsAndLaneCode(linkIds.toSeq)
 
     updateNewLane.flatMap { laneToUpdate =>
-      val originalLane = allExistingLanes.find(_.id == laneToUpdate.id)
-      val laneToUpdateCode = getLaneCode(laneToUpdate).toInt
+      val originalSelectedLane = allExistingLanes.find(_.id == laneToUpdate.id)
+      val laneToUpdateOriginalLaneCode = getLaneCode(laneToUpdate).toInt
 
       linkIds.map{ linkId =>
-        val laneRelatedByUpdatedLaneCode = allExistingLanes.find(laneAux => laneAux.laneCode == laneToUpdateCode && laneAux.linkId == linkId)
-          .getOrElse(throw new InvalidParameterException(s"LinkId: $linkId dont have laneCode: $laneToUpdateCode for update!"))
+        val sideCodeForLink = sideCodesForLinks.find(_.linkId == linkId)
+          .getOrElse(throw new InvalidParameterException("Side Code not found for link ID: " + linkId))
+          .sideCode
+        val laneRelatedByLaneCode = allExistingLanes.find(laneAux => laneAux.laneCode == laneToUpdateOriginalLaneCode && laneAux.linkId == linkId && laneAux.sideCode == sideCodeForLink)
+          .getOrElse(throw new InvalidParameterException(s"LinkId: $linkId dont have laneCode: $laneToUpdateOriginalLaneCode for update!"))
 
-        originalLane match {
+        originalSelectedLane match {
           case Some(lane) =>
             //oldLane is the lane related with the laneToUpdate by Id, when various links we need to find this lane Id and lane code
-            val sideCodeForLink = sideCodesForLinks.find(_.linkId == linkId)
-              .getOrElse(throw new InvalidParameterException("Side Code not found for link ID: " + linkId))
-              .sideCode
             val oldLane = allExistingLanes.find(laneAux => laneAux.laneCode == lane.laneCode && laneAux.linkId == linkId && laneAux.sideCode == sideCodeForLink)
               .getOrElse(throw new InvalidParameterException(s"LinkId: $linkId dont have laneCode: ${lane.laneCode} for update!"))
 
             val isExactlyMatchingSingleLinkLane = (lane: PersistedLane) => linkIds.size == 1 &&
-              lane.startMeasure == laneToUpdate.startMeasure && lane.startMeasure == laneToUpdate.startMeasure && lane.laneCode == laneToUpdateCode
+              lane.startMeasure == laneToUpdate.startMeasure && lane.startMeasure == laneToUpdate.startMeasure && lane.laneCode == laneToUpdateOriginalLaneCode
 
             if (isExactlyMatchingSingleLinkLane(lane)) {
               var newLaneID = lane.id
-              if (isSomePropertyDifferent(lane, laneToUpdate.properties)) {
-                val persistedLaneToUpdate = PersistedLane(lane.id, linkId, sideCode, laneToUpdateCode, lane.municipalityCode,
+              if (isSomePropertyDifferent(lane, laneToUpdate.properties) || laneToUpdate.newLaneCode.nonEmpty) {
+                val laneCode = laneToUpdate.newLaneCode match {
+                  case Some(newLaneCode) => newLaneCode
+                  case None => laneToUpdateOriginalLaneCode
+                }
+                val persistedLaneToUpdate = PersistedLane(lane.id, linkId, sideCode, laneCode, lane.municipalityCode,
                   lane.startMeasure, lane.endMeasure, Some(username), None, None, None, None, None, false, 0, None, laneToUpdate.properties)
                 moveToHistory(lane.id, None, false, false, username)
                 newLaneID = dao.updateEntryLane(persistedLaneToUpdate, username)
@@ -658,13 +703,17 @@ trait LaneOperations {
               val newLaneID = create(Seq(laneToUpdate), Set(linkId), sideCode, username)
               moveToHistory(oldLane.id, Some(newLaneID.head), true, true, username)
               newLaneID.head
-            } else if (oldLane.laneCode != laneToUpdateCode || isSomePropertyDifferent(oldLane, laneToUpdate.properties)) {
+            } else if (oldLane.laneCode != laneToUpdateOriginalLaneCode || isSomePropertyDifferent(oldLane, laneToUpdate.properties) || laneToUpdate.newLaneCode.nonEmpty) {
               //Something changed on properties or lane code
-              val persistedLaneToUpdate = PersistedLane(oldLane.id, linkId, sideCode, laneToUpdateCode, oldLane.municipalityCode,
+              val laneCode = laneToUpdate.newLaneCode match {
+                case Some(newLaneCode) => newLaneCode
+                case None => laneToUpdateOriginalLaneCode
+              }
+              val persistedLaneToUpdate = PersistedLane(oldLane.id, linkId, sideCodeForLink, laneCode, oldLane.municipalityCode,
                 oldLane.startMeasure, oldLane.endMeasure, Some(username), None, None, None, None, None, false, 0, None, laneToUpdate.properties)
 
-              if (oldLane.laneCode != laneToUpdateCode)
-                moveToHistory(laneRelatedByUpdatedLaneCode.id, Some(oldLane.id), true, true, username)
+              if (oldLane.laneCode != laneToUpdateOriginalLaneCode)
+                moveToHistory(laneRelatedByLaneCode.id, Some(oldLane.id), true, true, username)
 
               moveToHistory(oldLane.id, None, false, false, username)
               dao.updateEntryLane(persistedLaneToUpdate, username)
@@ -677,18 +726,18 @@ trait LaneOperations {
             //so it will be a update, if have some modification, and not a expire and then create
 
             if (linkIds.size == 1 &&
-              (laneRelatedByUpdatedLaneCode.startMeasure != laneToUpdate.startMeasure || laneRelatedByUpdatedLaneCode.endMeasure != laneToUpdate.endMeasure)) {
+              (laneRelatedByLaneCode.startMeasure != laneToUpdate.startMeasure || laneRelatedByLaneCode.endMeasure != laneToUpdate.endMeasure)) {
               val newLaneID = create(Seq(laneToUpdate), Set(linkId), sideCode, username)
-              moveToHistory(laneRelatedByUpdatedLaneCode.id, Some(newLaneID.head), true, true, username)
+              moveToHistory(laneRelatedByLaneCode.id, Some(newLaneID.head), true, true, username)
               newLaneID.head
-            } else if(isSomePropertyDifferent(laneRelatedByUpdatedLaneCode, laneToUpdate.properties)){
-              val persistedLaneToUpdate = PersistedLane(laneRelatedByUpdatedLaneCode.id, linkId, sideCode, laneToUpdateCode, laneToUpdate.municipalityCode,
+            } else if(isSomePropertyDifferent(laneRelatedByLaneCode, laneToUpdate.properties)){
+              val persistedLaneToUpdate = PersistedLane(laneRelatedByLaneCode.id, linkId, sideCodeForLink, laneToUpdateOriginalLaneCode, laneToUpdate.municipalityCode,
                 laneToUpdate.startMeasure, laneToUpdate.endMeasure, Some(username), None, None, None, None, None, false, 0, None, laneToUpdate.properties)
 
-              moveToHistory(laneRelatedByUpdatedLaneCode.id, None, false, false, username)
+              moveToHistory(laneRelatedByLaneCode.id, None, false, false, username)
               dao.updateEntryLane(persistedLaneToUpdate, username)
             } else {
-              laneRelatedByUpdatedLaneCode.id
+              laneRelatedByLaneCode.id
             }
           case _ => throw new InvalidParameterException(s"Error: Could not find lane with lane Id ${laneToUpdate.id}!")
         }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -523,8 +523,11 @@ trait LaneOperations {
     val twoDigitOldPersistedLanes = pieceWiseLanesToPersistedLane(twoDigitOldPwLanes)
 
     laneChanges.flatMap(laneChange => {
-      val twoDigitExistingPersistedLane = twoDigitExistingPersistedLanes.find(_.id == laneChange.lane.id)
-      val twoDigitOldPersistedLane = twoDigitOldPersistedLanes.find(_.id == laneChange.lane.id)
+      val twoDigitExistingPersistedLane = twoDigitExistingPersistedLanes.find(lane => lane.id == laneChange.lane.id && lane.modifiedDateTime == laneChange.lane.modifiedDateTime)
+      val twoDigitOldPersistedLane = laneChange.oldLane match {
+        case Some(oldLane) => twoDigitOldPersistedLanes.find(lane => lane.id == oldLane.id && lane.modifiedDateTime == oldLane.modifiedDateTime)
+        case _ => None
+      }
 
       twoDigitExistingPersistedLane match {
         case Some(twoDigitExistingLane) =>
@@ -1212,7 +1215,8 @@ trait LaneOperations {
           else {
             val oldLaneCode = lane.laneAttributes.find(_.publicId == "lane_code").get.values.head.value.toString
             val newLaneCode = firstDigit.get.toString.concat(oldLaneCode).toInt
-            val newLaneAttributes = Seq(LaneProperty("lane_code", Seq(LanePropertyValue(newLaneCode))))
+            val newLaneCodeProperty = LaneProperty("lane_code", Seq(LanePropertyValue(newLaneCode)))
+            val newLaneAttributes = lane.laneAttributes.filterNot(_.publicId == "lane_code") ++ Seq(newLaneCodeProperty)
             Option(lane.copy(laneAttributes = newLaneAttributes))
           }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
@@ -70,7 +70,7 @@ object ChangeLanesAccordingToVvhChanges {
     val allLanes = assetsOnChangedLinks.filterNot(a => projectedLanes.exists(_.linkId == a.linkId)) ++ projectedLanes ++ lanesWithoutChangedLinks
     val groupedAssets = allLanes.groupBy(_.linkId)
     val (changedLanes, changeSet) = laneFiller.fillTopology(roadLinks, groupedAssets, Some(changedSet))
-    val persistedChangedLanes = pieceWiseLanestoPersistedLane(changedLanes)
+    val persistedChangedLanes = pieceWiseLanesToPersistedLane(changedLanes)
 
     val changeSetFilteredExpired = filterExpiredIds(changeSet)
     (changeSetFilteredExpired, persistedChangedLanes)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -187,7 +187,8 @@ class LaneServiceSpec extends LaneTestSupporter {
       val newLane1 = ServiceWithDao.create(Seq(NewLane(0, 0, 500, 745, false, false, lanePropertiesValues1)), Set(100L), 1, usernameTest)
       newLane1.length should be(1)
 
-      val updatedLane = ServiceWithDao.update(Seq(NewLane(newLane1.head, 0, 500, 745, false, false, updateValues1)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 1)))
+      val allExistingLanes = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L))
+      val updatedLane = ServiceWithDao.update(Seq(NewLane(newLane1.head, 0, 500, 745, false, false, updateValues1)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 1)), allExistingLanes)
       updatedLane.length should be(1)
 
       //Verify the presence one line with old data before the update on histories tables
@@ -212,7 +213,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val createdLane = ServiceWithDao.getPersistedLanesByIds(newLaneId.toSet)
       createdLane.head.attributes.length should be(3)
 
-      val updatedLaneId = ServiceWithDao.update(Seq(NewLane(newLaneId.head, 0, 500, 745, false, false, lanePropertiesWithEmptyDate)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 1)))
+      val updatedLaneId = ServiceWithDao.update(Seq(NewLane(newLaneId.head, 0, 500, 745, false, false, lanePropertiesWithEmptyDate)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 1)), createdLane)
       val updatedLane = ServiceWithDao.getPersistedLanesByIds(updatedLaneId.toSet)
       updatedLane.head.attributes.length should be(2)
     }
@@ -1137,7 +1138,8 @@ class LaneServiceSpec extends LaneTestSupporter {
       )
 
       val lane1Id = ServiceWithDao.create(Seq(newLane1), Set(100L), 2, usernameTest).head
-      ServiceWithDao.update(Seq(newLane1.copy(id = lane1Id, properties = newLanePropertiesValues11)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 2)))
+      val allExistingLanes = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L))
+      ServiceWithDao.update(Seq(newLane1.copy(id = lane1Id, properties = newLanePropertiesValues11)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 2)), allExistingLanes)
 
       when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(100L), false)).thenReturn(
         Seq(RoadLink(100L, Seq(Point(0.0, 0.0), Point(100.0, 0.0)), 100, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None, Map(
@@ -1195,12 +1197,13 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       ServiceWithDao.create(Seq(newLane2), Set(100L), 2, usernameTest)
       val lane4Id = ServiceWithDao.create(Seq(newLane4), Set(100L), 2, usernameTest).head
+      val allExistingLanes = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L))
 
       val newLanePropertiesValuesOld4 = Seq(LaneProperty("lane_code", Seq(LanePropertyValue(2))),
         LaneProperty("lane_type", Seq(LanePropertyValue("3")))
       )
 
-      ServiceWithDao.update(Seq(newLane4.copy(id = lane4Id, properties = newLanePropertiesValuesOld4)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 2)))
+      ServiceWithDao.update(Seq(newLane4.copy(id = lane4Id, properties = newLanePropertiesValuesOld4)), Set(100L), 1, usernameTest, Seq(SideCodesForLinkIds(100L, 2)), allExistingLanes)
 
       when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(100L), false)).thenReturn(
         Seq(RoadLink(100L, Seq(Point(0.0, 0.0), Point(100.0, 0.0)), 100, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None, Map(
@@ -1231,9 +1234,10 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       ServiceWithDao.create(Seq(newLane1), Set(100L), 2, usernameTest)
       val lane2Id = ServiceWithDao.create(Seq(newLane2), Set(100L), 2, usernameTest).head
+      val allExistingLanes = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L))
 
       val subLane2Split = NewLane(0, 0, 50, 745, false, false, lanePropertiesValues2)
-      ServiceWithDao.update(Seq(subLane2Split), Set(100L), 2, usernameTest, Seq(SideCodesForLinkIds(100L, 2)))
+      ServiceWithDao.update(Seq(subLane2Split), Set(100L), 2, usernameTest, Seq(SideCodesForLinkIds(100L, 2)), allExistingLanes)
 
       when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(100L), false)).thenReturn(
         Seq(RoadLink(100L, Seq(Point(0.0, 0.0), Point(100.0, 0.0)), 100, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None, Map(
@@ -1266,8 +1270,9 @@ class LaneServiceSpec extends LaneTestSupporter {
       ServiceWithDao.create(Seq(newLane1), Set(100L), 2, usernameTest)
       ServiceWithDao.create(Seq(newLane2), Set(100L), 2, usernameTest)
 
+      val allExistingLanes = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L))
       val subLane2Split = NewLane(0, 0, 50, 745, false, false, lanePropertiesValues2)
-      val subLane2Id = ServiceWithDao.update(Seq(subLane2Split), Set(100L), 2, usernameTest, Seq(SideCodesForLinkIds(100L, 2))).head
+      val subLane2Id = ServiceWithDao.update(Seq(subLane2Split), Set(100L), 2, usernameTest, Seq(SideCodesForLinkIds(100L, 2)), allExistingLanes).head
 
       when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(100L), false)).thenReturn(
         Seq(RoadLink(100L, Seq(Point(0.0, 0.0), Point(100.0, 0.0)), 100, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None, Map(
@@ -1342,12 +1347,14 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1Id = ServiceWithDao.create(Seq(newLane1), Set(100L), 2, usernameTest).head
       val lane2Id = ServiceWithDao.create(Seq(newLane2), Set(100L), 2, usernameTest).head
 
+      val allExistingLanes = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L))
+
       val lane1toLaneCode2 = newLane1.copy(id = lane1Id, newLaneCode = Some(2), properties = lanePropertiesValues2)
       val lane2toLaneCode1 = newLane2.copy(id = lane2Id, newLaneCode = Some(1), properties = lanePropertiesValues1)
 
       val sideCodesForLinkIds = SideCodesForLinkIds(100L, 2)
 
-      val updatedIds = ServiceWithDao.update(Seq(lane1toLaneCode2, lane2toLaneCode1), Set(100L), 2,usernameTest, Seq(sideCodesForLinkIds))
+      val updatedIds = ServiceWithDao.update(Seq(lane1toLaneCode2, lane2toLaneCode1), Set(100L), 2,usernameTest, Seq(sideCodesForLinkIds), allExistingLanes)
 
       when(mockRoadLinkService.getRoadLinksByLinkIdsFromVVH(Set(100L), false)).thenReturn(
         Seq(RoadLink(100L, Seq(Point(0.0, 0.0), Point(100.0, 0.0)), 100, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None, Map(


### PR DESCRIPTION
Toimi ok devissä, poislukien, että muutossanomien testaus ei onnistunut devissä (lokaalisti todettu OK), koska tiketissä DROTH-3104 tehty muutos pieceWiseLanesToTwoDigitWithMassQuery-funktioon, joka on puskettu development aiheutti virheellisiä tyyppi castauksia. Tämä bugi korjataan tiketissä DROTH-3104.