### PR TITLE
DROTH-3104 Allow batch to get object from S3

### DIFF
--- a/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
@@ -23,6 +23,7 @@
       }
     ],
     "executionRoleArn": "arn:aws:iam::475079312496:role/DEV-batchSystem-BatchTaskRole-VGL42N9TANTI",
+    "jobRoleArn": "arn:aws:iam::475079312496:role/DEV-batchSystem-BatchJobRole-EZGAXBVXWXO8",
     "environment": [
       {
         "name": "containerCPU",

--- a/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
@@ -23,7 +23,7 @@
       }
     ],
     "executionRoleArn": "arn:aws:iam::475079312496:role/DEV-batchSystem-BatchTaskRole-VGL42N9TANTI",
-    "jobRoleArn": "arn:aws:iam::475079312496:role/DEV-batchSystem-BatchJobRole-EZGAXBVXWXO8",
+    "jobRoleArn": "arn:aws:iam::475079312496:role/DEV-digiroad2-JobRole",
     "environment": [
       {
         "name": "containerCPU",

--- a/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
@@ -23,6 +23,7 @@
       }
     ],
     "executionRoleArn": "arn:aws:iam::920408837790:role/digiroad-batch-system-BatchTaskRole-NTGCBVRU7CCR",
+    "jobRoleArn": "arn:aws:iam::920408837790:role/Prod-digiroad2-JobRole",
     "environment": [
       {
         "name": "containerCPU",

--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -23,7 +23,7 @@
       }
     ],
     "executionRoleArn": "arn:aws:iam::475079312496:role/QA-batchSystem-BatchTaskRole-1QO0VDAJOYS45",
-    "jobRoleArn": "arn:aws:iam::475079312496:role/QA-batchSystem-BatchJobRole-38BJCSXZBNR9",
+    "jobRoleArn": "arn:aws:iam::475079312496:role/QA-digiroad2-JobRole",
     "environment": [
       {
         "name": "containerCPU",

--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -23,6 +23,7 @@
       }
     ],
     "executionRoleArn": "arn:aws:iam::475079312496:role/QA-batchSystem-BatchTaskRole-1QO0VDAJOYS45",
+    "jobRoleArn": "arn:aws:iam::475079312496:role/QA-batchSystem-BatchJobRole-38BJCSXZBNR9",
     "environment": [
       {
         "name": "containerCPU",

--- a/aws/cloud-formation/batchSystem/batchSystem.yaml
+++ b/aws/cloud-formation/batchSystem/batchSystem.yaml
@@ -162,6 +162,9 @@ Resources:
                   - 'ssm:GetParameter'
                   - 'ssm:GetParameters'
                   - 'ssm:GetParametersByPath'
+
+                  # Allow batch to get objects from S3, used for main lane start date import
+                  - 's3:GetObject'
                 Resource: '*'
       Tags:
         - Key: Name

--- a/aws/cloud-formation/batchSystem/batchSystem.yaml
+++ b/aws/cloud-formation/batchSystem/batchSystem.yaml
@@ -177,6 +177,7 @@ Resources:
   BatchJobRole:
     Type: AWS::IAM::Role
     Properties:
+      RoleName: !Join [ '-', [ !Ref EnvironmentName, !Ref ApplicationName, 'JobRole']]
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/aws/cloud-formation/batchSystem/batchSystem.yaml
+++ b/aws/cloud-formation/batchSystem/batchSystem.yaml
@@ -195,7 +195,7 @@ Resources:
                 Resource: '*'
       Tags:
         - Key: Name
-          Value: !Join [ '-', [ !Ref EnvironmentName, !Ref ApplicationName, 'batchTaskRole' ] ]
+          Value: !Join [ '-', [ !Ref EnvironmentName, !Ref ApplicationName, 'batchJobRole' ] ]
         - Key: Environment
           Value: !Ref EnvironmentName
         - Key: Owner

--- a/aws/cloud-formation/batchSystem/batchSystem.yaml
+++ b/aws/cloud-formation/batchSystem/batchSystem.yaml
@@ -163,6 +163,33 @@ Resources:
                   - 'ssm:GetParameters'
                   - 'ssm:GetParametersByPath'
 
+                Resource: '*'
+      Tags:
+        - Key: Name
+          Value: !Join [ '-', [ !Ref EnvironmentName, !Ref ApplicationName, 'batchTaskRole' ] ]
+        - Key: Environment
+          Value: !Ref EnvironmentName
+        - Key: Owner
+          Value: !Ref Owner
+        - Key: Project
+          Value: !Ref Project
+
+  BatchJobRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: [ecs-tasks.amazonaws.com]
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+        - PolicyName: !Join [ '-', [ !Ref EnvironmentName, !Ref ApplicationName,'BatchJobRole' ] ]
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action:
                   # Allow batch to get objects from S3, used for main lane start date import
                   - 's3:GetObject'
                 Resource: '*'
@@ -175,6 +202,7 @@ Resources:
           Value: !Ref Owner
         - Key: Project
           Value: !Ref Project
+
 
   BatchServiceRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
Lisätty lupa hakea S3:sta tiedostoja BatchTaskRole-roolille. Taitaa vaatia tämän, kun käytetään InstanceProfileCredentialsProvider tunnusten saamiseksi alkupäivänmäärien import-batchissa aws-ympäristössä.