### PR TITLE
DROTH-3346 fix bug with lane cut tool saving. Remove redundant code, …

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -1009,88 +1009,57 @@ trait LaneOperations {
     newLanesByLaneCode.flatMap { case (laneCode, lanesToUpdate) =>
       val oldLanesByCode = oldLanes.filter(_.laneCode == laneCode)
 
-      if (lanesToUpdate.size >= 2) {
-        //When one or more lanes are cut to smaller pieces
-        val newLanesIDs = lanesToUpdate.map { lane =>
-          create(Seq(lane), linkIds, sideCode, username).head
-        }
+      //When one or more lanes are cut to smaller pieces
+      val newLanesIDs = lanesToUpdate.map { lane =>
+        create(Seq(lane), linkIds, sideCode, username).head
+      }
 
-        val createdNewLanes = dao.fetchLanesByIds(newLanesIDs.toSet)
+      val createdNewLanes = dao.fetchLanesByIds(newLanesIDs.toSet)
 
-        def newLanesWithinOldLaneRange(newLanes: Seq[PersistedLane], oldLane: PersistedLane) = {
-          newLanes.filter(newLane => newLane.startMeasure >= oldLane.startMeasure && newLane.endMeasure <= oldLane.endMeasure)
-        }
-
-        /*Creates an explicit expired lane piece for those parts of the split line that have been deleted before saving.
-        Needed for change messages, so that the expiration change will be mapped to the expired lane part in ChangeAPI.*/
-        def createExpiredPartsOfOldLane(newLanes: Seq[PersistedLane], oldLane: PersistedLane): Unit = {
-          val sortedNewLanes = newLanes.sortBy(_.startMeasure)
-          var start = oldLane.startMeasure
-          sortedNewLanes.foreach { newLane =>
-            if (start < newLane.startMeasure) {
-              val replacementLaneId = create(Seq(NewLane(0, start, newLane.startMeasure, oldLane.municipalityCode, true, true,
-                oldLane.attributes, Some(sideCode))), linkIds, sideCode, username).head
-              moveToHistory(oldLane.id, Some(replacementLaneId), true, false, username)
-              moveToHistory(replacementLaneId, None, true, true, username)
-              start = newLane.startMeasure
-            } else {
-              start = newLane.endMeasure
-            }
-
+      //Expire only those old lanes that have been replaced by new lane pieces.
+      oldLanesByCode.foreach { oldLane =>
+        val newLanesWithinRange = newLanesWithinOldLaneRange(createdNewLanes, oldLane)
+        if (!newLanesWithinRange.isEmpty) {
+          createExpiredPartsOfOldLane(newLanesWithinRange, oldLane, sideCode, linkIds, username)
+          newLanesWithinRange.foreach { newLane =>
+            moveToHistory(oldLane.id, Some(newLane.id), true, false, username)
           }
-          val lastNewLane = sortedNewLanes.last
-          if (lastNewLane.endMeasure < oldLane.endMeasure) {
-            val replacementLaneId = create(Seq(NewLane(0, lastNewLane.endMeasure, oldLane.endMeasure, oldLane.municipalityCode, true, true,
-              oldLane.attributes, Some(sideCode))), linkIds, sideCode, username).head
-            moveToHistory(oldLane.id, Some(replacementLaneId), true, false, username)
-            moveToHistory(replacementLaneId, None, true, true, username)
-          }
-        }
-
-        //Expire only those old lanes that have been replaced by new lane pieces.
-        oldLanes.foreach { oldLane =>
-          val newLanesWithinRange = newLanesWithinOldLaneRange(createdNewLanes, oldLane)
-          if (!newLanesWithinRange.isEmpty) {
-            createExpiredPartsOfOldLane(newLanesWithinRange, oldLane)
-            newLanesWithinRange.foreach { newLane =>
-              moveToHistory(oldLane.id, Some(newLane.id), true, false, username)
-            }
-            dao.deleteEntryLane(oldLane.id)
-          }
-        }
-
-        newLanesIDs
-
-      } else if (lanesToUpdate.size == 1 && oldLanesByCode.size == 2) {
-        //When its to transform two lanes in one on same roadlink
-        val newLanesIDs = lanesToUpdate.map { lane =>
-          create(Seq(lane), linkIds, sideCode, username).head
-        }
-
-        oldLanesByCode.foreach { oldLane =>
-          moveToHistory(oldLane.id, Some(newLanesIDs.head), true, true, username)
-        }
-
-        newLanesIDs
-
-      } else {
-        //When its to update both lanes in one link
-        oldLanesByCode.map { oldLane =>
-          val newDataToUpdate = lanesToUpdate.filter(_.id == oldLane.id).head
-
-          if (isSomePropertyDifferent(oldLane, newDataToUpdate.properties)) {
-            val persistedLaneToUpdate = PersistedLane(newDataToUpdate.id, linkIds.head, sideCode, oldLane.laneCode, newDataToUpdate.municipalityCode,
-              newDataToUpdate.startMeasure, newDataToUpdate.endMeasure, Some(username), None, None, None, None, None, false, 0, None, newDataToUpdate.properties)
-
-            moveToHistory(oldLane.id, None, false, false, username)
-            dao.updateEntryLane(persistedLaneToUpdate, username)
-
-          } else {
-            oldLane.id
-          }
+          dao.deleteEntryLane(oldLane.id)
         }
       }
+
+      newLanesIDs
     }.toSeq
+  }
+
+  def newLanesWithinOldLaneRange(newLanes: Seq[PersistedLane], oldLane: PersistedLane) = {
+    newLanes.filter(newLane => newLane.startMeasure >= oldLane.startMeasure && newLane.endMeasure <= oldLane.endMeasure)
+  }
+
+  /*Creates an explicit expired lane piece for those parts of the split line that have been deleted before saving.
+  Needed for change messages, so that the expiration change will be mapped to the expired lane part in ChangeAPI.*/
+  def createExpiredPartsOfOldLane(newLanes: Seq[PersistedLane], oldLane: PersistedLane, sideCode: Int, linkIds: Set[Long], username: String): Unit = {
+    val sortedNewLanes = newLanes.sortBy(_.startMeasure)
+    var start = oldLane.startMeasure
+    sortedNewLanes.foreach { newLane =>
+      if (start < newLane.startMeasure) {
+        val replacementLaneId = create(Seq(NewLane(0, start, newLane.startMeasure, oldLane.municipalityCode, true, true,
+          oldLane.attributes, Some(sideCode))), linkIds, sideCode, username).head
+        moveToHistory(oldLane.id, Some(replacementLaneId), true, false, username)
+        moveToHistory(replacementLaneId, None, true, true, username)
+        start = newLane.startMeasure
+      } else {
+        start = newLane.endMeasure
+      }
+
+    }
+    val lastNewLane = sortedNewLanes.last
+    if (lastNewLane.endMeasure < oldLane.endMeasure) {
+      val replacementLaneId = create(Seq(NewLane(0, lastNewLane.endMeasure, oldLane.endMeasure, oldLane.municipalityCode, true, true,
+        oldLane.attributes, Some(sideCode))), linkIds, sideCode, username).head
+      moveToHistory(oldLane.id, Some(replacementLaneId), true, false, username)
+      moveToHistory(replacementLaneId, None, true, true, username)
+    }
   }
 
   def expireAllAdditionalLanes(username: String): Unit = {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -500,7 +500,7 @@ class LaneServiceSpec extends LaneTestSupporter {
     }
   }
 
-  test("Update two lanes in one roadlink to only one lane") {
+  test("Replace two old split lanes with new full length additional lane") {
     runWithRollback {
       val lanePropertiesSubLaneSplit2 = Seq(
         LaneProperty("lane_code", Seq(LanePropertyValue(2))),
@@ -551,7 +551,10 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       //Simulation of sending a main lane, and one sublane not splitted
       val currentMainLane = mainLane.copy(id = mainLane1Id)
-      ServiceWithDao.processNewLanes(Set(currentMainLane, subLane2), Set(100L), 1, usernameTest, sideCodesForLinkIds)
+      val expiredSubLane2A = subLane2SplitA.copy(id = newSubLane2SplitAId, isExpired = true)
+      val expiredSubLane2B = subLane2SplitB.copy(id = newSubLane2SplitBId, isExpired = true)
+
+      ServiceWithDao.processNewLanes(Set(currentMainLane, subLane2, expiredSubLane2A, expiredSubLane2B ), Set(100L), 1, usernameTest, sideCodesForLinkIds)
 
       val lanesAfterSplit = laneDao.fetchLanesByLinkIdsAndLaneCode(Seq(100L), Seq(1, 2), true)
       lanesAfterSplit.size should be(2)
@@ -576,7 +579,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historyLanes.size should be(2)
 
       val historylane2A = historyLanes.filter(_.oldId == newSubLane2SplitAId).head
-      historylane2A.newId should not be 0
+      historylane2A.newId should be (0)
       historylane2A.newId should not be mainLane1Id
       historylane2A.startMeasure should be(0)
       historylane2A.endMeasure should be(250.0)
@@ -586,7 +589,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       }
 
       val historylane2B = historyLanes.filter(_.oldId == newSubLane2SplitBId).head
-      historylane2B.newId should not be 0
+      historylane2B.newId should be (0)
       historylane2B.newId should not be mainLane1Id
       historylane2B.startMeasure should be(250.0)
       historylane2B.endMeasure should be(500.0)


### PR DESCRIPTION
Korjattu bugi katkaistujen kaistojen tallennuksessa. UI muutosten tallennuksesta poistettu mahdollisuus yhdistää kaksi katkottua kaistaa yhdeksi kaistaksi. (Ei ikinä toteutettu UI puolella?) Muokattu tämän Unit Test vastaamaan nykyistä tilannetta. Siirretty newLanesWithinOldLaneRange ja createExpiredPartsOfOldLane funktiot pois createMultiLanesOnLink funktion sisältä. Poistettu koodi ei näytä aiheuttavan regressiota kaistojen katkaisussa.