### PR TITLE
Droth 3254 turn off change info

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/RoadLinkClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/RoadLinkClient.scala
@@ -1089,13 +1089,14 @@ class VVHChangeInfoClient(vvhRestApiEndPoint: String) extends VVHClientOperation
   }
 
   def fetchByDates(since: DateTime, until: DateTime): Seq[ChangeInfo] = {
-    val definition = layerDefinition(withCreatedDateFilter(since, until))
+    /*val definition = layerDefinition(withCreatedDateFilter(since, until))
     val url = serviceUrl(definition, queryParameters())
 
     fetchVVHFeatures(url) match {
       case Left(features) => features.map(extractFeature)
       case Right(error) => throw new ClientException(error.toString)
-    }
+    }*/
+    Seq()  //disabled due to DROTH-3254
   }
 
   protected  def withCreatedDateFilter(lowerDate: DateTime, higherDate: DateTime): String = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/RoadLinkClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/vvh/RoadLinkClient.scala
@@ -1052,7 +1052,7 @@ class OldVVHRoadLinkClient(vvhRestApiEndPoint: String) extends VVHClientOperatio
   // TODO: Temporary parsing from string to long. Remove after not needed anymore
     queryByLinkIds(parseLinkIdsToLong(linkIds), fieldSelection, fetchGeometry, resultTransition, Filter.withLinkIdFilter)
 }
-
+//Replace with new tiekamu client in future
 class VVHChangeInfoClient(vvhRestApiEndPoint: String) extends VVHClientOperations {
   override type LinkType = ChangeInfo
   override type Content = Map[String, Any]


### PR DESCRIPTION
Tehdään nyt tyhjä lista tyyliin. Sitten kun poistetaan noi muut vvhclient hommat vois uudelleen nimetä koko object.