### PR TITLE
DROTH-3356 Fixed bug with Lane Temp address, refactored code to avoid…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -106,9 +106,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     val roadLinks = roadLinkService.getRoadLinksFromVVH(municipalityNumber)
     val lanes = laneService.getLanesByRoadLinks(roadLinks)
 
-    val (lanesWithViiteAddress, noRoadAddress) = roadAddressService.laneWithRoadAddress(Seq(lanes)).flatten.partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
-    val lanesWithTempAddress = roadAddressService.experimentalLaneWithRoadAddress(Seq(noRoadAddress)).flatten.filter(_.attributes.contains("TEMP_ROAD_NUMBER"))
-    val lanesWithRoadAddress = lanesWithViiteAddress ++ lanesWithTempAddress
+    val lanesWithRoadAddress = laneService.getRoadAddressForLanes(lanes)
     val lanesWithNormalRoadAddress = lanesWithConsistentRoadAddress(lanesWithRoadAddress)
 
     val twoDigitLanes = laneService.pieceWiseLanesToTwoDigitWithMassQuery(lanesWithNormalRoadAddress).flatten
@@ -161,11 +159,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
         && (roadPartRange contains roadLink.attributes("VIITE_ROAD_PART_NUMBER")) && roadLink.attributes("VIITE_TRACK") == params.track.value)
 
       val lanesOnRoadLinks = laneService.getLanesByRoadLinks(correctLinks)
-      val (lanesWithViiteAddress, lanesWithoutRoadAddress) = roadAddressService.laneWithRoadAddress(Seq(lanesOnRoadLinks))
-        .flatten.partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
-      val lanesWithTempAddress = roadAddressService.experimentalLaneWithRoadAddress(Seq(lanesWithoutRoadAddress)).flatten
-        .filter(_.attributes.contains("TEMP_ROAD_NUMBER"))
-      val lanesWithRoadAddress = lanesWithViiteAddress ++ lanesWithTempAddress
+      val lanesWithRoadAddress = laneService.getRoadAddressForLanes(lanesOnRoadLinks)
 
       val lanesWithNormalRoadAddress = lanesWithConsistentRoadAddress(lanesWithRoadAddress)
       val twoDigitLanes = laneService.pieceWiseLanesToTwoDigitWithMassQuery(lanesWithNormalRoadAddress).flatten

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -32,8 +32,8 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
 
   when(mockRoadLinkService.getRoadLinksFromVVH(any[Int])).thenReturn(Seq(roadLink))
   when(mockRoadAddressService.getAllByRoadNumber(any())).thenReturn(Seq(roadAddress))
