### PR TITLE
DROTH-3345 MainLanePopulationProcess initialProcess truncate all lane…

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
@@ -405,6 +405,17 @@ class LaneDao(val vvhClient: VVHClient, val roadLinkService: RoadLinkService ){
     }
   }
 
+  //Deletes all lane info, only to be used in MainLanePopulation initial process
+  def truncateLaneTables(): Unit = {
+    sqlu"""TRUNCATE TABLE LANE""".execute
+    sqlu"""TRUNCATE TABLE LANE_ATTRIBUTE""".execute
+    sqlu"""TRUNCATE TABLE LANE_LINK""".execute
+    sqlu"""TRUNCATE TABLE LANE_POSITION""".execute
+    sqlu"""TRUNCATE TABLE LANE_HISTORY""".execute
+    sqlu"""TRUNCATE TABLE LANE_HISTORY_ATTRIBUTE""".execute
+    sqlu"""TRUNCATE TABLE LANE_HISTORY_LINK""".execute
+    sqlu"""TRUNCATE TABLE LANE_HISTORY_POSITION""".execute
+  }
 
   def updateEntryLane( lane: PersistedLane, username: String ): Long = {
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -1108,6 +1108,11 @@ trait LaneOperations {
     }
   }
 
+  //Deletes all lane info, only to be used in MainLanePopulation initial process
+  def deleteAllPreviousLaneData(): Unit = {
+    dao.truncateLaneTables()
+  }
+
   def persistedLaneToTwoDigitLaneCode(lane: PersistedLane, newTransaction: Boolean = true): Option[PersistedLane] = {
     val roadLink = roadLinkService.getRoadLinksByLinkIdsFromVVH(Set(lane.linkId), newTransaction).head
     val pwLane = laneFiller.toLPieceWiseLane(Seq(lane), roadLink).head

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/MainLanePopulationProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/MainLanePopulationProcess.scala
@@ -124,18 +124,11 @@ object MainLanePopulationProcess {
 
   // Moves all existing lanes to history and creates new main lanes from vvh road links
   def initialProcess(): Unit = {
-    logger.info(s"Start to remove existing lanes ${DateTime.now()}")
+    logger.info(s"Truncate all lane tables ${DateTime.now()}")
 
-    val municipalities: Seq[Int] = PostGISDatabase.withDynSession {
-      Queries.getMunicipalities
-    }
+    PostGISDatabase.withDynTransaction(laneService.deleteAllPreviousLaneData())
 
-    municipalities.foreach { municipality =>
-      logger.info("Deleting lanes from municipality -> " + municipality)
-      PostGISDatabase.withDynTransaction(laneService.expireAllMunicipalityLanes(municipality, username))
-    }
-
-    logger.info(s"Finished removing lanes ${DateTime.now()}")
+    logger.info(s"Finished removing all lane data ${DateTime.now()}")
 
     // Populate main lanes from road links
     process(initialProcessing = true)


### PR DESCRIPTION
Truncate kaikki kaistataulut historioinnin sijaan, niin voidaan aloittaa puhtaalta pöydältä kun aletaan luomaan kaistatietoja eri ympäristöille, eikä vanhaa historiatietoa jää kummittelemaan kantaan. 

Aikaisempi pullari suljettu, oli menossa väärään haaraan.