### PR TITLE
DROTH-3351 fix roadlinks without lanes api mapping

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -2318,7 +2318,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       } else {
         validateBoundingBox(boundingRectangle)
         val (assets, roadLinksWithoutLanes) = usedService.getByBoundingBox(boundingRectangle, withWalkingCycling = params.getAsOrElse[Boolean]("withWalkingCycling", false))
-        mapLanes(assets) ++ roadLinkToApiWithLaneInfo(roadLinksWithoutLanes,withLaneInfo = false)
+        mapLanes(assets) ++ Seq(roadLinkToApiWithLaneInfo(roadLinksWithoutLanes))
       }
 
     } getOrElse {


### PR DESCRIPTION
Jäänyt vastaus bäkkäriltä väärään muotoon kaistattomien tielinkkien osalta. Käyty läpi kaistakoodia, ei löytynyt muuta korjattavaa liittyen tilanteisiin, joissa kaistoja ei löydy tielinkiltä. QA:lla vastaan tullut None.get virhe näyttäisi johtuneen pyöristämisvirheestä kaistan päätepisteiden koordinaateissa. (päätepisteiden desimaaleissa heittoa, vaikka todellisuudessa osoittavat samaan pisteeseen), ei saatu toistettua ongelmaa, tuntuu toimivan riittävän hyvin.