### PR TITLE
DROTH-3361 rollback change to clear-db.sql

### DIFF
--- a/digiroad2-oracle/src/main/resources/clear-db.sql
+++ b/digiroad2-oracle/src/main/resources/clear-db.sql
@@ -65,6 +65,7 @@ drop table if exists service_user cascade;
 drop table if exists single_choice_value cascade;
 drop table if exists single_choice_value_history cascade;
 drop table if exists temporary_id cascade;
+drop table if exists temp_road_address_info cascade;
 drop table if exists terminal_bus_stop_link cascade;
 drop table if exists text_property_value cascade;
 drop table if exists text_property_value_history cascade;


### PR DESCRIPTION
Lisätään clear-db.sql takaisin temp_road_address_info droppaaminen. Buildi ei mennyt läpi kun yritti luoda testejä varten taulun vaikka se oli vielä olemassa