### PR TITLE
DROTH-3351 Handling for cases where no nextPoint found

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -110,7 +110,10 @@ object LanePartitioner {
           case Some(laneWithContinuing) =>
             val checkedLane = checkLane(sortedLanes.last, laneWithContinuing.lane, allLanes)
             val nextPoint = checkedLane.endpoints.find(_.round() != continuingPoint.round())
-            getSortedLanes(nextPoint.get, sortedLanes ++ Seq(checkedLane))
+            nextPoint match {
+              case Some(point) => getSortedLanes(point, sortedLanes ++ Seq(checkedLane))
+              case _ => sortedLanes
+            }
           case _ => sortedLanes
         }
       }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -112,7 +112,7 @@ object LanePartitioner {
             val nextPoint = checkedLane.endpoints.find(_.round() != continuingPoint.round())
             nextPoint match {
               case Some(point) => getSortedLanes(point, sortedLanes ++ Seq(checkedLane))
-              case _ => sortedLanes
+              case None => sortedLanes
             }
           case _ => sortedLanes
         }


### PR DESCRIPTION
Lisätty käsittely tapauksille jossa kaistajoukkoa muodostaessa ei löydetä seuraavaa pistettä. Pistettä ei löytynyt tapauksissa, jossa kaistajoukon alku- tai loppupäässä oli linkki, jonka päätepisteet olivat samat (esim. asuinalueen ympyrän muotoinen pihatie)