### PR TITLE
DROTH-3307 Removed .toInt conversion

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -818,7 +818,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
           lastModifiedBy(trafficSign.createdBy, trafficSign.modifiedBy),
           "linkSource" -> trafficSign.linkSource.value,
           "type" -> Try(TrafficSignType.applyOTHValue(trafficSignService.getProperty(trafficSign, "trafficSigns_type").get.propertyValue.toInt).NewLawCode).getOrElse(""),
-          "oldTrafficCode" -> Try(showOldTrafficCode(trafficSign).toInt).getOrElse(""),
+          "oldTrafficCode" -> showOldTrafficCode(trafficSign),
           "value" -> trafficSignService.getProperty(trafficSign, "trafficSigns_value").map(_.propertyDisplayValue.getOrElse("")),
           "additionalInformation" -> trafficSignService.getProperty(trafficSign, "trafficSigns_info").map(_.propertyDisplayValue.getOrElse("")),
           "municipalityId" -> trafficSignService.getProperty(trafficSign, "municipality_id").map(_.propertyDisplayValue.getOrElse("")),


### PR DESCRIPTION
Poistettu https://extranet.vayla.fi/jira/browse/DROTH-3337 tiketissä lisätty Int konversio. Vanhan lain mukainen koodi voi sisältää myös kirjaimia esim. uuden koodin merkki 'F31':n vanha koodi on '665 a'