-  when(mockRoadAddressService.laneWithRoadAddress(any())).thenReturn(Seq(Seq(pieceWiseLane)))
-  when(mockRoadAddressService.experimentalLaneWithRoadAddress(any())).thenReturn(Seq(Seq(pieceWiseLane)))
+  when(mockRoadAddressService.laneWithRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
+  when(mockRoadAddressService.experimentalLaneWithRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
 
   //Creates two road links geometrically next to each other
   def createRoadLinks(): Seq[RoadLink] = {

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -33,7 +33,7 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
   when(mockRoadLinkService.getRoadLinksFromVVH(any[Int])).thenReturn(Seq(roadLink))
   when(mockRoadAddressService.getAllByRoadNumber(any())).thenReturn(Seq(roadAddress))
   when(mockRoadAddressService.laneWithRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
-  when(mockRoadAddressService.LaneWithTempRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
+  when(mockRoadAddressService.laneWithTempRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
 
   //Creates two road links geometrically next to each other
   def createRoadLinks(): Seq[RoadLink] = {

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -33,7 +33,7 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
   when(mockRoadLinkService.getRoadLinksFromVVH(any[Int])).thenReturn(Seq(roadLink))
   when(mockRoadAddressService.getAllByRoadNumber(any())).thenReturn(Seq(roadAddress))
   when(mockRoadAddressService.laneWithRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
-  when(mockRoadAddressService.experimentalLaneWithRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
+  when(mockRoadAddressService.LaneWithTempRoadAddress(any())).thenReturn(Seq(pieceWiseLane))
 
   //Creates two road links geometrically next to each other
   def createRoadLinks(): Seq[RoadLink] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -179,16 +179,15 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
     * @param pieceWiseLanes The linear assets sequence
     * @return
     */
-  def laneWithRoadAddress(pieceWiseLanes: Seq[Seq[PieceWiseLane]]): Seq[Seq[PieceWiseLane]] = {
+  def laneWithRoadAddress(pieceWiseLanes: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
     try {
-      val addressData = groupRoadAddress(getAllByLinkIds(pieceWiseLanes.flatMap(pwl => pwl.map(_.linkId)))).map(a => (a.linkId, a)).toMap
-      pieceWiseLanes.map(
-        _.map(pwl =>
-          if (addressData.contains(pwl.linkId))
-            pwl.copy(attributes = pwl.attributes ++ roadAddressAttributes(addressData(pwl.linkId)))
-          else
-            pwl
-        ))
+      val addressData = groupRoadAddress(getAllByLinkIds(pieceWiseLanes.map(_.linkId))).map(a => (a.linkId, a)).toMap
+      pieceWiseLanes.map(pwl =>
+        if (addressData.contains(pwl.linkId))
+          pwl.copy(attributes = pwl.attributes ++ roadAddressAttributes(addressData(pwl.linkId)))
+        else
+          pwl
+      )
     } catch {
       case hhce: HttpHostConnectException =>
         logger.error(s"Viite connection failing with message ${hhce.getMessage}")
@@ -267,18 +266,17 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
   }
 
 
-  def experimentalLaneWithRoadAddress(pieceWiseLanes: Seq[Seq[PieceWiseLane]]): Seq[Seq[PieceWiseLane]] = {
+  def experimentalLaneWithRoadAddress(pieceWiseLanes: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
     if (pieceWiseLanes.nonEmpty) {
       try {
-        val addressData = withDynTransaction(roadLinkTempDao.getByLinkIds(pieceWiseLanes.head.map(_.linkId).toSet)).map(a => (a.linkId, a)).toMap
+        val addressData = withDynTransaction(roadLinkTempDao.getByLinkIds(pieceWiseLanes.map(_.linkId).toSet)).map(a => (a.linkId, a)).toMap
 
-        pieceWiseLanes.map(
-          _.map(pwa =>
-            if (addressData.contains(pwa.linkId))
-              pwa.copy(attributes = pwa.attributes ++ roadAddressAttributesTemp(addressData(pwa.linkId)))
-            else
-              pwa
-          ))
+        pieceWiseLanes.map(pwa =>
+          if (addressData.contains(pwa.linkId))
+            pwa.copy(attributes = pwa.attributes ++ roadAddressAttributesTemp(addressData(pwa.linkId)))
+          else
+            pwa
+        )
       } catch {
         case hhce: HttpHostConnectException =>
           logger.error(s"Viite connection failing with message ${hhce.getMessage}")
@@ -287,7 +285,7 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
           logger.error(s"Viite error with message ${vce.getMessage}")
           pieceWiseLanes
       }
-    }else{
+    } else {
       pieceWiseLanes
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -266,7 +266,7 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
   }
 
 
-  def experimentalLaneWithRoadAddress(pieceWiseLanes: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
+  def LaneWithTempRoadAddress(pieceWiseLanes: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
     if (pieceWiseLanes.nonEmpty) {
       try {
         val addressData = withDynTransaction(roadLinkTempDao.getByLinkIds(pieceWiseLanes.map(_.linkId).toSet)).map(a => (a.linkId, a)).toMap

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -266,7 +266,7 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
   }
 
 
-  def LaneWithTempRoadAddress(pieceWiseLanes: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
+  def laneWithTempRoadAddress(pieceWiseLanes: Seq[PieceWiseLane]): Seq[PieceWiseLane] = {
     if (pieceWiseLanes.nonEmpty) {
       try {
         val addressData = withDynTransaction(roadLinkTempDao.getByLinkIds(pieceWiseLanes.map(_.linkId).toSet)).map(a => (a.linkId, a)).toMap

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -522,7 +522,7 @@ trait LaneOperations {
       roadAddressService.laneWithRoadAddress(lanes).partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
     }
     val frozenInfo = LogUtils.time(logger, "TEST LOG Get temp road address for lanes ") {
-      roadAddressService.LaneWithTempRoadAddress(lanesMissingUpdatedInfo)
+      roadAddressService.laneWithTempRoadAddress(lanesMissingUpdatedInfo)
     }
     (lanesWithUpdatedInfo ++ frozenInfo)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -522,9 +522,9 @@ trait LaneOperations {
       roadAddressService.laneWithRoadAddress(lanes).partition(_.attributes.contains("VIITE_ROAD_NUMBER"))
     }
     val frozenInfo = LogUtils.time(logger, "TEST LOG Get temp road address for lanes ") {
-      roadAddressService.experimentalLaneWithRoadAddress(lanesMissingUpdatedInfo)
+      roadAddressService.LaneWithTempRoadAddress(lanesMissingUpdatedInfo)
     }
-    (lanesWithUpdatedInfo ++ frozenInfo).distinct
+    (lanesWithUpdatedInfo ++ frozenInfo)
   }
 
   def laneChangesToTwoDigitLaneCode(laneChanges: Seq[LaneChange], roadLinks: Seq[RoadLink]): Seq[LaneChange] = {


### PR DESCRIPTION
Korjattu bugi TEMP osoitetiedon haussa, keskitetty tieosoitteiden haku kaistoille yhteen funktioon toistamisen sijaan. Tieosoitteiden haussa oli jäänne ajalta, jolloin osoitteet haettiin Partition jälkeen muodossa Seq[Seq[PieceWiseLane]]. Muutettu Seq[PieceWiseLane], niin ei tarvi turhia kikkailuja tehdä .map ja .flatten kanssa. 