### PR TITLE
DROTH-3104 Added handling for VKM errors

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/LanesCsvImporter.scala
@@ -230,7 +230,14 @@ class LanesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
           })
 
           val twoDigitPwLanes = LogUtils.time(logger, "Transform " + pwLanes.size + " lanes to two digit lanes with mass query") {
-            laneService.pieceWiseLanesToTwoDigitWithMassQuery(pwLanes)
+            try {
+              laneService.pieceWiseLanesToTwoDigitWithMassQuery(pwLanes)
+            }
+            catch {
+              case rae: RoadAddressException =>
+                logger.error(rae.getMessage)
+                Seq()
+            }
           }
           val twoDigitLanes = laneService.pieceWiseLanesToPersistedLane(twoDigitPwLanes.flatten)
           //Lanes where VKM failed to transform coordinates to road addresses


### PR DESCRIPTION
Lisätty käsittely VKM virheille. Rivi, jolla virhe on tullut ja muunnettavat kaistat tulostuvat raporttiin lopuksi