### PR TITLE
Droth 3121 fix some error remove unneeded client

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -275,7 +275,7 @@ object Digiroad2Context {
   }
 
   lazy val speedLimitService: SpeedLimitService = {
-    new SpeedLimitService(eventbus, roadLinkClient, roadLinkService)
+    new SpeedLimitService(eventbus, roadLinkService)
   }
 
   lazy val userProvider: UserProvider = {

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -299,7 +299,7 @@ object Digiroad2Context {
   }
 
   lazy val linearAssetDao: PostGISLinearAssetDao = {
-    new PostGISLinearAssetDao(roadLinkClient, roadLinkService)
+    new PostGISLinearAssetDao()
   }
 
   lazy val roadLinkService: RoadLinkService = {

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -3,8 +3,8 @@ package fi.liikennevirasto.digiroad2
 import java.util.Properties
 import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, ActorSystem, Props}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.pointasset.PostGISPointMassLimitationDao
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MassTransitStopDao, MunicipalityDao}
@@ -27,6 +27,7 @@ import fi.liikennevirasto.digiroad2.util.Digiroad2Properties
 import fi.liikennevirasto.digiroad2.vallu.ValluSender
 import org.apache.http.impl.client.HttpClientBuilder
 import org.slf4j.LoggerFactory
+
 import scala.concurrent.duration.FiniteDuration
 
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -7,7 +7,7 @@ import fi.liikennevirasto.digiroad2.Digiroad2Context.municipalityProvider
 import fi.liikennevirasto.digiroad2.asset.DateParser._
 import fi.liikennevirasto.digiroad2.asset.{PointAssetValue, HeightLimit => HeightLimitInfo, WidthLimit => WidthLimitInfo, _}
 import fi.liikennevirasto.digiroad2.authentication.{JWTAuthentication, UnauthenticatedException, UserNotFoundException}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{IncomingServicePoint, ServicePoint}
 import fi.liikennevirasto.digiroad2.dao.{MapViewZoom, MunicipalityDao}
 import fi.liikennevirasto.digiroad2.lane._

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/MunicipalityApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/MunicipalityApi.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.AwsDao
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
@@ -150,7 +150,7 @@ class Digiroad2ApiSpec extends AuthenticatedApiSpec with BeforeAndAfter {
   val testObstacleService = new ObstacleService(mockRoadLinkService)
   val testRailwayCrossingService = new RailwayCrossingService(mockRoadLinkService)
   val testDirectionalTrafficSignService = new DirectionalTrafficSignService(mockRoadLinkService)
-  val testSpeedLimitProvider = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService)
+  val testSpeedLimitProvider = new SpeedLimitService(new DummyEventBus, mockRoadLinkService)
   val testMassTransitStopService: MassTransitStopService = new MassTransitStopService {
     override def eventbus: DigiroadEventBus = new DummyEventBus
     override def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
@@ -2,7 +2,8 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.authentication.SessionApi
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.vvh.VVHChangeInfoClient
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MassTransitStopDao, MunicipalityDao, RoadLinkDAO}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/Digiroad2ApiSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.authentication.SessionApi
-import fi.liikennevirasto.digiroad2.client.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.client.vvh.VVHChangeInfoClient
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MassTransitStopDao, MunicipalityDao, RoadLinkDAO}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiRequestSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiRequestSpec.scala
@@ -1,5 +1,5 @@
 package fi.liikennevirasto.digiroad2
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.AwsDao
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.SpeedLimitService

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiSpec.scala
@@ -43,7 +43,7 @@ class MunicipalityApiSpec extends FunSuite with Matchers with BeforeAndAfter {
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val obstacleService = new ObstacleService(mockRoadLinkService)
-  val speedLimitService = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService)
+  val speedLimitService = new SpeedLimitService(new DummyEventBus, mockRoadLinkService)
   val pavedRoadService = new PavedRoadService(mockRoadLinkService, new DummyEventBus)
 
   protected implicit val jsonFormats: Formats = DefaultFormats

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiSpec.scala
@@ -1,15 +1,15 @@
 package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.FeatureClass.AllOthers
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.AwsDao
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, _}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset._
 import fi.liikennevirasto.digiroad2.service.pointasset.{HeightLimit => _, WidthLimit => _, _}
-import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator, LinearAssetUtils}
+import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, LinkIdGenerator}
+
 import javax.sql.DataSource
 import org.json4s.{DefaultFormats, Formats}
 import org.mockito.ArgumentMatchers._

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/MunicipalityApiSpec.scala
@@ -1,7 +1,8 @@
 package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.AwsDao
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, _}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -4,7 +4,7 @@ import java.io.{ByteArrayInputStream, InputStream}
 import fi.liikennevirasto.digiroad2.Digiroad2Context.userProvider
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.csvDataImporter.{LanesCsvImporter, RoadLinkCsvImporter, TrafficLightsCsvImporter, TrafficSignCsvImporter}
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, RoadLinkOverrideDAO}
 import fi.liikennevirasto.digiroad2.lane.{LaneRoadAddressInfo, NewLane}

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -4,7 +4,8 @@ import java.io.{ByteArrayInputStream, InputStream}
 import fi.liikennevirasto.digiroad2.Digiroad2Context.userProvider
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.VVHComplementaryClient
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.csvDataImporter.{LanesCsvImporter, RoadLinkCsvImporter, TrafficLightsCsvImporter, TrafficSignCsvImporter}
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, RoadLinkOverrideDAO}
 import fi.liikennevirasto.digiroad2.lane.{LaneRoadAddressInfo, NewLane}

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -23,7 +23,7 @@ import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2.{AssetProperty, DigiroadEventBus, ExcludedRow, FloatingReason, GeometryUtils, IncompleteRow, MalformedRow, Point, Status}
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, FloatingAsset, Position, PropertyValue, TrafficDirection, Unknown}
-import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, MassTransitStopDao, MunicipalityDao, RoadLinkDAO}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -23,7 +23,7 @@ import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2.{AssetProperty, DigiroadEventBus, ExcludedRow, FloatingReason, GeometryUtils, IncompleteRow, MalformedRow, Point, Status}
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, FloatingAsset, Position, PropertyValue, TrafficDirection, Unknown}
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, MassTransitStopDao, MunicipalityDao, RoadLinkDAO}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/CsvDataImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/CsvDataImporter.scala
@@ -1,13 +1,13 @@
 package fi.liikennevirasto.digiroad2
 
 import java.util.Properties
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}
 import org.apache.http.impl.client.HttpClientBuilder
 import org.joda.time.DateTime
 import fi.liikennevirasto.digiroad2.asset.ServicePointsClass.{Unknown => _, _}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
 import fi.liikennevirasto.digiroad2.util.Digiroad2Properties
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/RoadLinkClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/RoadLinkClient.scala
@@ -1,0 +1,98 @@
+package fi.liikennevirasto.digiroad2.client
+
+import com.vividsolutions.jts.geom.Polygon
+import fi.liikennevirasto.digiroad2.Point
+import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, ConstructionType, LinkGeomSource, TrafficDirection}
+import fi.liikennevirasto.digiroad2.client.kgv.RoadLinkHistoryClient
+import fi.liikennevirasto.digiroad2.client.vvh.{OldVVHRoadLinkClient, VVHChangeInfoClient, VVHComplementaryClient, VVHFrozenTimeRoadLinkClientServicePoint}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLinkLike
+import org.joda.time.DateTime
+
+sealed trait FeatureClass
+object FeatureClass {
+  case object TractorRoad extends FeatureClass
+  case object DrivePath extends FeatureClass
+  case object CycleOrPedestrianPath extends FeatureClass
+  case object WinterRoads extends FeatureClass
+  case object SpecialTransportWithoutGate extends FeatureClass
+  case object SpecialTransportWithGate extends FeatureClass
+  case object CarRoad_IIIa extends FeatureClass
+  case object CarRoad_IIIb extends FeatureClass
+  case object AllOthers extends FeatureClass
+}
+
+
+sealed trait IRoadLinkFetched extends RoadLinkLike {
+  def featureClass: FeatureClass
+  def modifiedAt: Option[DateTime]
+}
+
+case class RoadLinkFetched(linkId: String, municipalityCode: Int, geometry: Seq[Point],
+                           administrativeClass: AdministrativeClass, trafficDirection: TrafficDirection,
+                           featureClass: FeatureClass, modifiedAt: Option[DateTime] = None, attributes: Map[String, Any] = Map(),
+                           constructionType: ConstructionType = ConstructionType.InUse, linkSource: LinkGeomSource = LinkGeomSource.NormalLinkInterface, length: Double = 0.0) extends IRoadLinkFetched {
+  def roadNumber: Option[String] = attributes.get("ROADNUMBER").map(_.toString)
+  def verticalLevel: Option[String] = attributes.get("VERTICALLEVEL").map(_.toString)
+  val timeStamp = attributes.getOrElse("LAST_EDITED_DATE", attributes.getOrElse("CREATED_DATE", BigInt(0))).asInstanceOf[BigInt].longValue()
+}
+
+
+case class HistoryRoadLink(linkId: String, municipalityCode: Int, geometry: Seq[Point], administrativeClass: AdministrativeClass,
+                           trafficDirection: TrafficDirection, featureClass: FeatureClass, modifiedAt: Option[DateTime] = None, createdDate:BigInt = 0, endDate: BigInt = 0, attributes: Map[String, Any] = Map(),kmtkid:String="",version:Int=0,
+                           constructionType: ConstructionType = ConstructionType.InUse, linkSource: LinkGeomSource = LinkGeomSource.NormalLinkInterface, length: Double = 0.0) extends IRoadLinkFetched {
+  def roadNumber: Option[String] = attributes.get("ROADNUMBER").map(_.toString)
+  val timeStamp: Long = attributes.getOrElse("LAST_EDITED_DATE", createdDate).asInstanceOf[BigInt].longValue()
+}
+
+case class LinkOperationError(content: String, statusCode:String, url:String ="") extends Exception(s"Content: ${content}, Status code: ${statusCode}, ${url} ")
+class ClientException(response: String) extends RuntimeException(response)
+
+trait Filter {
+  def withFilter[T](attributeName: String, ids: Set[T]): String = ???
+
+  def withMunicipalityFilter(municipalities: Set[Int]): String = ???
+
+  def withRoadNameFilter[T](attributeName: String, names: Set[T]): String = ???
+
+  def combineFiltersWithAnd(filter1: String, filter2: String): String = ???
+
+  def combineFiltersWithAnd(filter1: String, filter2: Option[String]): String = ???
+
+  def withOldkmtkidFilter(linkIds: Set[String]): String = ???
+  /**
+    *
+    * @param polygon to be converted to string
+    * @return string compatible with VVH polygon query
+    */
+  def stringifyPolygonGeometry(polygon: Polygon): String = ???
+
+  // Query filters methods
+  def withLinkIdFilter[T](linkIds: Set[T]): String = ???
+
+  def withFinNameFilter(roadNameSource: String)(roadNames: Set[String]): String = ???
+
+  def withMmlIdFilter(mmlIds: Set[Long]): String = ???
+
+  def withMtkClassFilter(ids: Set[Long]): String = ???
+
+  def withLastEditedDateFilter(lowerDate: DateTime, higherDate: DateTime): String = ???
+
+  def withDateLimitFilter(attributeName: String, lowerDate: DateTime, higherDate: DateTime): String = ???
+
+}
+
+class RoadLinkClient(vvhRestApiEndPoint: String) {
+  lazy val roadLinkData: OldVVHRoadLinkClient = new OldVVHRoadLinkClient(vvhRestApiEndPoint)
+  lazy val frozenTimeRoadLinkData: VVHFrozenTimeRoadLinkClientServicePoint = new VVHFrozenTimeRoadLinkClientServicePoint(vvhRestApiEndPoint)
+  lazy val roadLinkChangeInfo: VVHChangeInfoClient = new VVHChangeInfoClient(vvhRestApiEndPoint)
+  lazy val complementaryData: VVHComplementaryClient = new VVHComplementaryClient(vvhRestApiEndPoint)
+  lazy val historyData: RoadLinkHistoryClient = new RoadLinkHistoryClient()
+
+  def fetchRoadLinkByLinkId(linkId: String): Option[RoadLinkFetched] = {
+    roadLinkData.fetchByLinkId(linkId) match {
+      case Some(vvhRoadLink) => Some(vvhRoadLink)
+      case None => complementaryData.fetchByLinkId(linkId)
+    }
+  }
+  
+}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -1,0 +1,200 @@
+package fi.liikennevirasto.digiroad2.client.kgv
+
+import com.vividsolutions.jts.geom.Polygon
+import fi.liikennevirasto.digiroad2.Point
+import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource}
+import fi.liikennevirasto.digiroad2.client.{ClientException, FeatureClass, Filter, HistoryRoadLink, IRoadLinkFetched, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.util.Digiroad2Properties
+import org.joda.time.DateTime
+import org.json4s.{DefaultFormats, Formats}
+import org.slf4j.LoggerFactory
+
+import java.math.BigInteger
+import scala.concurrent.Future
+import scala.util.Try
+import scala.concurrent.ExecutionContext.Implicits.global
+
+case class ChangeKgv( id: Int, oldKmtkId: String, oldVersion: Int, newKmtkId: String,
+                      newVersion: Int, `type`: String, ruleId: String, cTime: DateTime,
+                      mFromOld: String, mToOld: Int, mFromNew: Int, mToNew: Int,
+                      taskId: String)
+
+trait LinkOperationsAbstract {
+  type LinkType
+  type Content
+  protected val linkGeomSource: LinkGeomSource
+  protected def restApiEndPoint: String
+  protected def serviceName: String
+
+  protected implicit val jsonFormats: Formats = DefaultFormats
+
+  lazy val logger = LoggerFactory.getLogger(getClass)
+
+  protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int],
+                                               filter: Option[String]): Seq[LinkType] = ???
+
+  protected def queryByMunicipality(municipality: Int, filter: Option[String] = None): Seq[LinkType] = ???
+
+  protected def queryByPolygons(polygon: Polygon): Seq[LinkType] = ???
+
+  protected def queryLinksIdByPolygons(polygon: Polygon): Seq[String] = ???
+
+  protected def queryByLinkIds[LinkType](linkIds: Set[String], filter: Option[String] = None): Seq[LinkType] = ???
+  protected def queryByIds[LinkType](idSet: Set[String],filter:(Set[String])=>String): Seq[LinkType] = ???
+  protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int]): Seq[LinkType] = {
+    queryByMunicipalitiesAndBounds(bounds, municipalities, None)
+  }
+}
+
+class KgvRoadLinkClient(collection: Option[KgvCollection] = None,linkGeomSourceValue:Option[LinkGeomSource] = None) extends KgvRoadLinkClientBase {
+  override type LinkType = RoadLinkFetched
+}
+
+class KgvRoadLinkClientBase(collection: Option[KgvCollection] = None, linkGeomSourceValue:Option[LinkGeomSource] = None, extractor:ExtractorBase = new Extractor) extends KgvOperation(extractor) {
+
+  override type LinkType
+  override def restApiEndPoint: String = Digiroad2Properties.kgvEndpoint
+  protected val serviceName:String = collection.getOrElse(throw new ClientException("Collection is not defined") ).value
+  protected val linkGeomSource: LinkGeomSource = linkGeomSourceValue.getOrElse(throw new ClientException("LinkGeomSource is not defined") )
+  val filter:Filter = FilterOgc
+
+  def fetchByMunicipality(municipality: Int): Seq[LinkType] = {
+    queryByMunicipality(municipality)
+  }
+
+  def fetchByMunicipalityF(municipality: Int): Future[Seq[LinkType]] = {
+    Future(queryByMunicipality(municipality))
+  }
+
+  def fetchByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int]): Seq[LinkType] = {
+    queryByMunicipalitiesAndBounds(bounds, municipalities)
+  }
+
+  def fetchByBounds(bounds: BoundingRectangle): Seq[LinkType] = {
+    queryByMunicipalitiesAndBounds(bounds, Set[Int]())
+  }
+
+  def fetchByMunicipalitiesAndBoundsF(bounds: BoundingRectangle, municipalities: Set[Int]): Future[Seq[LinkType]] = {
+    Future(queryByMunicipalitiesAndBounds(bounds, municipalities))
+  }
+
+  def fetchByLinkId(linkId: String): Option[LinkType] = fetchByLinkIds(Set(linkId)).headOption
+
+  def fetchByLinkIds(linkIds: Set[String]): Seq[LinkType] = {
+    queryByLinkIds[LinkType](linkIds)
+  }
+
+  def fetchByLinkIdsF(linkIds: Set[String]) = Future(fetchByLinkIds(linkIds))
+
+  def fetchVVHRoadlinks[LinkType](linkIds: Set[String]): Seq[LinkType] =
+    queryByLinkIds[LinkType](linkIds)
+
+  def fetchByChangesDates(lowerDate: DateTime, higherDate: DateTime): Seq[LinkType] = {
+    queryByLastEditedDate(lowerDate,higherDate)
+  }
+
+  def fetchByDatetime(lowerDate: DateTime, higherDate: DateTime): Seq[LinkType] = {
+    queryByDatetimeAndFilter(lowerDate,higherDate)
+  }
+
+  def fetchByPolygonF(polygon : Polygon): Future[Seq[LinkType]] = {
+    Future(queryByPolygons(polygon))
+  }
+
+  def fetchLinkIdsByPolygonF(polygon : Polygon): Future[Seq[String]] = {
+    Future(queryLinksIdByPolygons(polygon))
+  }
+  def fetchWalkwaysByBoundsAndMunicipalitiesF(bounds: BoundingRectangle, municipalities: Set[Int]): Future[Seq[LinkType]] = {
+    Future(queryByMunicipalitiesAndBounds(bounds, municipalities, Some(filter.withMtkClassFilter(Set(12314)))))
+  }
+
+  def fetchWalkwaysByMunicipalitiesF(municipality: Int): Future[Seq[LinkType]] =
+    Future(queryByMunicipality(municipality, Some(filter.withMtkClassFilter(Set(12314)))))
+
+  def fetchByMmlIds(toSet: Set[Long]): Seq[LinkType] = queryByFilter(Some(filter.withMmlIdFilter(toSet)))
+
+  def fetchByMmlId(mmlId: Long) : Option[LinkType]= fetchByMmlIds(Set(mmlId)).headOption
+}
+
+class ExtractHistory extends ExtractorBase {
+
+  override type LinkType = HistoryRoadLink
+
+  override def extractFeature(feature: Feature, path: List[List[Double]], linkGeomSource: LinkGeomSource): LinkType  = {
+    val attributes = feature.properties
+    val lastEditedDate = Option(BigInteger.valueOf(new DateTime(attributes("versionstarttime").asInstanceOf[String]).getMillis))
+    val startTime = Option(BigInteger.valueOf(new DateTime(attributes("starttime").asInstanceOf[String]).getMillis))
+    val linkGeometry: Seq[Point] = path.map(point => {
+      Point(anyToDouble(point(0)).get, anyToDouble(point(1)).get, anyToDouble(point(2)).get)
+    })
+    val linkGeometryForApi = Map("points" -> path.map(point => Map("x" -> anyToDouble(point(0)).get, "y" -> anyToDouble(point(1)).get, "z" -> anyToDouble(point(2)).get, "m" -> anyToDouble(point(3)).get)))
+    val linkGeometryWKTForApi = Map("geometryWKT" -> (s"LINESTRING ZM (${path.map(point => anyToDouble(point(0)).get + " " + anyToDouble(point(1)).get + " " + anyToDouble(point(2)).get + " " + anyToDouble(point(3)).get).mkString(", ")})"))
+
+    val linkId = attributes("id").asInstanceOf[String]
+    val municipalityCode = attributes("municipalitycode").asInstanceOf[String].toInt
+    val roadClassCode = attributes("roadclass").asInstanceOf[String].toInt
+    val roadClass = featureClassCodeToFeatureClass.getOrElse(roadClassCode, FeatureClass.AllOthers)
+
+    val kmtkId = linkId.split(":")(0)
+    val version = linkId.split(":")(1).toInt
+
+    HistoryRoadLink(linkId, municipalityCode, linkGeometry, extractAdministrativeClass(attributes),
+      extractTrafficDirection(attributes), roadClass, createdDate = startTime.get,
+      attributes = extractAttributes(attributes,lastEditedDate.get,startTime.get)
+        ++ linkGeometryForApi ++ linkGeometryWKTForApi, kmtkid = kmtkId, version = version)
+  }
+}
+class ExtractKgvChange extends ExtractorBase {
+  override type LinkType = ChangeKgv
+
+  override def extractFeature(feature: Feature, path: List[List[Double]], linkGeomSource: LinkGeomSource): LinkType  = {
+    val attributes = feature.properties
+
+    ChangeKgv(
+      attributes("id").toString.toInt,
+      attributes("oldkmtkid").toString,
+      attributes("oldversion").toString.toInt,
+      attributes("newkmtkid").toString,
+      attributes("newversion").toString.toInt,
+      attributes("type").toString,
+      attributes("ruleid").toString,
+      new DateTime(attributes("ctime").asInstanceOf[String]),
+      attributes("mfromold").toString,
+      attributes("mtoold").toString.toInt,
+      attributes("mfromnew").toString.toInt,
+      attributes("mtonew").toString.toInt,
+      attributes("taskid").toString)
+  }
+}
+class RoadLinkHistoryClient(serviceName:KgvCollection = KgvCollection.LinkVersios, linkGeomSource:LinkGeomSource=LinkGeomSource.HistoryLinkInterface)
+  extends KgvRoadLinkClientBase(Some(serviceName),Some(linkGeomSource),extractor = new ExtractHistory) {
+
+  override type LinkType = HistoryRoadLink
+
+  private def enrichWithChangeInfo(response: Seq[HistoryRoadLink]): Seq[HistoryRoadLink] = {
+    val changesLinkInfo = new RoadLinkChangeKGvClient().fetchByOldKmtkId(response.map(_.kmtkid).toSet)
+    response.map(r => {
+      val newId = Try {
+        val link = changesLinkInfo.find(f => r.kmtkid == f.oldKmtkId && r.version == f.oldVersion).get
+        s"${link.oldKmtkId}:${link.oldVersion}"
+      }.getOrElse(None)
+      r.copy(attributes = r.attributes ++ Map("LINKID_NEW" -> newId))
+    })
+  }
+
+  override protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int]): Seq[LinkType] = {
+    val response = queryByMunicipalitiesAndBounds(bounds, municipalities, None)
+    enrichWithChangeInfo(response)
+  }
+
+}
+
+class RoadLinkChangeKGvClient(serviceName:KgvCollection = KgvCollection.Changes, linkGeomSource:LinkGeomSource=LinkGeomSource.Unknown)
+  extends KgvRoadLinkClientBase(Some(serviceName),Some(linkGeomSource),extractor = new ExtractKgvChange) {
+
+  override type LinkType = ChangeKgv
+
+  def fetchByOldKmtkId(ids: Set[String]): Seq[LinkType] = {
+    queryByIds(ids,filter.withOldkmtkidFilter).asInstanceOf[Seq[LinkType]]
+  }
+}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
@@ -1,8 +1,9 @@
-package fi.liikennevirasto.digiroad2.client.vvh
+package fi.liikennevirasto.digiroad2.client.kgv
 
 import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.{ClientException, FeatureClass, Filter, LinkOperationError, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.util.{Digiroad2Properties, KgvUtil, LogUtils, Parallel}
 import org.apache.http.HttpStatus
 import org.apache.http.client.config.{CookieSpecs, RequestConfig}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MaintenanceRoadCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MaintenanceRoadCsvImporter.scala
@@ -1,11 +1,10 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import java.io.{InputStream, InputStreamReader}
-
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2.{AssetProperty, CsvDataImporterOperations, DigiroadEventBus, ExcludedRow, ImportResult, IncompleteRow, MalformedRow, Status}
 import fi.liikennevirasto.digiroad2.asset.{DynamicProperty, DynamicPropertyValue, MaintenanceRoadAsset, SideCode}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.linearasset.{DynamicAssetValue, DynamicValue}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
@@ -4,7 +4,7 @@ import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{ImportLogDAO, MassTransitStopDao, MunicipalityDao}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import fi.liikennevirasto.digiroad2.asset.{PropertyValue, SimplePointAssetProperty, State}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PedestrianCrossingCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PedestrianCrossingCsvImporter.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import fi.liikennevirasto.digiroad2.asset.State
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/RailwayCrossingCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/RailwayCrossingCsvImporter.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import fi.liikennevirasto.digiroad2.asset.{PropertyValue, SimplePointAssetProperty, State}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/RoadLinkCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/RoadLinkCsvImporter.scala
@@ -5,7 +5,7 @@ import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2.{AssetProperty, CsvDataImporterOperations, DigiroadEventBus, ExcludedRow, ImportResult, IncompleteRow, MalformedRow, Status}
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, State}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ServicePointCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ServicePointCsvImporter.scala
@@ -4,7 +4,7 @@ import java.text.Normalizer
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset.{ServicePointsClass, State}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{IncomingService, IncomingServicePoint}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficLightsCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficLightsCsvImporter.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import fi.liikennevirasto.digiroad2.asset.{PointAssetState, PointAssetStructure, SimplePointAssetProperty, State}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.TrafficLight
 import fi.liikennevirasto.digiroad2.lane.LaneType
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -5,7 +5,7 @@ import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2.TrafficSignTypeGroup.AdditionalPanels
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.lane.LaneType
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
@@ -6,7 +6,7 @@ import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.ComplimentaryLinkInterface
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, ConstructionType}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.util.LogUtils
 import org.joda.time.DateTime

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadAddressDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadAddressDAO.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.dao
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.SideCode
 import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, TowardsDigitizing}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.util.Track
 import org.joda.time.DateTime
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -5,7 +5,7 @@ import Database.dynamicSession
 import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, BoundingRectangle, ConstructionType, LinkGeomSource, TrafficDirection}
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.withDbConnection
 import fi.liikennevirasto.digiroad2.util.{KgvUtil, LogUtils}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkOverrideDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkOverrideDAO.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.dao
 
 import fi.liikennevirasto.digiroad2.asset
 import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.postgis.{MassQuery, PostGISDatabase}
 import fi.liikennevirasto.digiroad2.service.{LinkProperties, LinkPropertiesEntries}
 import slick.driver.JdbcDriver.backend.Database.dynamicSession

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneDao.scala
@@ -1,10 +1,8 @@
 package fi.liikennevirasto.digiroad2.dao.lane
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.lane._
 import fi.liikennevirasto.digiroad2.postgis.MassQuery
-import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.asset.DateParser.DateTimeSimplifiedFormat
@@ -27,7 +25,7 @@ case class LanePropertyRow(publicId: String, propertyValue: Option[Any])
 case class NewLaneWithIds(laneId: Long, positionId: Long, lane: PersistedLane)
 
 
-class LaneDao(val roadLinkClient: RoadLinkClient, val roadLinkService: RoadLinkService ){
+class LaneDao(){
 
   implicit val getLightLane = new GetResult[LightLane] {
     def apply(r: PositionedResult) = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneHistoryDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneHistoryDao.scala
@@ -1,7 +1,5 @@
 package fi.liikennevirasto.digiroad2.dao.lane
 
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
-import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.asset.DateParser.DateTimeSimplifiedFormat
@@ -22,7 +20,7 @@ case class LaneHistoryRow(id: Long, newId: Long, oldId: Long, linkId: String, si
                           historyCreatedDate: DateTime, historyCreatedBy: String)
 case class laneToHistoryLane(oldId: Long, historyId: Long, historyPositionId: Long)
 
-class LaneHistoryDao(val roadLinkClient: RoadLinkClient, val roadLinkService: RoadLinkService) {
+class LaneHistoryDao() {
 
   implicit val getLaneHistoryAsset: GetResult[LaneHistoryRow] = new GetResult[LaneHistoryRow] {
     def apply(r: PositionedResult): LaneHistoryRow = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
@@ -29,7 +29,7 @@ case class AssetLastModification(id: Long, linkId: String, modifiedBy: Option[St
 case class AssetLink(id: Long, linkId: String)
 
 
-class PostGISLinearAssetDao(val roadLinkClient: RoadLinkClient, val roadLinkService: RoadLinkService ) {
+class PostGISLinearAssetDao() {
   implicit def bool2int(b:Boolean) = if (b) 1 else 0
   val logger: Logger = LoggerFactory.getLogger(getClass)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
@@ -8,7 +8,6 @@ import org.joda.time.DateTime
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.Queries.{insertMultipleChoiceValue, multipleChoicePropertyValuesByAssetIdAndPropertyId}
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISMaintenanceDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISMaintenanceDao.scala
@@ -15,7 +15,7 @@ import fi.liikennevirasto.digiroad2.service.linearasset.Measures
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
 import slick.jdbc.StaticQuery.interpolation
 
-class PostGISMaintenanceDao(val roadLinkClient: RoadLinkClient, val roadLinkService: RoadLinkService) {
+class PostGISMaintenanceDao() {
 
   def fetchPotentialServiceRoads(includeFloating: Boolean = false, includeExpire: Boolean = false ): Seq[PersistedLinearAsset] = {
     val floatingFilter = if (includeFloating) "" else " and a.floating = '0'"

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISMaintenanceDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISMaintenanceDao.scala
@@ -7,7 +7,6 @@ import org.joda.time.DateTime
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.Queries.DynamicPropertyRow
 import fi.liikennevirasto.digiroad2.dao.{DynamicAssetRow, Queries, Sequences}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -10,7 +10,6 @@ import org.joda.time.DateTime
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import com.github.tototoshi.slick.MySQLJodaSupport._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -18,7 +18,7 @@ import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
 import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
 
-class PostGISSpeedLimitDao(val roadLinkClient: RoadLinkClient, val roadLinkService: RoadLinkService) {
+class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) {
   def MassQueryThreshold = 500
   case class UnknownLimit(linkId: String, municipality: String, administrativeClass: String)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/manoeuvre/ManoeuvreDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/manoeuvre/ManoeuvreDAO.scala
@@ -16,7 +16,7 @@ import slick.jdbc.{StaticQuery => Q}
 case class PersistedManoeuvreRow(id: Long, linkId: String, destLinkId: String, elementType: Int, modifiedDate: Option[DateTime],
                                  modifiedBy: Option[String], additionalInfo: String, createdDate: DateTime, createdBy: String, isSuggested: Boolean)
 
-class ManoeuvreDao(val roadLinkClient: RoadLinkClient) {
+class ManoeuvreDao() {
 
   def find(id: Long): Option[Manoeuvre] = {
     val manoeuvresById = Map(id -> fetchManoeuvreById(id))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/manoeuvre/ManoeuvreDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/manoeuvre/ManoeuvreDAO.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.dao.linearasset.manoeuvre
 
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.asset.TrafficSigns
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.linearasset.{ValidityPeriod, ValidityPeriodDayOfWeek}
 import fi.liikennevirasto.digiroad2.postgis.MassQuery
 import fi.liikennevirasto.digiroad2.service.linearasset.{ElementTypes, Manoeuvre, ManoeuvreElement, NewManoeuvre}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/DataImportManager.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/DataImportManager.scala
@@ -4,7 +4,7 @@ import java.io.InputStream
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.csvDataImporter._
 import fi.liikennevirasto.digiroad2.user.User
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/TrafficSignManager.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/TrafficSignManager.scala
@@ -60,7 +60,7 @@ case class TrafficSignManager(manoeuvreService: ManoeuvreService, roadLinkServic
   protected implicit val jsonFormats: Formats = DefaultFormats + LinkGeomSourceSerializer + DateTimeSerializer
 
   lazy val linearAssetDao: PostGISLinearAssetDao = {
-    new PostGISLinearAssetDao(roadLinkService.roadLinkClient, roadLinkService)
+    new PostGISLinearAssetDao()
   }
   
   def createAssets(trafficSignInfo: TrafficSignInfo, newTransaction: Boolean = true ): Unit = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/process/AssetValidator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/process/AssetValidator.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.process
 import java.sql.SQLIntegrityConstraintViolationException
 import java.util.{NoSuchElementException, Properties}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, Queries}
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/process/HazmatTransportProhibitionValidator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/process/HazmatTransportProhibitionValidator.scala
@@ -12,7 +12,7 @@ class HazmatTransportProhibitionValidator extends AssetServiceValidatorOperation
   override def assetTypeInfo: AssetTypeInfo =  HazmatTransportProhibition
   override val radiusDistance: Int = 50
 
-  lazy val dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkClient, roadLinkService)
+  lazy val dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
 
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/process/ManoeuvreValidator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/process/ManoeuvreValidator.scala
@@ -18,7 +18,7 @@ class ManoeuvreValidator extends AssetServiceValidatorOperations {
 
   override def assetTypeInfo: AssetTypeInfo = Manoeuvres
 
-  lazy val manoeuvreDao: ManoeuvreDao = new ManoeuvreDao(roadLinkClient)
+  lazy val manoeuvreDao: ManoeuvreDao = new ManoeuvreDao()
 
   val allowedTrafficSign: Set[TrafficSignType] = Set(NoLeftTurn, NoRightTurn, NoUTurn)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -9,15 +9,15 @@ import com.vividsolutions.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.GeometryUtils._
 import fi.liikennevirasto.digiroad2.asset.DateParser._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, RoadLinkDAO, RoadLinkOverrideDAO}
-import fi.liikennevirasto.digiroad2.linearasset.{ RoadLink, RoadLinkProperties, TinyRoadLink}
+import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, RoadLinkProperties, TinyRoadLink}
 import fi.liikennevirasto.digiroad2.postgis.{MassQuery, PostGISDatabase}
 import fi.liikennevirasto.digiroad2.asset.CycleOrPedestrianPath
 import fi.liikennevirasto.digiroad2.user.User
 import fi.liikennevirasto.digiroad2.util._
 import fi.liikennevirasto.digiroad2._
-import fi.liikennevirasto.digiroad2.client.Caching
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
+import fi.liikennevirasto.digiroad2.client.{Caching, FeatureClass, HistoryRoadLink, IRoadLinkFetched, RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO.LinkAttributesDao
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.withDbConnection
 import fi.liikennevirasto.digiroad2.util.UpdateIncompleteLinkList.generateProperties

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.service.lane
 import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.{MassQueryParams, VKMClient}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
 import fi.liikennevirasto.digiroad2.dao.lane.{LaneDao, LaneHistoryDao}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, RoadAddressTEMP}
 import fi.liikennevirasto.digiroad2.lane.LaneFiller._
@@ -23,9 +23,8 @@ case class LaneChange(lane: PersistedLane, oldLane: Option[PersistedLane], chang
 
 class LaneService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus, roadAddressServiceImpl: RoadAddressService) extends LaneOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
-  override def dao: LaneDao = new LaneDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
-  override def historyDao: LaneHistoryDao = new LaneHistoryDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: LaneDao = new LaneDao()
+  override def historyDao: LaneHistoryDao = new LaneHistoryDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def polygonTools: PolygonTools = new PolygonTools()
@@ -39,7 +38,6 @@ trait LaneOperations {
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
   def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
   def roadLinkService: RoadLinkService
-  def roadLinkClient: RoadLinkClient
   def dao: LaneDao
   def historyDao: LaneHistoryDao
   def municipalityDao: MunicipalityDao

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
@@ -1,14 +1,13 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
-import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.dao._
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
-import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, SideCodeAdjustment}
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import org.joda.time.DateTime
 
 class DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetOperations {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.dao._
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
@@ -13,7 +13,7 @@ import org.joda.time.DateTime
 
 class DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
@@ -16,7 +16,6 @@ class DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusIm
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   def dynamicLinearAssetDao: DynamicLinearAssetDao = new DynamicLinearAssetDao

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/HazmatTransportProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/HazmatTransportProhibitionService.scala
@@ -15,7 +15,6 @@ class HazmatTransportProhibitionService(roadLinkServiceImpl: RoadLinkService, ev
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   def inaccurateDAO: InaccurateAssetDAO = new InaccurateAssetDAO

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/HazmatTransportProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/HazmatTransportProhibitionService.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/HazmatTransportProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/HazmatTransportProhibitionService.scala
@@ -12,7 +12,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class HazmatTransportProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -5,7 +5,7 @@ import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.pointasset.PostGISTrafficSignDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, MunicipalityInfo, PostGISAssetDao, Queries}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -49,7 +49,6 @@ trait LinearAssetOperations {
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
   def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
   def roadLinkService: RoadLinkService
-  def roadLinkClient: RoadLinkClient
   def dao: PostGISLinearAssetDao
   def municipalityDao: MunicipalityDao
   def eventBus: DigiroadEventBus
@@ -580,7 +579,6 @@ class LinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools : PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -577,7 +577,7 @@ trait LinearAssetOperations {
 
 class LinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAxleWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAxleWeightLimitService.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAxleWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAxleWeightLimitService.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearAxleWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAxleWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAxleWeightLimitService.scala
@@ -14,7 +14,6 @@ class LinearAxleWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBu
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearBogieWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearBogieWeightLimitService.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearBogieWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearBogieWeightLimitService.scala
@@ -12,7 +12,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearBogieWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearBogieWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearBogieWeightLimitService.scala
@@ -15,7 +15,6 @@ class LinearBogieWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventB
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   override def inaccurateDAO: InaccurateAssetDAO = new InaccurateAssetDAO

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearHeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearHeightLimitService.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearHeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearHeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearHeightLimitService.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearHeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearHeightLimitService.scala
@@ -14,7 +14,6 @@ class LinearHeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImp
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearLengthLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearLengthLimitService.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearLengthLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearLengthLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearLengthLimitService.scala
@@ -14,7 +14,6 @@ class LinearLengthLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImp
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearLengthLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearLengthLimitService.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsService.scala
@@ -28,7 +28,6 @@ case class LinearSevenRestrictionsService(roadLinkServiceImpl: RoadLinkService, 
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsService.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsService.scala
@@ -25,7 +25,7 @@ trait LinearSevenRestrictionsOperations extends LinearAssetOperations {
 
 case class LinearSevenRestrictionsService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearSevenRestrictionsOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTotalWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTotalWeightLimitService.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearTotalWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTotalWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTotalWeightLimitService.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTotalWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTotalWeightLimitService.scala
@@ -14,7 +14,6 @@ class LinearTotalWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventB
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTrailerTruckWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTrailerTruckWeightLimitService.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTrailerTruckWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTrailerTruckWeightLimitService.scala
@@ -14,7 +14,6 @@ class LinearTrailerTruckWeightLimitService(roadLinkServiceImpl: RoadLinkService,
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTrailerTruckWeightLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearTrailerTruckWeightLimitService.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearTrailerTruckWeightLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearWidthLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearWidthLimitService.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearWidthLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearWidthLimitService.scala
@@ -14,7 +14,6 @@ class LinearWidthLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearWidthLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearWidthLimitService.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
 
 class LinearWidthLimitService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISMaintenanceDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
@@ -17,7 +17,6 @@ class MaintenanceService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   def maintenanceDAO: PostGISMaintenanceDao = new PostGISMaintenanceDao()

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
@@ -20,7 +20,7 @@ class MaintenanceService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
-  def maintenanceDAO: PostGISMaintenanceDao = new PostGISMaintenanceDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  def maintenanceDAO: PostGISMaintenanceDao = new PostGISMaintenanceDao()
   override def getInaccurateRecords(typeId: Int, municipalities: Set[Int] = Set(), adminClass: Set[AdministrativeClass] = Set()) = throw new UnsupportedOperationException("Not supported method")
 
   override def getByBoundingBox(typeId: Int, bounds: BoundingRectangle, municipalities: Set[Int] = Set()): Seq[Seq[PieceWiseLinearAsset]] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
@@ -14,7 +14,7 @@ import slick.driver.JdbcDriver.backend.Database.dynamicSession
 
 class MaintenanceService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ManoeuvreService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ManoeuvreService.scala
@@ -46,7 +46,7 @@ class ManoeuvreCreationException(val response: Set[String]) extends RuntimeExcep
 class ManoeuvreService(roadLinkService: RoadLinkService, eventBus: DigiroadEventBus) {
   val logger = LoggerFactory.getLogger(getClass)
 
-  def dao: ManoeuvreDao = new ManoeuvreDao(roadLinkService.roadLinkClient)
+  def dao: ManoeuvreDao = new ManoeuvreDao()
   def inaccurateDAO: InaccurateAssetDAO = new InaccurateAssetDAO
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetService.scala
@@ -17,7 +17,7 @@ import scala.slick.jdbc.{StaticQuery => Q}
 
 class NumericValueLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetService.scala
@@ -20,7 +20,6 @@ class NumericValueLinearAssetService(roadLinkServiceImpl: RoadLinkService, event
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetService.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, SideCode}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetService.scala
@@ -15,7 +15,6 @@ class OnOffLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetService.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetService.scala
@@ -12,7 +12,7 @@ import org.joda.time.DateTime
 
 class OnOffLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetService(roadLinkServiceImpl, eventBusImpl){
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -16,7 +16,7 @@ class ProhibitionCreationException(val response: Set[String]) extends RuntimeExc
 
 class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -19,7 +19,6 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   override def assetFiller: AssetFiller = new OneWayAssetFiller

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 import fi.liikennevirasto.digiroad2.asset.ProhibitionClass._
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo 
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{AssetLastModification, PostGISLinearAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
@@ -12,7 +12,7 @@ import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 
 class RoadWidthService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
@@ -15,7 +15,6 @@ class RoadWidthService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   override def dynamicLinearAssetDao: DynamicLinearAssetDao = new DynamicLinearAssetDao

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -4,8 +4,9 @@ import java.util.NoSuchElementException
 import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.New
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISSpeedLimitDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -5,7 +5,7 @@ import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.New
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISSpeedLimitDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory
 
 case class ChangedSpeedLimit(speedLimit: SpeedLimit, link: RoadLink)
 
-class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkClient: RoadLinkClient, roadLinkService: RoadLinkService) {
+class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkService) {
   val dao: PostGISSpeedLimitDao = new PostGISSpeedLimitDao(roadLinkService)
   val inaccurateAssetDao: InaccurateAssetDAO = new InaccurateAssetDAO()
   val assetDao: PostGISAssetDao = new PostGISAssetDao()

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory
 case class ChangedSpeedLimit(speedLimit: SpeedLimit, link: RoadLink)
 
 class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkClient: RoadLinkClient, roadLinkService: RoadLinkService) {
-  val dao: PostGISSpeedLimitDao = new PostGISSpeedLimitDao(roadLinkClient, roadLinkService)
+  val dao: PostGISSpeedLimitDao = new PostGISSpeedLimitDao(roadLinkService)
   val inaccurateAssetDao: InaccurateAssetDAO = new InaccurateAssetDAO()
   val assetDao: PostGISAssetDao = new PostGISAssetDao()
   val logger = LoggerFactory.getLogger(getClass)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetService.scala
@@ -12,7 +12,7 @@ import org.joda.time.DateTime
 
 class TextValueLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends LinearAssetOperations {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetService.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, SideCode, UnknownLinkType}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetService.scala
@@ -15,7 +15,6 @@ class TextValueLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBus
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleService.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 import fi.liikennevirasto.digiroad2.PointAssetFiller.AssetAdjustment
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, PropertyValue, SimplePointAssetProperty}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{DirectionalTrafficSign, Obstacle, PostGISDirectionalTrafficSignDao, PostGISObstacleDao}
 import fi.liikennevirasto.digiroad2.linearasset.{LinkId, RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
@@ -19,7 +19,6 @@ class PavedRoadService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
   override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
   override def polygonTools: PolygonTools = new PolygonTools()
   override def assetDao: PostGISAssetDao = new PostGISAssetDao
   override def dynamicLinearAssetDao: DynamicLinearAssetDao = new DynamicLinearAssetDao

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
@@ -16,7 +16,7 @@ import scala.slick.jdbc.{StaticQuery => Q}
 
 class PavedRoadService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkServiceImpl.roadLinkClient, roadLinkServiceImpl)
+  override def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   override def municipalityDao: MunicipalityDao = new MunicipalityDao
   override def eventBus: DigiroadEventBus = eventBusImpl
   override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingService.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 import fi.liikennevirasto.digiroad2.PointAssetFiller.AssetAdjustment
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, PropertyValue, SimplePointAssetProperty}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{PostGISRailwayCrossingDao, RailwayCrossing}
 import fi.liikennevirasto.digiroad2.linearasset.{LinkId, RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightService.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 import fi.liikennevirasto.digiroad2.PointAssetFiller.AssetAdjustment
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, SimplePointAssetProperty}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{PostGISTrafficLightDao, TrafficLight}
 import fi.liikennevirasto.digiroad2.linearasset.{LinkId, RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
@@ -5,7 +5,6 @@ import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.DateParser.DateTimeSimplifiedFormat
 import fi.liikennevirasto.digiroad2.asset.SideCode._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{PersistedTrafficSign, PostGISTrafficSignDao}
 import fi.liikennevirasto.digiroad2.lane.LaneType
 import fi.liikennevirasto.digiroad2.linearasset.{LinkId, RoadLink, RoadLinkLike}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporter.scala
@@ -624,7 +624,7 @@ class AssetDataImporter {
   }
 
   private def splitSpeedLimits(chunkStart: Long, chunkEnd: Long) = {
-    val dao = new PostGISSpeedLimitDao(null, null)
+    val dao = new PostGISSpeedLimitDao(null)
 
     withDynTransaction {
       val speedLimitLinks = sql"""

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporter.scala
@@ -654,7 +654,7 @@ class AssetDataImporter {
   }
 
   private def splitLinearAssets(typeId: Int, chunkStart: Long, chunkEnd: Long) = {
-    val dao = new PostGISLinearAssetDao(null, null)
+    val dao = new PostGISLinearAssetDao()
 
     withDynTransaction {
       val linearAssetLinks = sql"""

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporter.scala
@@ -8,7 +8,7 @@ import Database.dynamicSession
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.dao.pointasset.{Obstacle, PostGISObstacleDao}
 import fi.liikennevirasto.digiroad2.dao.Queries._

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetValidatorProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetValidatorProcess.scala
@@ -88,7 +88,7 @@ object AssetValidatorProcess {
   def verifyInaccurateSpeedLimits(): Unit = {
     println("Start inaccurate SpeedLimit verification\n")
     println(DateTime.now())
-    val dao = new PostGISSpeedLimitDao(null, null)
+    val dao = new PostGISSpeedLimitDao(null)
 
     //Expire all inaccuratedAssets
     PostGISDatabase.withDynTransaction {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetValidatorProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AssetValidatorProcess.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.asset.{Municipality, SpeedLimitAsset, State}
 import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{InaccurateAssetDAO, Queries}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISSpeedLimitDao
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AutomaticLaneCreationModificationProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/AutomaticLaneCreationModificationProcess.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
 import fi.liikennevirasto.digiroad2.client.viite.{ChangeInformation, IntegrationViiteClient, SearchViiteClient}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}
 import fi.liikennevirasto.digiroad2.service.lane.LaneService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
@@ -1,6 +1,7 @@
 package fi.liikennevirasto.digiroad2.util
 
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.lane.LaneFiller.{ChangeSet, baseAdjustment}
 import fi.liikennevirasto.digiroad2.lane.{NewLane, PersistedLane}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/CsvGenerator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/CsvGenerator.scala
@@ -9,7 +9,7 @@ import org.joda.time.{DateTime, Seconds}
 import slick.jdbc.StaticQuery.interpolation
 import slick.driver.JdbcDriver.backend.{Database, DatabaseDef}
 import Database.dynamicSession
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/CsvGenerator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/CsvGenerator.scala
@@ -15,7 +15,7 @@ import fi.liikennevirasto.digiroad2.service.RoadLinkService
 
 class CsvGenerator(vvhServiceHost: String) {
   val roadLinkService = new RoadLinkService(new RoadLinkClient(vvhServiceHost), new DummyEventBus, new DummySerializer)
-  val linearAssetDao = new PostGISLinearAssetDao(roadLinkService.roadLinkClient, roadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
 
   val Source = 1
   val Destination = 3

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -12,7 +12,7 @@ import fi.liikennevirasto.digiroad2.asset.{HeightLimit, _}
 import fi.liikennevirasto.digiroad2.client.VKMClient
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.New
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO.{AdministrativeClassDao, FunctionalClassDao, LinkAttributes, LinkAttributesDao}
 import fi.liikennevirasto.digiroad2.dao.{PostGISUserProvider, _}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISSpeedLimitDao}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -121,7 +121,7 @@ object DataFixture {
   }
 
   lazy val postGISLinearAssetDao : PostGISLinearAssetDao = {
-    new PostGISLinearAssetDao(roadLinkClient, roadLinkService)
+    new PostGISLinearAssetDao()
   }
 
   lazy val inaccurateAssetDAO : InaccurateAssetDAO = {
@@ -632,7 +632,7 @@ object DataFixture {
   }
 
   def fillLaneAmountsMissingInRoadLink(): Unit = {
-    val dao = new PostGISLinearAssetDao(null, null)
+    val dao = new PostGISLinearAssetDao()
     val roadLinkService = new RoadLinkService(roadLinkClient, new DummyEventBus, new DummySerializer)
 
     lazy val linearAssetService: LinearAssetService = {
@@ -738,7 +738,7 @@ object DataFixture {
     println("\nFill Road Width in missing and incomplete road links")
     println(DateTime.now())
 
-    val dao = new PostGISLinearAssetDao(null, null)
+    val dao = new PostGISLinearAssetDao()
     val roadLinkService = new RoadLinkService(roadLinkClient, new DummyEventBus, new DummySerializer)
 
     lazy val roadWidthService: RoadWidthService = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -149,7 +149,7 @@ object DataFixture {
   }
 
   lazy val speedLimitDao: PostGISSpeedLimitDao = {
-    new PostGISSpeedLimitDao(null, null)
+    new PostGISSpeedLimitDao(null)
   }
 
   lazy val verificationService: VerificationService = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -74,7 +74,7 @@ object DataFixture {
   }
 
   lazy val speedLimitService: SpeedLimitService = {
-    new SpeedLimitService(new DummyEventBus, roadLinkClient, roadLinkService)
+    new SpeedLimitService(new DummyEventBus, roadLinkService)
   }
 
   lazy val manoeuvreService: ManoeuvreService = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/LaneUtils.scala
@@ -4,7 +4,8 @@ import java.util.Properties
 import fi.liikennevirasto.digiroad2.asset.SideCode
 import fi.liikennevirasto.digiroad2.client.VKMClient
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.{RoadAddressTEMP, RoadLinkTempDAO}
 import fi.liikennevirasto.digiroad2.lane.LaneNumber.MainLane
 import fi.liikennevirasto.digiroad2.lane.{LaneEndPoints, LaneRoadAddressInfo, NewLane, PersistedLane}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/MainLanePopulationProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/MainLanePopulationProcess.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.digiroad2.asset.{CycleOrPedestrianPath, LinkType, Moto
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.toSideCode
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
 import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer, lane}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.lane.{LaneProperty, LanePropertyValue, LaneType, PersistedLane}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.digiroad2.util
 
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RefreshRoadLinkCache.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RefreshRoadLinkCache.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.client.Caching
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinks.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinks.scala
@@ -6,7 +6,7 @@ import fi.liikennevirasto.digiroad2.{DigiroadEventBus, DummySerializer, Geometry
 import fi.liikennevirasto.digiroad2.asset.{DateParser, SideCode, State}
 import fi.liikennevirasto.digiroad2.client.VKMClient
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{Queries, RoadAddressTEMP, RoadLinkTempDAO}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RoadLinkHistoryProcessor.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RoadLinkHistoryProcessor.scala
@@ -1,6 +1,6 @@
 package fi.liikennevirasto.digiroad2.util
 
-import fi.liikennevirasto.digiroad2.client.vvh.{HistoryRoadLink, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{HistoryRoadLink, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLinkLike
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ServicePointImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ServicePointImporter.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import org.joda.time.DateTime
 import slick.driver.JdbcDriver.backend.{Database, DatabaseDef}
 import Database.dynamicSession
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import slick.jdbc.StaticQuery.interpolation

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
@@ -91,7 +91,7 @@ trait TrafficSignLinearGenerator {
     new TrafficSignService(roadLinkService, eventbus)
   }
 
-  lazy val postGisLinearAssetDao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkService.roadLinkClient, roadLinkService)
+  lazy val postGisLinearAssetDao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   lazy val dynamicLinearAssetDao: DynamicLinearAssetDao = new DynamicLinearAssetDao
 
   def createValue(trafficSigns: Seq[PersistedTrafficSign]): Option[Value]

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
@@ -5,7 +5,6 @@ import java.util.Properties
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, BothDirections, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset.{PointAssetValue, _}
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.DynamicLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
@@ -28,8 +27,6 @@ case class TrafficSignToLinear(roadLink: RoadLink, value: Value, sideCode: SideC
 
 trait TrafficSignLinearGenerator {
   def roadLinkService: RoadLinkService
-
-  def roadLinkClient: RoadLinkClient
 
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
@@ -682,7 +679,6 @@ trait TrafficSignLinearGenerator {
 //Prohibition
 case class TrafficSignProhibitionGenerator(roadLinkServiceImpl: RoadLinkService) extends TrafficSignLinearGenerator  {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
 
   override val assetType : Int = Prohibition.typeId
 
@@ -942,7 +938,6 @@ trait TrafficSignDynamicAssetGenerator extends TrafficSignLinearGenerator  {
 ***************************************************************/
 class TrafficSignParkingProhibitionGenerator(roadLinkServiceImpl: RoadLinkService) extends TrafficSignDynamicAssetGenerator {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
 
   override val assetType : Int = ParkingProhibition.typeId
 
@@ -1101,7 +1096,6 @@ class TrafficSignParkingProhibitionGenerator(roadLinkServiceImpl: RoadLinkServic
   ***************************************************************/
 class TrafficSignRoadWorkGenerator(roadLinkServiceImpl: RoadLinkService) extends TrafficSignDynamicAssetGenerator {
   override def roadLinkService: RoadLinkService = roadLinkServiceImpl
-  override def roadLinkClient: RoadLinkClient = roadLinkServiceImpl.roadLinkClient
 
   override val assetType: Int = RoadWorksAsset.typeId
   private val MAX_DISTANCE: Int = 1000

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UpdateIncompleteLinkList.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UpdateIncompleteLinkList.scala
@@ -2,7 +2,8 @@ package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.asset.DateParser.DateTimePropertyFormat
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, FeatureClass, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ValidateLaneChangesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ValidateLaneChangesAccordingToVvhChanges.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.util
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.{AgainstDigitizing, BothDirections, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset.{CycleOrPedestrianPath, MotorwayServiceAccess, SideCode, SpecialTransportWithGate, SpecialTransportWithoutGate, TractorRoad}
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.lane.{LaneNumberOneDigit, PersistedLane}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset._
 import fi.liikennevirasto.digiroad2.service.pointasset.PavedRoadService

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -23,7 +23,7 @@ object LinearAssetUpdateProcess {
   lazy val prohibitionService = new ProhibitionService(roadLinkService, eventbus)
   lazy val hazMatTransportProhibitionService = new HazmatTransportProhibitionService(roadLinkService, eventbus)
   lazy val roadWidthService = new RoadWidthService(roadLinkService, eventbus)
-  lazy val speedLimitService = new SpeedLimitService(eventbus, roadLinkClient, roadLinkService)
+  lazy val speedLimitService = new SpeedLimitService(eventbus, roadLinkService)
 
   private def getLinearAssetService(typeId: Int): LinearAssetOperations = {
     typeId match {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -60,7 +60,7 @@ object LinearAssetUpdateProcess {
   lazy val prohibitionUpdater = new ProhibitionUpdater(prohibitionService)
   lazy val hazMatTransportProhibitionUpdater = new HazMatTransportProhibitionUpdater(hazMatTransportProhibitionService)
   lazy val roadWidthUpdater = new RoadWidthUpdater(roadWidthService)
-  lazy val speedLimitUpdater = new SpeedLimitUpdater(eventbus, roadLinkClient, roadLinkService, speedLimitService)
+  lazy val speedLimitUpdater = new SpeedLimitUpdater(eventbus, roadLinkService, speedLimitService)
 
   def main(args: Array[String]): Unit = {
     val batchMode = Digiroad2Properties.batchMode

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -21,7 +21,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   def roadLinkClient: RoadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
   def roadLinkService: RoadLinkService = new RoadLinkService(roadLinkClient, eventBus, new DummySerializer)
   def assetFiller: AssetFiller = new AssetFiller
-  def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao(roadLinkClient, roadLinkService)
+  def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
   val logger = LoggerFactory.getLogger(getClass)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.util.assetUpdater
 import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2.asset.{EuropeanRoads, ExitNumbers, UnknownLinkType}
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.{New, isExtensionChange, isReplacementChange}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
@@ -13,6 +13,7 @@ import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.{LinearAssetOperations, LinearAssetTypes, Measures}
 import fi.liikennevirasto.digiroad2.util.{Digiroad2Properties, LinearAssetUtils}
 import fi.liikennevirasto.digiroad2._
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
 import org.slf4j.LoggerFactory
 
 class LinearAssetUpdater(service: LinearAssetOperations) {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -14,7 +14,7 @@ import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import org.slf4j.LoggerFactory
 
-class SpeedLimitUpdater(eventbus: DigiroadEventBus, roadLinkClient: RoadLinkClient, roadLinkService: RoadLinkService, service: SpeedLimitService) {
+class SpeedLimitUpdater(eventbus: DigiroadEventBus, roadLinkService: RoadLinkService, service: SpeedLimitService) {
 
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
   val dao = service.dao
@@ -108,7 +108,7 @@ class SpeedLimitUpdater(eventbus: DigiroadEventBus, roadLinkClient: RoadLinkClie
   }
 
   def purgeUnknown(linkIds: Set[String], expiredLinkIds: Seq[String]): Unit = {
-    val roadLinks = roadLinkClient.roadLinkData.fetchByLinkIds(linkIds)
+    val roadLinks = roadLinkService.fetchVVHRoadlinks(linkIds)
     roadLinks.foreach { rl =>
       dao.purgeFromUnknownSpeedLimits(rl.linkId, GeometryUtils.geometryLength(rl.geometry))
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.util.assetUpdater
 import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2.asset.UnknownLinkType
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.New
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/HazmatTransportProhibitionValidatorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/HazmatTransportProhibitionValidatorSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/LinearMassLimitationServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/LinearMassLimitationServiceSpec.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.DynamicLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
@@ -15,7 +14,6 @@ import slick.jdbc.{StaticQuery => Q}
 
 class LinearMassLimitationServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockDynamicDao = MockitoSugar.mock[DynamicLinearAssetDao]
   val TotalWeightLimits = 30

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/ManoeuvreValidatorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/ManoeuvreValidatorSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/PedestrianCrossingValidatorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/PedestrianCrossingValidatorSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{PedestrianCrossing, PersistedTrafficSign, PostGISPedestrianCrossingDao}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/PointAssetOperationsSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/PointAssetOperationsSpec.scala
@@ -5,7 +5,8 @@ import fi.liikennevirasto.digiroad2.PointAssetOperations._
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.PointAssetFiller._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.PersistedMassTransitStop
 import fi.liikennevirasto.digiroad2.util.LinkIdGenerator

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/SevenRestrictionsLimitationValidatorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/SevenRestrictionsLimitationValidatorSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.client
 import com.vividsolutions.jts.geom.GeometryFactory
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource}
-import fi.liikennevirasto.digiroad2.client.vvh.{KgvCollection, KgvRoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvRoadLinkClient}
 import org.geotools.geometry.jts.GeometryBuilder
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/RoadLinkClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/RoadLinkClientSpec.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.client
 import com.vividsolutions.jts.geom.GeometryFactory
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.util.Digiroad2Properties
 import org.geotools.geometry.jts.GeometryBuilder
 import org.scalatest.{FunSuite, Matchers}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/RoadLinkClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/RoadLinkClientSpec.scala
@@ -15,7 +15,7 @@ class RoadLinkClientSpec extends FunSuite with Matchers{
   /**
     * Checks that VVH history bounding box search works uses API example bounding box so it should receive results
     */
-  test("Tries to connect VVH history API and retrive result") {
+  ignore("Tries to connect VVH history API and retrive result") {
     val roadLinkClient= new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
     val result= roadLinkClient.historyData.fetchByMunicipalitiesAndBounds(BoundingRectangle(Point(564000, 6930000),Point(566000, 6931000)), Set(420))
     result.size should be >1
@@ -26,16 +26,16 @@ class RoadLinkClientSpec extends FunSuite with Matchers{
     val result= roadLinkClient.roadLinkData.fetchByPolygon(geomBuilder.polygon(564000,6930000,566000,6931000,567000,6933000))
     result.size should be >1
   }
-
-  test("Fetch roadlinks with empty polygon string") {
+  //TODO these test are no longer needed now when we use local db, Delete test in later time
+  ignore("Fetch roadlinks with empty polygon string") {
     val roadLinkClient= new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
     val result= roadLinkClient.roadLinkData.fetchByPolygon(geomBuilder.polygon())
     result.size should be (0)
   }
   /**
-    * Checks that VVH history link id search works and returns something
+    * Checks that VVH history link id search works and returns something //TODO these test are no longer needed now when we use local db, Delete test in later time
     */
-  test("Test VVH History LinkId API") {
+  ignore("Test VVH History LinkId API") {
     val roadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
     val result = roadLinkClient.historyData.fetchByLinkIds(Set("440484","440606","440405","440489"))
     result.nonEmpty should be (true)
@@ -62,8 +62,8 @@ class RoadLinkClientSpec extends FunSuite with Matchers{
   /**
     * Test for frozen december 15.12.2016 VVH API: No test cases writen to documentation so test might fail for not having any links
   */
-
-  test("Frozen In Time API test ") {
+  //TODO these test are no longer needed now when we use local db, Delete test in later time
+  ignore("Frozen In Time API test ") {
     val frozenApiEnabled = Digiroad2Properties.vvhRoadlinkFrozen
     if (frozenApiEnabled=="true") { //Api only exists in QA and Production
       val roadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/ManoeuvreDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/ManoeuvreDaoSpec.scala
@@ -15,12 +15,12 @@ import org.scalatest.{FunSuite, Matchers}
 class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
-
+  val dao = new ManoeuvreDao()
+  
   test("test setManoeuvreExceptions") {
     runWithRollback {
       val (linkId1, linkId2, linkId3) =
         (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
-      val dao = new ManoeuvreDao()
       val mano = NewManoeuvre(Set(), Seq(), None, Seq(linkId1, linkId2, linkId3), None, false)
       val id = dao.createManoeuvre("user", mano)
       id > 0 should be (true)
@@ -36,7 +36,6 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test create Manoeuvre For Update") {
     runWithRollback {
-      val dao = new ManoeuvreDao()
       val validityPeriod = Set(ValidityPeriod(12, 13, ValidityPeriodDayOfWeek("Sunday"), 30, 15), ValidityPeriod(8, 12, ValidityPeriodDayOfWeek("Saturday"), 0, 10))
       val exceptions = List(4,5)
       val mano = NewManoeuvre(validityPeriod, exceptions, None, Seq(LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom()), None, false)
@@ -56,7 +55,6 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test getByRoadLinks") {
     runWithRollback {
-      val dao = new ManoeuvreDao()
       val (linkId1, linkId2) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
       val mano = NewManoeuvre(Set(), Seq(), None, Seq(linkId1, linkId2), None, false)
       val id = dao.createManoeuvre("user", mano)
@@ -76,7 +74,6 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test addManoeuvreValidityPeriods") {
     runWithRollback {
-      val dao = new ManoeuvreDao()
       val (linkId1, linkId2, linkId3) =
         (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
       val mano = NewManoeuvre(Set(), Seq(), None, Seq(linkId1, linkId2, linkId3), None, false)
@@ -98,7 +95,6 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test addManoeuvreExceptions") {
     runWithRollback {
-      val dao = new ManoeuvreDao()
       val mano = NewManoeuvre(Set(), Seq(1, 2), None, Seq(LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom()), None, false)
       val id = dao.createManoeuvre("user", mano)
       id > 0 should be (true)
@@ -114,7 +110,6 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test deleteManoeuvre") {
     runWithRollback {
-      val dao = new ManoeuvreDao()
       val mano = NewManoeuvre(Set(), Seq(1, 2), Option("added"), Seq(LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom()), None, false)
       val id = dao.createManoeuvre("user", mano)
       id > 0 should be (true)
@@ -126,7 +121,6 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
   }
 
   test("test createManoeuvre") {
-    val dao = new ManoeuvreDao()
     val (linkId1, linkId2, linkId3) =
       (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
     val elements = Seq(ManoeuvreElement(1, linkId1, linkId2, ElementTypes.FirstElement),

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/ManoeuvreDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/ManoeuvreDaoSpec.scala
@@ -21,7 +21,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
     runWithRollback {
       val (linkId1, linkId2, linkId3) =
         (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
-      val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+      val dao = new ManoeuvreDao()
       val mano = NewManoeuvre(Set(), Seq(), None, Seq(linkId1, linkId2, linkId3), None, false)
       val id = dao.createManoeuvre("user", mano)
       id > 0 should be (true)
@@ -37,7 +37,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test create Manoeuvre For Update") {
     runWithRollback {
-      val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+      val dao = new ManoeuvreDao()
       val validityPeriod = Set(ValidityPeriod(12, 13, ValidityPeriodDayOfWeek("Sunday"), 30, 15), ValidityPeriod(8, 12, ValidityPeriodDayOfWeek("Saturday"), 0, 10))
       val exceptions = List(4,5)
       val mano = NewManoeuvre(validityPeriod, exceptions, None, Seq(LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom()), None, false)
@@ -57,7 +57,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test getByRoadLinks") {
     runWithRollback {
-      val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+      val dao = new ManoeuvreDao()
       val (linkId1, linkId2) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
       val mano = NewManoeuvre(Set(), Seq(), None, Seq(linkId1, linkId2), None, false)
       val id = dao.createManoeuvre("user", mano)
@@ -77,7 +77,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test addManoeuvreValidityPeriods") {
     runWithRollback {
-      val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+      val dao = new ManoeuvreDao()
       val (linkId1, linkId2, linkId3) =
         (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
       val mano = NewManoeuvre(Set(), Seq(), None, Seq(linkId1, linkId2, linkId3), None, false)
@@ -99,7 +99,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test addManoeuvreExceptions") {
     runWithRollback {
-      val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+      val dao = new ManoeuvreDao()
       val mano = NewManoeuvre(Set(), Seq(1, 2), None, Seq(LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom()), None, false)
       val id = dao.createManoeuvre("user", mano)
       id > 0 should be (true)
@@ -115,7 +115,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
 
   test("test deleteManoeuvre") {
     runWithRollback {
-      val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+      val dao = new ManoeuvreDao()
       val mano = NewManoeuvre(Set(), Seq(1, 2), Option("added"), Seq(LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom()), None, false)
       val id = dao.createManoeuvre("user", mano)
       id > 0 should be (true)
@@ -127,7 +127,7 @@ class ManoeuvreDaoSpec extends  FunSuite with Matchers {
   }
 
   test("test createManoeuvre") {
-    val dao = new ManoeuvreDao(MockitoSugar.mock[RoadLinkClient])
+    val dao = new ManoeuvreDao()
     val (linkId1, linkId2, linkId3) =
       (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
     val elements = Seq(ManoeuvreElement(1, linkId1, linkId2, ElementTypes.FirstElement),

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/ManoeuvreDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/ManoeuvreDaoSpec.scala
@@ -1,6 +1,5 @@
 package fi.liikennevirasto.digiroad2.dao.linearasset
 
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.linearasset.manoeuvre.ManoeuvreDao
 import fi.liikennevirasto.digiroad2.linearasset.{ValidityPeriod, ValidityPeriodDayOfWeek}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDaoSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers, Tag}
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDaoSpec.scala
@@ -21,7 +21,7 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   val linkId: String = LinkIdGenerator.generateRandom()
   val roadLink = RoadLinkFetched(linkId, 0, List(Point(0.0, 0.0), Point(0.0, 200.0)), Municipality, TrafficDirection.BothDirections, AllOthers)
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-
+  val dao = new PostGISLinearAssetDao()
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
   def setupTestProhibition(linkId: String,
@@ -55,7 +55,6 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   }
 
   test("fetch simple prohibition without validity periods or exceptions") {
-    val dao = new PostGISLinearAssetDao(null, null)
     val linkId = LinkIdGenerator.generateRandom()
     val fixtureProhibitionValues = Set(ProhibitionValue(typeId = 10, validityPeriods = Set.empty, exceptions = Set.empty, ""))
 
@@ -73,7 +72,6 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   }
 
   test("fetch prohibition with validity period") {
-    val dao = new PostGISLinearAssetDao(null, null)
     val linkId = LinkIdGenerator.generateRandom()
     val fixtureProhibitionValues = Set(ProhibitionValue(typeId = 10, Set(ValidityPeriod(12, 16, Weekday)), exceptions = Set.empty, ""))
 
@@ -91,7 +89,6 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   }
 
   test("fetch prohibition with validity period and exceptions") {
-    val dao = new PostGISLinearAssetDao(null, null)
     val linkId = LinkIdGenerator.generateRandom()
     val fixtureProhibitionValues = Set(
       ProhibitionValue(typeId = 10, Set(ValidityPeriod(12, 16, Weekday)), exceptions = Set(1, 2, 3), ""))
@@ -110,7 +107,6 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   }
 
   test("fetch prohibition with validity period, exceptions and additional information") {
-    val dao = new PostGISLinearAssetDao(null, null)
     val linkId = LinkIdGenerator.generateRandom()
     val fixtureProhibitionValues = Set(
       ProhibitionValue(typeId = 10, Set(ValidityPeriod(12, 16, Weekday)), exceptions = Set(1, 2, 3), "test value string"))
@@ -129,7 +125,6 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   }
 
   test("fetch multiple prohibitions") {
-    val dao = new PostGISLinearAssetDao(null, null)
     val linkId1 = LinkIdGenerator.generateRandom()
     val linkId2 = LinkIdGenerator.generateRandom()
     val linkId3 = LinkIdGenerator.generateRandom()
@@ -173,7 +168,6 @@ class PostGISLinearAssetDaoSpec extends FunSuite with Matchers {
   }
 
   test("all entities should be expired") {
-    val dao = new PostGISLinearAssetDao(null, null)
     val typeId = 110
     val linkId = LinkIdGenerator.generateRandom()
     runWithRollback {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDaoSpec.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.dao.linearasset
 
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.FeatureClass.AllOthers
 import fi.liikennevirasto.digiroad2.linearasset.ValidityPeriodDayOfWeek.Weekday
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator, TestTransactions}
@@ -11,7 +10,8 @@ import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers, Tag}
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
@@ -36,7 +36,7 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
       when(mockRoadLinkService.fetchByLinkId(roadLink.linkId)).thenReturn(Some(roadLink))
     }
 
-    new PostGISSpeedLimitDao(mockRoadLinkClient, mockRoadLinkService)
+    new PostGISSpeedLimitDao(mockRoadLinkService)
   }
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
@@ -64,7 +64,7 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 1, TrafficDirection.UnknownDirection, CableFerry, None, None, Map("MUNICIPALITYCODE" -> BigInt(235))),
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 1, TrafficDirection.UnknownDirection, UnknownLinkType, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       )
-      val dao = new PostGISSpeedLimitDao(MockitoSugar.mock[RoadLinkClient], MockitoSugar.mock[RoadLinkService])
+      val dao = new PostGISSpeedLimitDao(MockitoSugar.mock[RoadLinkService])
 
       val speedLimits = dao.getSpeedLimitLinksByRoadLinks(roadLinks.filter(_.isCarTrafficRoad))
 
@@ -79,7 +79,7 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 7, TrafficDirection.UnknownDirection, MultipleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235))),
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 8, TrafficDirection.UnknownDirection, MultipleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       )
-      val dao = new PostGISSpeedLimitDao(MockitoSugar.mock[RoadLinkClient], MockitoSugar.mock[RoadLinkService])
+      val dao = new PostGISSpeedLimitDao(MockitoSugar.mock[RoadLinkService])
 
       val speedLimits = dao.getSpeedLimitLinksByRoadLinks(roadLinks.filter(_.isCarTrafficRoad))
 
@@ -179,7 +179,7 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
 
   test("speed limit mass query") {
     val ids = Seq.range(1L, 500L).map(_.toString).toSet
-    val dao = new PostGISSpeedLimitDao(null, null)
+    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(Option(ids))
     }
@@ -187,7 +187,7 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
 
   test("speed limit no mass query") {
     val ids = Seq.range(1L, 2L).map(_.toString).toSet
-    val dao = new PostGISSpeedLimitDao(null, null)
+    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(Option(ids))
     }
@@ -195,14 +195,14 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
 
   test("speed limit empty set must not crash") {
     val ids = Set():Set[String]
-    val dao = new PostGISSpeedLimitDao(null, null)
+    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(Option(ids))
     }
   }
 
   test("speed limit no set must not crash") {
-    val dao = new PostGISSpeedLimitDao(null, null)
+    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(None)
     }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.{FunSuite, Matchers, Tag}
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
-import fi.liikennevirasto.digiroad2.client.vvh.{RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures
@@ -24,7 +24,6 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
 
   private def daoWithRoadLinks(roadLinks: Seq[RoadLinkFetched]): PostGISSpeedLimitDao = {
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
     
     when(mockRoadLinkService.fetchVVHRoadlinks(roadLinks.map(_.linkId).toSet))
       .thenReturn(roadLinks)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
@@ -38,6 +38,7 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
     new PostGISSpeedLimitDao(mockRoadLinkService)
   }
 
+  val dao = new PostGISSpeedLimitDao(mockRoadLinkService)
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
 
@@ -63,7 +64,6 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 1, TrafficDirection.UnknownDirection, CableFerry, None, None, Map("MUNICIPALITYCODE" -> BigInt(235))),
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 1, TrafficDirection.UnknownDirection, UnknownLinkType, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       )
-      val dao = new PostGISSpeedLimitDao(MockitoSugar.mock[RoadLinkService])
 
       val speedLimits = dao.getSpeedLimitLinksByRoadLinks(roadLinks.filter(_.isCarTrafficRoad))
 
@@ -78,7 +78,6 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 7, TrafficDirection.UnknownDirection, MultipleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235))),
         RoadLink("080f5065-5ce7-4c58-b838-d0b4daf84adc:1", List(Point(0.0, 0.0), Point(370.0, 0.0)), 370.0, Municipality, 8, TrafficDirection.UnknownDirection, MultipleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       )
-      val dao = new PostGISSpeedLimitDao(MockitoSugar.mock[RoadLinkService])
 
       val speedLimits = dao.getSpeedLimitLinksByRoadLinks(roadLinks.filter(_.isCarTrafficRoad))
 
@@ -178,7 +177,6 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
 
   test("speed limit mass query") {
     val ids = Seq.range(1L, 500L).map(_.toString).toSet
-    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(Option(ids))
     }
@@ -186,7 +184,6 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
 
   test("speed limit no mass query") {
     val ids = Seq.range(1L, 2L).map(_.toString).toSet
-    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(Option(ids))
     }
@@ -194,14 +191,12 @@ class PostGISSpeedLimitDaoSpec extends FunSuite with Matchers {
 
   test("speed limit empty set must not crash") {
     val ids = Set():Set[String]
-    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(Option(ids))
     }
   }
 
   test("speed limit no set must not crash") {
-    val dao = new PostGISSpeedLimitDao(null)
     runWithRollback {
       dao.getCurrentSpeedLimitsByLinkIds(None)
     }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDaoSpec.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.dao.linearasset
 
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.FeatureClass.AllOthers
 import fi.liikennevirasto.digiroad2.linearasset.ValidityPeriodDayOfWeek.Weekday
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator, TestTransactions}
@@ -12,7 +11,8 @@ import org.scalatest.{FunSuite, Matchers, Tag}
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkFetched
+import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
+import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
@@ -7,6 +7,7 @@ import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
 import fi.liikennevirasto.digiroad2.client._
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, VVHChangeInfoClient, VVHComplementaryClient}
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, RoadLinkDAO, RoadLinkOverrideDAO}
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO.LinkAttributesDao
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
@@ -4,8 +4,9 @@ import fi.liikennevirasto.digiroad2.asset.DateParser._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.{AgainstDigitizing, BothDirections, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.FeatureClass.AllOthers
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
+import fi.liikennevirasto.digiroad2.client._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{ComplementaryLinkDAO, RoadLinkDAO, RoadLinkOverrideDAO}
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO.LinkAttributesDao
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.service.lane
 import fi.liikennevirasto.digiroad2.asset.DateParser.DatePropertyFormat
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.VKMClient
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, RoadAddressTEMP}
 import fi.liikennevirasto.digiroad2.dao.lane.{LaneDao, LaneHistoryDao}
 import fi.liikennevirasto.digiroad2.lane.LaneFiller.{ChangeSet, SideCodeAdjustment}
@@ -21,7 +20,6 @@ import org.scalatest.{FunSuite, Matchers}
 
 class LaneTestSupporter extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
@@ -31,8 +29,8 @@ class LaneTestSupporter extends FunSuite with Matchers {
   val mockRoadAddressService = MockitoSugar.mock[RoadAddressService]
   val mockLaneService = MockitoSugar.mock[LaneService]
 
-  val laneDao = new LaneDao(mockRoadLinkClient, mockRoadLinkService)
-  val laneHistoryDao = new LaneHistoryDao(mockRoadLinkClient, mockRoadLinkService)
+  val laneDao = new LaneDao()
+  val laneHistoryDao = new LaneHistoryDao()
   val linkId: String = LinkIdGenerator.generateRandom()
   val roadLinkWithLinkSource = RoadLink(
     linkId, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality,
@@ -67,7 +65,6 @@ class LaneTestSupporter extends FunSuite with Matchers {
     override def dao: LaneDao = mockLaneDao
     override def historyDao: LaneHistoryDao = mockLaneHistoryDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def vkmClient: VKMClient = mockVKMClient
@@ -85,7 +82,6 @@ class LaneServiceSpec extends LaneTestSupporter {
 
     override def withDynTransaction[T](f: => T): T = f
     override def roadLinkService: RoadLinkService = mockRoadLinkService
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def dao: LaneDao = laneDao
     override def historyDao: LaneHistoryDao = laneHistoryDao
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
@@ -22,7 +22,6 @@ import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{StaticQuery => Q}
 class DynamicLinearTestSupporter extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val (linkId1, linkId2, linkId3, linkId4) =
     (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
@@ -43,7 +43,7 @@ class DynamicLinearTestSupporter extends FunSuite with Matchers {
   when(mockLinearAssetDao.fetchLinearAssetsByLinkIds(30, Seq(linkId1), "mittarajoitus", false))
     .thenReturn(Seq(PersistedLinearAsset(1, linkId1, 1, Some(NumericValue(40000)), 0.4, 9.6, None, None, None, None, false, 30, 0, None, LinkGeomSource.NormalLinkInterface, None, None, None)))
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mVLinearAssetDao: DynamicLinearAssetDao = new DynamicLinearAssetDao
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
   val mockAssetDao = MockitoSugar.mock[PostGISAssetDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
@@ -2,6 +2,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset.{DynamicProperty, _}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
@@ -95,7 +95,6 @@ class DynamicLinearTestSupporter extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = mockLinearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao
@@ -114,7 +113,6 @@ class DynamicLinearAssetServiceSpec extends DynamicLinearTestSupporter {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset.{DynamicProperty, _}
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao._
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicValueAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicValueAssetServiceSpec.scala
@@ -17,7 +17,7 @@ class DynamicValueAssetServiceSpec extends FunSuite with Matchers {
 
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
 
   object ServiceWithDao extends TextValueLinearAssetService(mockRoadLinkService, mockEventBus) {
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicValueAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicValueAssetServiceSpec.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{DynamicAssetValue, DynamicValue}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
@@ -12,7 +11,6 @@ import org.scalatest.mockito.MockitoSugar
 
 class DynamicValueAssetServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
 
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicValueAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicValueAssetServiceSpec.scala
@@ -24,7 +24,6 @@ class DynamicValueAssetServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
   }
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
@@ -51,7 +51,6 @@ class LinearAssetSpecSupport extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = mockLinearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao
@@ -70,7 +69,6 @@ class LinearAssetServiceSpec extends LinearAssetSpecSupport  {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
@@ -42,7 +42,7 @@ class LinearAssetSpecSupport extends FunSuite with Matchers {
 
   val mockLinearAssetDao: PostGISLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockEventBus: DigiroadEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockMunicipalityDao: MunicipalityDao = MockitoSugar.mock[MunicipalityDao]
   val mockAssetDao: PostGISAssetDao = MockitoSugar.mock[PostGISAssetDao]
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
@@ -2,6 +2,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetServiceSpec.scala
@@ -24,7 +24,6 @@ import slick.jdbc.StaticQuery.interpolation
 class LinearAssetSpecSupport extends FunSuite with Matchers {
 
   val mockRoadLinkService: RoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient: RoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools: PolygonTools = MockitoSugar.mock[PolygonTools]
 
   val (linkId1, linkId2) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
@@ -574,7 +573,6 @@ class LinearAssetServiceSpec extends LinearAssetSpecSupport  {
 
   ignore("Should extend traffic count on segment") {
     val timeStamp = LinearAssetUtils.createTimeStamp(-5)
-    when(mockRoadLinkService.roadLinkClient).thenReturn(mockRoadLinkClient)
     val service = new LinearAssetService(mockRoadLinkService, new DummyEventBus) {
       override def withDynTransaction[T](f: => T): T = f
       override def withDynSession[T](f: => T): T = f
@@ -720,7 +718,6 @@ class LinearAssetServiceSpec extends LinearAssetSpecSupport  {
 
   ignore("Adjust projected asset with creation"){
     val timeStamp = LinearAssetUtils.createTimeStamp(-5)
-    when(mockRoadLinkService.roadLinkClient).thenReturn(mockRoadLinkClient)
 
     val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
     val linearAssetService = new LinearAssetService(mockRoadLinkService, mockEventBus) {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
@@ -25,7 +25,7 @@ class LinearSevenRestrictionsServiceSpec extends FunSuite with Matchers {
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
 
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mVLinearAssetDao: DynamicLinearAssetDao = new DynamicLinearAssetDao
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
   val mockAssetDao = MockitoSugar.mock[PostGISAssetDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
@@ -21,7 +21,6 @@ import slick.jdbc.StaticQuery.interpolation
 
 class LinearSevenRestrictionsServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
@@ -53,7 +53,6 @@ class LinearSevenRestrictionsServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = mockLinearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao
@@ -69,7 +68,6 @@ class LinearSevenRestrictionsServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearSevenRestrictionsServiceSpec.scala
@@ -2,7 +2,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao._
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
@@ -19,7 +19,6 @@ import org.scalatest.{FunSuite, Matchers}
 
 class MaintenanceServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
 
   val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
@@ -3,6 +3,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 import com.vividsolutions.jts.geom.{GeometryFactory, Polygon}
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISMaintenanceDao}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 import com.vividsolutions.jts.geom.{GeometryFactory, Polygon}
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISMaintenanceDao}
 import fi.liikennevirasto.digiroad2.linearasset._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
@@ -53,7 +53,7 @@ class MaintenanceServiceSpec extends FunSuite with Matchers {
     .thenReturn(Seq(PersistedLinearAsset(1, "1", 1, Some(NumericValue(40000)), 0.4, 9.6, None, None, None, None, false, MaintenanceRoadAsset.typeId, 0, None, LinkGeomSource.NormalLinkInterface, None, None, None)))
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val linearAssetDao = new PostGISLinearAssetDao()
-  val maintenanceDao = new PostGISMaintenanceDao(mockRoadLinkClient, mockRoadLinkService)
+  val maintenanceDao = new PostGISMaintenanceDao()
   val dynamicLinearAssetDAO = new DynamicLinearAssetDao
 
   object ServiceWithDao extends MaintenanceService(mockRoadLinkService, mockEventBus) {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
@@ -61,7 +61,6 @@ class MaintenanceServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def maintenanceDAO: PostGISMaintenanceDao = maintenanceDao
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
@@ -75,7 +74,6 @@ class MaintenanceServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def maintenanceDAO: PostGISMaintenanceDao = mockMaintenanceDao
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceServiceSpec.scala
@@ -52,7 +52,7 @@ class MaintenanceServiceSpec extends FunSuite with Matchers {
   when(mockDynamicLinearAssetDao.fetchDynamicLinearAssetsByLinkIds(MaintenanceRoadAsset.typeId, Seq("1")))
     .thenReturn(Seq(PersistedLinearAsset(1, "1", 1, Some(NumericValue(40000)), 0.4, 9.6, None, None, None, None, false, MaintenanceRoadAsset.typeId, 0, None, LinkGeomSource.NormalLinkInterface, None, None, None)))
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val maintenanceDao = new PostGISMaintenanceDao(mockRoadLinkClient, mockRoadLinkService)
   val dynamicLinearAssetDAO = new DynamicLinearAssetDao
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MassTransitLaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MassTransitLaneServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, SideCodeAdjustment}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MassTransitLaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/MassTransitLaneServiceSpec.scala
@@ -20,7 +20,6 @@ class MassTransitLaneServiceSpec extends DynamicLinearTestSupporter {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumberOfLanesServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumberOfLanesServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, SideCodeAdjustment, ValueAdjustment}
@@ -19,8 +19,7 @@ import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{StaticQuery => Q}
 
 class NumberOfLanesServiceSpec extends LinearAssetSpecSupport {
-
-  when(mockRoadLinkService.roadLinkClient).thenReturn(mockRoadLinkClient)
+  
 
   val linearAssetService = new NumberOfLanesService(mockRoadLinkService, mockEventBus) {
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NumericValue, PersistedLinearAsset, RoadLink}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NumericValue, PersistedLinearAsset, RoadLink}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
@@ -16,7 +16,6 @@ import org.scalatest.mockito.MockitoSugar
 
 class NumericValueLinearAssetServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
 
   val linkId = LinkIdGenerator.generateRandom()

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
@@ -36,7 +36,7 @@ class NumericValueLinearAssetServiceSpec extends FunSuite with Matchers {
   when(mockLinearAssetDao.fetchLinearAssetsByLinkIds(30, Seq("1"), "mittarajoitus", false))
     .thenReturn(Seq(PersistedLinearAsset(1, "1", 1, Some(NumericValue(40000)), 0.4, 9.6, None, None, None, None, false, 30, 0, None, LinkGeomSource.NormalLinkInterface, None, None, None)))
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
 
   object ServiceWithDao extends NumericValueLinearAssetService(mockRoadLinkService, mockEventBus) {
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/NumericValueLinearAssetServiceSpec.scala
@@ -43,7 +43,6 @@ class NumericValueLinearAssetServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def getUncheckedLinearAssets(areas: Option[Set[Int]]) = throw new UnsupportedOperationException("Not supported method")
   }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
@@ -21,7 +21,7 @@ class OnOffLinearAssetServiceSpec  extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val mockLinearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val mockLinearAssetDao = new PostGISLinearAssetDao()
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockAssetDao = MockitoSugar.mock[PostGISAssetDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
@@ -35,7 +35,6 @@ class OnOffLinearAssetServiceSpec  extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = mockLinearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
   }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NewLinearAsset, NumericValue, RoadLink}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/OnOffLinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NewLinearAsset, NumericValue, RoadLink}
@@ -19,7 +19,6 @@ class OnOffLinearAssetServiceSpec  extends FunSuite with Matchers {
   protected implicit val jsonFormats: Formats = DefaultFormats
 
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockLinearAssetDao = new PostGISLinearAssetDao()
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
@@ -63,7 +63,6 @@ class ProhibitionServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def assetDao: PostGISAssetDao = mockAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
@@ -1,7 +1,6 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset.{Municipality, _}
-import fi.liikennevirasto.digiroad2.client.vvh._
 import fi.liikennevirasto.digiroad2.dao._
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment, SideCodeAdjustment, VVHChangesAdjustment}
@@ -13,6 +12,7 @@ import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingTrafficSign, Tra
 import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator, PolygonTools, TestTransactions}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import org.joda.time.DateTime
 import org.mockito.ArgumentCaptor

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
@@ -25,7 +25,6 @@ import slick.jdbc.StaticQuery.interpolation
 
 class ProhibitionServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockTrafficSignService = MockitoSugar.mock[TrafficSignService]
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
@@ -12,6 +12,7 @@ import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingTrafficSign, Tra
 import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator, PolygonTools, TestTransactions}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import org.joda.time.DateTime

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionServiceSpec.scala
@@ -49,7 +49,7 @@ class ProhibitionServiceSpec extends FunSuite with Matchers {
   when(mockLinearAssetDao.fetchLinearAssetsByLinkIds(30, Seq(linkId2), "mittarajoitus", false))
     .thenReturn(Seq(PersistedLinearAsset(1, linkId2, 1, Some(NumericValue(40000)), 0.4, 9.6, None, None, None, None, false, 30, 0, None, LinkGeomSource.NormalLinkInterface, None, None, None)))
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockManoeuvreService = MockitoSugar.mock[ManoeuvreService]
 
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
@@ -58,7 +58,6 @@ class RoadWidthServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
 
@@ -79,7 +78,6 @@ class RoadWidthServiceSpec extends FunSuite with Matchers {
     val service = new RoadWidthService(mockRoadLinkService, new DummyEventBus) {
       override def withDynTransaction[T](f: => T): T = f
       override def withDynSession[T](f: => T): T = f
-      override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     }
     service
   }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{AssetLastModification, PostGISLinearAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
@@ -23,7 +23,6 @@ class RoadWidthServiceSpec extends FunSuite with Matchers {
   val RoadWidthAssetTypeId = 120
 
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
@@ -2,6 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{AssetLastModification, PostGISLinearAssetDao}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthServiceSpec.scala
@@ -28,7 +28,7 @@ class RoadWidthServiceSpec extends FunSuite with Matchers {
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
 
   val linkId = LinkIdGenerator.generateRandom()

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
@@ -2,6 +2,8 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISSpeedLimitDao}
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.ChangeSet

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
@@ -73,17 +73,17 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       when(mockRoadLinkService.fetchNormalOrComplimentaryRoadLinkByLinkId(roadLink.linkId)).thenReturn(Some(roadLink))
     }
 
-    new PostGISSpeedLimitDao(mockRoadLinkClient, mockRoadLinkService)
+    new PostGISSpeedLimitDao(mockRoadLinkService)
   }
 
 
-  private def truncateLinkGeometry(linkId: String, startMeasure: Double, endMeasure: Double, roadLinkClient: RoadLinkClient): Seq[Point] = {
+  private def truncateLinkGeometry(linkId: String, startMeasure: Double, endMeasure: Double): Seq[Point] = {
     val geometry = mockRoadLinkService.fetchNormalOrComplimentaryRoadLinkByLinkId(linkId).get.geometry
     GeometryUtils.truncateGeometry3D(geometry, startMeasure, endMeasure)
   }
 
   def assertSpeedLimitEndPointsOnLink(speedLimitId: Long, linkId: String, startMeasure: Double, endMeasure: Double, dao: PostGISSpeedLimitDao) = {
-    val expectedEndPoints = GeometryUtils.geometryEndpoints(truncateLinkGeometry(linkId, startMeasure, endMeasure, dao.roadLinkClient).toList)
+    val expectedEndPoints = GeometryUtils.geometryEndpoints(truncateLinkGeometry(linkId, startMeasure, endMeasure).toList)
     val limitEndPoints = GeometryUtils.geometryEndpoints(dao.getLinksWithLengthFromVVH(speedLimitId).find { link => link._1 == linkId }.get._3)
     expectedEndPoints._1.distance2DTo(limitEndPoints._1) should be(0.0 +- 0.01)
     expectedEndPoints._2.distance2DTo(limitEndPoints._2) should be(0.0 +- 0.01)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
@@ -30,6 +30,8 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     override def withDynTransaction[T](f: => T): T = f
   }
 
+  val eventBus = MockitoSugar.mock[DigiroadEventBus]
+  
   val (linkId1, linkId2, linkId3, linkId4) =
     (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(),
       LinkIdGenerator.generateRandom())
@@ -172,9 +174,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   ignore("request unknown speed limit persist in bounding box fetch") {
     runWithRollback {
       val eventBus = MockitoSugar.mock[DigiroadEventBus]
-      val provider = new SpeedLimitService(eventBus, mockRoadLinkService) {
-        override def withDynTransaction[T](f: => T): T = f
-      }
 
       provider.get(BoundingRectangle(Point(0.0, 0.0), Point(1.0, 1.0)), Set(235))
 
@@ -184,13 +183,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   ignore("request unknown speed limit persist in municipality fetch") {
     runWithRollback {
-      val eventBus = MockitoSugar.mock[DigiroadEventBus]
-      val provider = new SpeedLimitService(eventBus, mockRoadLinkService) {
-        override def withDynTransaction[T](f: => T): T = f
-      }
-
       provider.get(235)
-
       verify(eventBus, times(1)).publish("speedLimits:persistUnknownLimits", Seq(UnknownSpeedLimit(linkId1, 235, Municipality)))
     }
   }
@@ -274,11 +267,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Divided road link (change types 5 and 6)
     // Speed limit case 1
 
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
-
     val oldLinkId = LinkIdGenerator.generateRandom()
     val newLinkId1 = LinkIdGenerator.generateRandom()
     val newLinkId2 = LinkIdGenerator.generateRandom()
@@ -309,14 +297,14 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 80),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       before.length should be(1)
       before.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
       before.head.foreach(_.sideCode should be(SideCode.BothDirections))
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((newRoadLinks, changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
       after.length should be(3)
       after.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
@@ -330,11 +318,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
     // Divided road link (change types 5 and 6)
     // Speed limit case 2
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId = LinkIdGenerator.generateRandom()
     val newLinkId1 = LinkIdGenerator.generateRandom()
@@ -371,7 +354,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset2,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 60),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
 //      before.foreach(println)
 
@@ -388,7 +371,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       limit2.endMeasure should be (25.0)
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((newRoadLinks, changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
 //      after.foreach(println)
 
@@ -412,11 +395,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
     // Divided road link (change types 5 and 6)
     // Speed limit case 3
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId = LinkIdGenerator.generateRandom()
     val newLinkId1 = LinkIdGenerator.generateRandom()
@@ -453,7 +431,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset2,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 60),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       before.length should be(2)
       val (list1, list2) = before.flatten.partition(_.id == asset1)
@@ -469,7 +447,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       limit2.sideCode should be (SideCode.BothDirections)
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((newRoadLinks, changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
       after.length should be(4)
       after.flatten.forall(sl => sl.sideCode eq SideCode.BothDirections) should be (true)
@@ -494,11 +472,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
     // Combined road link (change types 1 and 2)
     // Speed limit case 1
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId1 = LinkIdGenerator.generateRandom()
     val oldLinkId2 = LinkIdGenerator.generateRandom()
@@ -540,7 +513,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((oldRoadLinks, Nil))
 
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       before.length should be(3)
       before.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
@@ -548,7 +521,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
 
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
       after.length should be(1)
       after.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
@@ -562,11 +535,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
     // Lengthened road link (change types 3 and 4)
     // Speed limit case 1
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId = LinkIdGenerator.generateRandom()
     val municipalityCode = 235
@@ -592,14 +560,14 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset1,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 80),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       before.length should be(1)
       before.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
       before.head.foreach(_.sideCode should be(SideCode.BothDirections))
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
       after.length should be(1)
       after.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
@@ -614,11 +582,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Shortened road link (change types 7 and 8)
     // 1. Common part + 2. Removed part
     // Speed limit case 1
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId = LinkIdGenerator.generateRandom()
     val municipalityCode = 235
@@ -644,14 +607,14 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset1,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 80),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       before.length should be(1)
       before.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
       before.head.foreach(_.sideCode should be(SideCode.BothDirections))
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
       after.length should be(1)
       after.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
@@ -666,11 +629,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Shortened road link (change types 7 and 8)
     // 1. Removed part + 2. Common part
     // Speed limit case 1
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId = LinkIdGenerator.generateRandom()
     val municipalityCode = 235
@@ -696,14 +654,14 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset1,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 80),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       before.length should be(1)
       before.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
       before.head.foreach(_.sideCode should be(SideCode.BothDirections))
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
       after.length should be(1)
       after.head.foreach(_.value should be(Some(SpeedLimitValue(80,false))))
@@ -717,11 +675,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
     // Combined road link (change types 1 and 2)
     // Speed limit case 1
-
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId1 = LinkIdGenerator.generateRandom()
     val oldLinkId2 = LinkIdGenerator.generateRandom()
@@ -762,12 +715,12 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset3,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 80),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((oldRoadLinks, Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList.flatten
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList.flatten
 
       before.length should be(3)
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList.flatten
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList.flatten
 
       after.length should be(1)
       after.head.modifiedBy should be(Some("KX2"))
@@ -787,21 +740,15 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     val boundingBox = BoundingRectangle(Point(123, 345), Point(567, 678))
 
     runWithRollback {
-      val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-      val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-
-      val provider = new SpeedLimitService(mockEventBus, mockRoadLinkService) {
-        override def withDynTransaction[T](f: => T): T = f
-      }
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(), Nil))
 
       provider.get(boundingBox, Set(municipalityCode))
 
-      verify(mockEventBus, times(1)).publish("speedLimits:update", ChangeSet(Set(), List(), List(), List(), Set(), List()))
-      verify(mockEventBus, times(1)).publish("speedLimits:saveProjectedSpeedLimits", List())
-      verify(mockEventBus, times(1)).publish("speedLimits:purgeUnknownLimits", (Set(), Seq()))
-      verify(mockEventBus, times(1)).publish("speedLimits:persistUnknownLimits", List())
+      verify(eventBus, times(1)).publish("speedLimits:update", ChangeSet(Set(), List(), List(), List(), Set(), List()))
+      verify(eventBus, times(1)).publish("speedLimits:saveProjectedSpeedLimits", List())
+      verify(eventBus, times(1)).publish("speedLimits:purgeUnknownLimits", (Set(), Seq()))
+      verify(eventBus, times(1)).publish("speedLimits:persistUnknownLimits", List())
 
     }
   }
@@ -836,11 +783,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
    }},
     */
 
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
-
     val oldLinkId = LinkIdGenerator.generateRandom()
     val municipalityCode = 235
     val administrativeClass = Municipality
@@ -865,7 +807,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       sqlu"""insert into single_choice_value (asset_id,enumerated_value_id,property_id) values ($asset1,(SELECT ev.id FROM enumerated_value ev, PROPERTY p WHERE p.ASSET_TYPE_ID = $speedLimitAssetTypeId AND p.id = ev.property_id AND ev.value = 80),(select id from property where public_id = 'rajoitus'))""".execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(oldRoadLink), Nil))
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
       //println(before)
 
@@ -874,7 +816,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       before.head.foreach(_.sideCode should be(SideCode.BothDirections))
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
       //println(after)
 
       after.length should be(1)
@@ -888,10 +830,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   // Works locally, won't work on CI because of number format.
   ignore("should return sensible repaired geometry after projection on overlapping data") {
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     val municipalityCode = 235
     val administrativeClass = Municipality
     val trafficDirection = TrafficDirection.BothDirections
@@ -1002,7 +940,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
 
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
       after.flatten.length should be (10)
       after.flatten.exists(_.id == 18040892) should be (false) // Removed too short, ~ 1 meter long
       after.flatten.filter(_.id == 0) should have size 1  // One orphaned or unknown segment in source data
@@ -1012,11 +950,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   }
   ignore("Must not expire assets that are outside of the current search even if mentioned in VVH change info") {
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     val municipalityCode = 235
     val administrativeClass = Municipality
     val trafficDirection = TrafficDirection.BothDirections
@@ -1045,7 +978,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((List(newRoadLink), changeInfo))
 
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
       provider.get(BoundingRectangle(Point(0.0, 0.0), Point(1.0, 1.0)), Set(235))
 
       verify(eventBus, times(1)).publish("speedLimits:update", ChangeSet(Set(), Seq(), Seq(), Seq(), Set(), Seq()))
@@ -1056,10 +989,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   test("Must be able to split one sided speedlimits and keep new speed limit") {
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     val municipalityCode = 235
     val administrativeClass = Municipality
     val trafficDirection = TrafficDirection.BothDirections
@@ -1092,19 +1021,19 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       when(mockRoadLinkService.getRoadLinkAndComplementaryFromVVH(any[String], any[Boolean])).thenReturn(Some(newRoadLink))
       when(mockRoadLinkService.fetchVVHRoadlinkAndComplementary(any[String])).thenReturn(Some(roadLinkFetched))
 
-      val before = service.get(boundingBox, Set(municipalityCode)).toList
+      val before = provider.get(boundingBox, Set(municipalityCode)).toList
 
 //      println("Before split")
 //      before.foreach(_.foreach(printSL))
 
-      val split = service.split(18050499, 419.599, 100, 80, "split", { (x: Int, y: AdministrativeClass) => })
+      val split = provider.split(18050499, 419.599, 100, 80, "split", { (x: Int, y: AdministrativeClass) => })
 
       split should have size(2);
 
 //      println("Split")
 //      split.foreach(printSL)
 
-      val after = service.get(boundingBox, Set(municipalityCode)).toList
+      val after = provider.get(boundingBox, Set(municipalityCode)).toList
 
 //      println("After split")
 //      after.foreach(_.foreach(printSL))
@@ -1122,10 +1051,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   ignore("Projecting and filling should return proper geometry on Integration API calls, too") {
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     val municipalityCode = 286
     val administrativeClass = Municipality
     val trafficDirection = TrafficDirection.BothDirections
@@ -1242,7 +1167,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.fetchVVHRoadlinksAndComplementary(any[Set[String]])).thenReturn(vvhRoadLinks)
 
-      val topology = service.get(municipalityCode)
+      val topology = provider.get(municipalityCode)
       topology.forall(sl => sl.id == 22696720 || sl.id == 0)  should be (true)
       topology.exists(_.id == 22696720) should be (true)
       topology.find(_.id == 22696720).get.value.getOrElse(0) should be (NumericValue(50))
@@ -1263,7 +1188,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       }
 
       // Stability check
-      val topologyAfterSave = service.get(municipalityCode)
+      val topologyAfterSave = provider.get(municipalityCode)
       topologyAfterSave.forall(sl =>
         topology.count(x =>
           x.linkId == sl.linkId && x.startMeasure == sl.startMeasure &&
@@ -1295,10 +1220,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   ignore ("Should stabilize on overlapping speed limits") {
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     val municipalityCode = 286
     val administrativeClass = Municipality
     val trafficDirection = TrafficDirection.BothDirections
@@ -1365,8 +1286,8 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.fetchVVHRoadlinksAndComplementary(any[Set[String]])).thenReturn(vvhRoadLinks)
 
-      val topology = service.get(municipalityCode).sortBy(_.startMeasure).sortBy(_.linkId)
-      topology.filter(_.id != 0).foreach(sl => service.dao.updateMValues(sl.id, (sl.startMeasure, sl.endMeasure), Some(sl.timeStamp)))
+      val topology = provider.get(municipalityCode).sortBy(_.startMeasure).sortBy(_.linkId)
+      topology.filter(_.id != 0).foreach(sl => provider.dao.updateMValues(sl.id, (sl.startMeasure, sl.endMeasure), Some(sl.timeStamp)))
       val newLimits = topology.filter(_.id == 0).map(sl => {
         val aId = Sequences.nextPrimaryKeySeqValue
         val lrmId = Sequences.nextLrmPositionPrimaryKeySeqValue
@@ -1383,7 +1304,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
       }
 
       // Stability check
-      val topologyAfterSave = service.get(municipalityCode)
+      val topologyAfterSave = provider.get(municipalityCode)
 
       topologyAfterSave.forall(_.id != 0) should be (true)
 
@@ -1413,10 +1334,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   test("Should filter out speed limits on walkways from TN-ITS message") {
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
     val roadLink1 = RoadLink(linkId1, List(Point(0.0, 0.0), Point(1.0, 0.0)), 10.0, Municipality, 8, TrafficDirection.BothDirections, CycleOrPedestrianPath, None, None, Map("MUNICIPALITYCODE" -> BigInt(345)))
     val roadLink2 = RoadLink(linkId2, List(Point(0.0, 0.0), Point(1.0, 0.0)), 10.0, Municipality, 5, TrafficDirection.BothDirections, Freeway, None, None, Map("MUNICIPALITYCODE" -> BigInt(345)))
@@ -1440,7 +1357,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
       when(mockRoadLinkService.getRoadLinksAndComplementariesFromVVH(any[Set[String]], any[Boolean])).thenReturn(Seq(roadLink1, roadLink2, roadLink3))
 
-      val result = service.getChanged(DateTime.parse("2016-11-01T12:00Z"), DateTime.parse("2016-11-02T12:00Z"))
+      val result = provider.getChanged(DateTime.parse("2016-11-01T12:00Z"), DateTime.parse("2016-11-02T12:00Z"))
       result.length should be(1)
       result.head.link.linkType should not be (TractorRoad)
       result.head.link.linkType should not be (CycleOrPedestrianPath)
@@ -1450,11 +1367,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   ignore("Ensure that when applying changes from change info doesn't create unknown speed limit"){
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
 
     val oldLinkId = LinkIdGenerator.generateRandom()
     val newLinkId1 = LinkIdGenerator.generateRandom()
@@ -1487,7 +1399,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
         """.execute
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((newRoadLinks, changeInfo))
-      val apeedLimits = service.get(boundingBox, Set(municipalityCode)).toList
+      val apeedLimits = provider.get(boundingBox, Set(municipalityCode)).toList
 
       verify(eventBus, times(1)).publish("speedLimits:persistUnknownLimits", Seq.empty)
       apeedLimits.length should be(3)
@@ -1497,12 +1409,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   ignore("Adjusts created speed limit, and goes through the saveProjectedLinearAssets actor, and not through the save unknowns"){
-    val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
-
     val oldLinkId = LinkIdGenerator.generateRandom()
     val newLinkId1 = LinkIdGenerator.generateRandom()
     val newLinkId2 = LinkIdGenerator.generateRandom()
@@ -1539,7 +1445,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
 
       when(mockRoadLinkService.getRoadLinksWithComplementaryAndChangesFromVVH(any[BoundingRectangle], any[Set[Int]], any[Boolean],any[Boolean])).thenReturn((newRoadLinks, changeInfo))
-      val apeedLimits = service.get(boundingBox, Set(municipalityCode)).toList
+      val apeedLimits = provider.get(boundingBox, Set(municipalityCode)).toList
 
 
       verify(eventBus, times(1)).publish("speedLimits:update", ChangeSet(Set(), List(), List(), Seq(), Set(asset), Seq()))
@@ -1555,10 +1461,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
 
   test("Delete link id from unknown speed limit list when that link does not exist anymore"){
-    val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
-      override def withDynTransaction[T](f: => T): T = f
-    }
     
     when(mockRoadLinkService.fetchVVHRoadlinks(any[Set[String]])).thenReturn(Seq())
 
@@ -1568,8 +1470,8 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     PostGISDatabase.withDynTransaction {
       sqlu"""INSERT INTO UNKNOWN_SPEED_LIMIT (MUNICIPALITY_CODE, ADMINISTRATIVE_CLASS, LINK_ID) VALUES ($municipalityCode, ${Municipality.value}, $oldLinkId)""".execute
 
-      service.purgeUnknown(Set(), Seq(oldLinkId))
-      val unknownSpeedLimits = service.dao.getMunicipalitiesWithUnknown(municipalityCode)
+      provider.purgeUnknown(Set(), Seq(oldLinkId))
+      val unknownSpeedLimits = provider.dao.getMunicipalitiesWithUnknown(municipalityCode)
 
       unknownSpeedLimits.isEmpty should be (true)
       dynamicSession.rollback()

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
@@ -1,8 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.FeatureClass.AllOthers
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.FeatureClass.AllOthers
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISSpeedLimitDao}
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.ChangeSet

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitServiceSpec.scala
@@ -25,8 +25,7 @@ import scala.language.implicitConversions
 
 class SpeedLimitServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val provider = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+  val provider = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
     override def withDynTransaction[T](f: => T): T = f
   }
 
@@ -61,7 +60,6 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   val roadLinkFetched = RoadLinkFetched(linkId5, 0, List(Point(0.0, 0.0), Point(0.0, 200.0)), Municipality, TrafficDirection.BothDirections, AllOthers)
 
   private def daoWithRoadLinks(roadLinks: Seq[RoadLinkFetched]): PostGISSpeedLimitDao = {
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
     
     when(mockRoadLinkService.fetchVVHRoadlinks(roadLinks.map(_.linkId).toSet))
       .thenReturn(roadLinks)
@@ -173,7 +171,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   ignore("request unknown speed limit persist in bounding box fetch") {
     runWithRollback {
       val eventBus = MockitoSugar.mock[DigiroadEventBus]
-      val provider = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+      val provider = new SpeedLimitService(eventBus, mockRoadLinkService) {
         override def withDynTransaction[T](f: => T): T = f
       }
 
@@ -186,7 +184,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   ignore("request unknown speed limit persist in municipality fetch") {
     runWithRollback {
       val eventBus = MockitoSugar.mock[DigiroadEventBus]
-      val provider = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+      val provider = new SpeedLimitService(eventBus, mockRoadLinkService) {
         override def withDynTransaction[T](f: => T): T = f
       }
 
@@ -276,8 +274,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 1
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -334,8 +331,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 2
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -417,8 +413,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 3
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -500,8 +495,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 1
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -569,8 +563,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 1
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -622,8 +615,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 1
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -675,8 +667,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 1
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -727,8 +718,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     // Speed limit case 1
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -796,11 +786,10 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     val boundingBox = BoundingRectangle(Point(123, 345), Point(567, 678))
 
     runWithRollback {
-      val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
       val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
       val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
 
-      val provider = new SpeedLimitService(mockEventBus, mockRoadLinkClient, mockRoadLinkService) {
+      val provider = new SpeedLimitService(mockEventBus, mockRoadLinkService) {
         override def withDynTransaction[T](f: => T): T = f
       }
 
@@ -847,8 +836,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
     */
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -900,8 +888,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   // Works locally, won't work on CI because of number format.
   ignore("should return sensible repaired geometry after projection on overlapping data") {
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     val municipalityCode = 235
@@ -1025,9 +1012,8 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
   }
   ignore("Must not expire assets that are outside of the current search even if mentioned in VVH change info") {
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     val municipalityCode = 235
@@ -1070,7 +1056,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   test("Must be able to split one sided speedlimits and keep new speed limit") {
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     val municipalityCode = 235
@@ -1136,7 +1122,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   ignore("Projecting and filling should return proper geometry on Integration API calls, too") {
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     val municipalityCode = 286
@@ -1309,7 +1295,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   ignore ("Should stabilize on overlapping speed limits") {
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     val municipalityCode = 286
@@ -1427,8 +1413,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   test("Should filter out speed limits on walkways from TN-ITS message") {
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
@@ -1465,9 +1450,8 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   ignore("Ensure that when applying changes from change info doesn't create unknown speed limit"){
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -1513,9 +1497,8 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   ignore("Adjusts created speed limit, and goes through the saveProjectedLinearAssets actor, and not through the save unknowns"){
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
 
@@ -1572,7 +1555,7 @@ class SpeedLimitServiceSpec extends FunSuite with Matchers {
 
   test("Delete link id from unknown speed limit list when that link does not exist anymore"){
     val eventBus = MockitoSugar.mock[DigiroadEventBus]
-    val service = new SpeedLimitService(eventBus, mockRoadLinkClient, mockRoadLinkService) {
+    val service = new SpeedLimitService(eventBus, mockRoadLinkService) {
       override def withDynTransaction[T](f: => T): T = f
     }
     

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
@@ -2,6 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, DummyEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
@@ -19,7 +19,6 @@ import slick.jdbc.{StaticQuery => Q}
 
 class TextValueLinearAssetServiceSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   private val (linkId, linkId2) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
   

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
@@ -36,7 +36,7 @@ class TextValueLinearAssetServiceSpec extends FunSuite with Matchers {
 
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
 
   object ServiceWithDao extends TextValueLinearAssetService(mockRoadLinkService, mockEventBus) {
     override def withDynTransaction[T](f: => T): T = f

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, DummyEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NumericValue, PersistedLinearAsset, RoadLink, TextualValue}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/linearasset/TextValueLinearAssetServiceSpec.scala
@@ -44,7 +44,6 @@ class TextValueLinearAssetServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
     override def getUncheckedLinearAssets(areas: Option[Set[Int]]) = throw new UnsupportedOperationException("Not supported method")
   }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/DirectionalTrafficSignServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/DirectionalTrafficSignServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/HeightLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/HeightLimitServiceSpec.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator, TestTransactions}
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MassTransitStopDao, MunicipalityDao, MunicipalityInfo, Sequences}
 import fi.liikennevirasto.digiroad2.dao.{RoadAddress => ViiteRoadAddress}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
@@ -4,7 +4,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{MassTransitStopDao, MunicipalityDao, MunicipalityInfo, Sequences}
 import fi.liikennevirasto.digiroad2.dao.{RoadAddress => ViiteRoadAddress}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
@@ -61,8 +61,7 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers with BeforeAndAf
     RoadLinkFetched(randomLinkId6, 91, List(Point(0.0,0.0), Point(120.0, 0.0)), Municipality, TrafficDirection.AgainstDigitizing, FeatureClass.AllOthers),
     RoadLinkFetched(randomLinkId7, 91, List(Point(0.0,0.0), Point(120.0, 0.0)), Municipality, TrafficDirection.UnknownDirection, FeatureClass.AllOthers, attributes = Map("ROADNAME_SE" -> "roadname_se",
       "ROADNAME_FI" -> "roadname_fi")))
-
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
+  
   val mockGeometryTransform = MockitoSugar.mock[GeometryTransform]
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleServiceSpec.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FunSuite, Matchers}
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment, SideCodeAdjustment}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
@@ -77,7 +77,6 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
     override def roadLinkService: RoadLinkService = mockRoadLinkService
     override def dao: PostGISLinearAssetDao = linearAssetDao
     override def eventBus: DigiroadEventBus = mockEventBus
-    override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override def polygonTools: PolygonTools = mockPolygonTools
 
     override def getUncheckedLinearAssets(areas: Option[Set[Int]]) = throw new UnsupportedOperationException("Not supported method")
@@ -94,7 +93,6 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
     val service = new PavedRoadService(mockRoadLinkService, new DummyEventBus) {
       override def withDynTransaction[T](f: => T): T = f
-      override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     }
     service
   }
@@ -470,7 +468,6 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
   test("Expire OTH Assets and create new assets based on VVH RoadLink data") {
     val service = new PavedRoadService(mockRoadLinkService, new DummyEventBus) {
       override def withDynTransaction[T](f: => T): T = f
-      override def roadLinkClient: RoadLinkClient = mockRoadLinkClient
     }
     val assetTypeId = 110
     val municipalityCode = 564

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
@@ -22,7 +22,6 @@ import slick.jdbc.StaticQuery.interpolation
 class PavedRoadServiceSpec extends FunSuite with Matchers {
 
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]
@@ -89,7 +88,6 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
   val assetLock = "Used to prevent deadlocks"
 
   private def createService() = {
-    val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
     val service = new PavedRoadService(mockRoadLinkService, new DummyEventBus) {
       override def withDynTransaction[T](f: => T): T = f
@@ -126,7 +124,7 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
   test("Should not create new paved road assets and return the existing paved road assets when VVH doesn't have change information") {
 
     val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-    when(mockRoadLinkService.roadLinkClient).thenReturn(mockRoadLinkClient)
+  
     val service = new PavedRoadService(mockRoadLinkService, new DummyEventBus) {
       override def withDynTransaction[T](f: => T): T = f
       override def withDynSession[T](f: => T): T = f
@@ -588,8 +586,6 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
   }
 
   ignore("Adjust projected asset with creation"){
-    val timeStamp = LinearAssetUtils.createTimeStamp(-5)
-    when(mockRoadLinkService.roadLinkClient).thenReturn(mockRoadLinkClient)
 
     val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
     val service = new PavedRoadService(mockRoadLinkService, mockEventBus) {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
@@ -27,7 +27,7 @@ class PavedRoadServiceSpec extends FunSuite with Matchers {
   val mockLinearAssetDao = MockitoSugar.mock[PostGISLinearAssetDao]
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val dynamicLinearAssetDao = new DynamicLinearAssetDao()
 
   val multiTypePropSeq = DynamicAssetValue(Seq(DynamicProperty("suggest_box","checkbox",required = false,List()),DynamicProperty("paallysteluokka", "single_choice", required = false, Seq(DynamicPropertyValue("50")))))

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadServiceSpec.scala
@@ -2,6 +2,7 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, Sequences}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PedestrianCrossingServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PedestrianCrossingServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import fi.liikennevirasto.digiroad2.dao.pointasset.{PedestrianCrossing, PostGISPedestrianCrossingDao}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingServiceSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightServiceSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.pointasset.TrafficLight
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignServiceSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.service.pointasset
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, BothDirections, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{PostGISUserProvider, Queries}
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/WeightLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/WeightLimitServiceSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/WidthLimitServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/WidthLimitServiceSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service.pointasset
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporterSpec.scala
@@ -5,6 +5,7 @@ import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.VVHChangeInfoClient
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{Queries, RoadLinkDAO, Sequences}
 import fi.liikennevirasto.digiroad2.dao.pointasset.Obstacle

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/AssetDataImporterSpec.scala
@@ -5,7 +5,7 @@ import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.{Queries, RoadLinkDAO, Sequences}
 import fi.liikennevirasto.digiroad2.dao.pointasset.Obstacle
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/PolygonToolsSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/PolygonToolsSpec.scala
@@ -8,7 +8,7 @@ import org.geotools.geometry.jts.GeometryBuilder
 import fi.liikennevirasto.digiroad2.asset.BoundingRectangle
 import fi.liikennevirasto.digiroad2.Point
 import com.vividsolutions.jts.io.WKTReader
-import fi.liikennevirasto.digiroad2.client.vvh.{Filter, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.Filter
 import fi.liikennevirasto.digiroad2.service.linearasset.Measures
 
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemovalSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.asset.{Municipality, TrafficDirection}
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.RoadLinkOverrideDAO
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinksSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinksSpec.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset.{SideCode, _}
 import fi.liikennevirasto.digiroad2.client.VKMClient
-import fi.liikennevirasto.digiroad2.client.vvh.RoadLinkClient
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}
 import fi.liikennevirasto.digiroad2.util.Track.{Combined, LeftSide, RightSide}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RoadLinkHistoryProcessorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RoadLinkHistoryProcessorSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.{Municipality, TrafficDirection}
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, HistoryRoadLink, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, HistoryRoadLink, RoadLinkFetched}
 import org.scalatest.{FunSuite, Matchers}
 
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RoundaboutProcessorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RoundaboutProcessorSpec.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import org.scalatest.{FunSuite, Matchers}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGeneratorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGeneratorSpec.scala
@@ -21,7 +21,7 @@ import org.mockito.ArgumentMatchers.any
 class TrafficSignLinearGeneratorSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockProhibitionService = MockitoSugar.mock[ProhibitionService]
 
   class TestTrafficSignProhibitionGenerator extends TrafficSignProhibitionGenerator(mockRoadLinkService) {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGeneratorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGeneratorSpec.scala
@@ -29,7 +29,6 @@ class TrafficSignLinearGeneratorSpec extends FunSuite with Matchers {
     override def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
     override lazy val postGisLinearAssetDao: PostGISLinearAssetDao = linearAssetDao
     override lazy val roadLinkService: RoadLinkService = mockRoadLinkService
-    override lazy val roadLinkClient: RoadLinkClient = mockRoadLinkClient
     override lazy val prohibitionService = mockProhibitionService
 
     case class createdObjectTest(id: Long, linkId: String, value: Value, sideCode: Int, startMeasure: Double, endMeasure: Double, roadLink: RoadLink)
@@ -410,7 +409,6 @@ class TrafficSignLinearGeneratorSpec extends FunSuite with Matchers {
     override def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
     override lazy val postGisLinearAssetDao: PostGISLinearAssetDao = linearAssetDao
     override lazy val roadLinkService: RoadLinkService = mockRoadLinkService
-    override lazy val roadLinkClient: RoadLinkClient = mockRoadLinkClient
   }
 
   val hazmatTransportProhibitionGenerator = new TestTrafficSignHazmatTransportProhibitionGenerator()
@@ -442,7 +440,6 @@ class TrafficSignLinearGeneratorSpec extends FunSuite with Matchers {
 
     override lazy val postGisLinearAssetDao: PostGISLinearAssetDao = linearAssetDao
     override lazy val roadLinkService: RoadLinkService = mockRoadLinkService
-    override lazy val roadLinkClient: RoadLinkClient = mockRoadLinkClient
   }
 
   test("parking generate segments additional panel DistanceFromSignToPointWhichSignApplies") {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGeneratorSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGeneratorSpec.scala
@@ -6,7 +6,6 @@ import fi.liikennevirasto.digiroad2.asset.ProhibitionClass.{Bus => _, _}
 import fi.liikennevirasto.digiroad2.dao.pointasset.PersistedTrafficSign
 import org.mockito.Mockito._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh._
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
@@ -15,12 +14,12 @@ import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
 import fi.liikennevirasto.digiroad2.asset.HazmatTransportProhibitionClass.{HazmatProhibitionTypeA, HazmatProhibitionTypeB}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.service.linearasset.ProhibitionService
 import org.mockito.ArgumentMatchers.any
 
 class TrafficSignLinearGeneratorSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val linearAssetDao = new PostGISLinearAssetDao()
   val mockProhibitionService = MockitoSugar.mock[ProhibitionService]
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/DynamicLinearAssetUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/DynamicLinearAssetUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.{CombinedRemovedPart, Removed}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.DynamicLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{DynamicAssetValue, DynamicValue, NumericValue, RoadLink}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/DynamicLinearAssetUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/DynamicLinearAssetUpdaterSpec.scala
@@ -19,7 +19,7 @@ class DynamicLinearAssetUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]
   val service = new DynamicLinearAssetService(mockRoadLinkService, mockEventBus)
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/HazMatTransportProhibitionUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/HazMatTransportProhibitionUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset.{Freeway, HazmatTransportProhibition, Municipality, TrafficDirection}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.DividedNewPart
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{ProhibitionValue, Prohibitions, RoadLink}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/HazMatTransportProhibitionUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/HazMatTransportProhibitionUpdaterSpec.scala
@@ -18,7 +18,7 @@ class HazMatTransportProhibitionUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val service = new HazmatTransportProhibitionService(mockRoadLinkService, mockEventBus)
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
@@ -19,7 +19,7 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]
   val service = new LinearAssetService(mockRoadLinkService, mockEventBus)
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.Removed
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.DynamicLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NumericValue, RoadLink}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.{CombinedRemovedPart, Removed}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISMaintenanceDao}
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset.{DynamicAssetValue, DynamicValue, RoadLink}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdaterSpec.scala
@@ -28,7 +28,7 @@ class MaintenanceRoadUpdaterSpec extends FunSuite with Matchers{
   val mockAssetDao = MockitoSugar.mock[PostGISAssetDao]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val linearAssetDao = new PostGISLinearAssetDao()
-  val maintenanceDao = new PostGISMaintenanceDao(mockRoadLinkClient, mockRoadLinkService)
+  val maintenanceDao = new PostGISMaintenanceDao()
   val dynamicLinearAssetDAO = new DynamicLinearAssetDao
 
   object Service extends MaintenanceService(mockRoadLinkService, mockEventBus) {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdaterSpec.scala
@@ -27,7 +27,7 @@ class MaintenanceRoadUpdaterSpec extends FunSuite with Matchers{
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
   val mockAssetDao = MockitoSugar.mock[PostGISAssetDao]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val maintenanceDao = new PostGISMaintenanceDao(mockRoadLinkClient, mockRoadLinkService)
   val dynamicLinearAssetDAO = new DynamicLinearAssetDao
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdaterSpec.scala
@@ -18,14 +18,12 @@ import org.scalatest.{FunSuite, Matchers}
 class PavedRoadUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockRoadLinkData = MockitoSugar.mock[OldVVHRoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]
   val mockAssetDao = MockitoSugar.mock[PostGISAssetDao]
   val mockDynamicLinearAssetDao = MockitoSugar.mock[DynamicLinearAssetDao]
-  when(mockRoadLinkClient.roadLinkData).thenReturn(mockRoadLinkData)
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdaterSpec.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.{CombinedRemovedPart, Removed}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, OldVVHRoadLinkClient, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.linearasset.{DynamicAssetValue, DynamicValue, NumericValue, RoadLink}
@@ -18,7 +18,6 @@ import org.scalatest.{FunSuite, Matchers}
 class PavedRoadUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
-  val mockRoadLinkData = MockitoSugar.mock[OldVVHRoadLinkClient]
   val mockPolygonTools = MockitoSugar.mock[PolygonTools]
   val linearAssetDao = new PostGISLinearAssetDao()
   val mockMunicipalityDao = MockitoSugar.mock[MunicipalityDao]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ProhibitionUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ProhibitionUpdaterSpec.scala
@@ -17,7 +17,7 @@ class ProhibitionUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val service = new ProhibitionService(mockRoadLinkService, mockEventBus)
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ProhibitionUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ProhibitionUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.{CombinedRemovedPart, Removed}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{ProhibitionValue, Prohibitions, RoadLink}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.{CombinedRemovedPart, Removed}
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, RoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo}
 import fi.liikennevirasto.digiroad2.dao.DynamicLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset.{NumericValue, RoadLink}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdaterSpec.scala
@@ -20,7 +20,7 @@ class RoadWidthUpdaterSpec extends FunSuite with Matchers {
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   val service = new RoadWidthService(mockRoadLinkService, mockEventBus)
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -25,7 +25,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
   val service = new SpeedLimitService(mockEventBus, mockRoadLinkClient, mockRoadLinkService)
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
-  object TestSpeedLimitUpdater extends SpeedLimitUpdater(mockEventBus, mockRoadLinkClient, mockRoadLinkService, service) {
+  object TestSpeedLimitUpdater extends SpeedLimitUpdater(mockEventBus, mockRoadLinkService, service) {
     override val dao: PostGISSpeedLimitDao = new PostGISSpeedLimitDao(mockRoadLinkService)
   }
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -19,9 +19,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
   val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
-  val mockRoadLinkData = MockitoSugar.mock[OldVVHRoadLinkClient]
   val linearAssetDao = new PostGISLinearAssetDao()
-  when(mockRoadLinkClient.roadLinkData).thenReturn(mockRoadLinkData)
   val service = new SpeedLimitService(mockEventBus, mockRoadLinkClient, mockRoadLinkService)
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
@@ -57,7 +55,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
       when(mockRoadLinkService.fetchVVHRoadlinkAndComplementary(oldLinkId)).thenReturn(Some(RoadLinkFetched(oldLinkId, oldRoadLink.municipalityCode, oldRoadLink.geometry,
         administrativeClass, trafficDirection, CarRoad_IIIa, None, Map(), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface, 25)))
       service.create(Seq(NewLimit(oldLinkId, 0.0, 25.0)), SpeedLimitValue(30), "test", (_, _) => Unit)
-      when(mockRoadLinkClient.roadLinkData.fetchByLinkIds(any[Set[String]])).thenReturn(Seq())
+      when(mockRoadLinkService.fetchVVHRoadlinks(any[Set[String]])).thenReturn(Seq())
       TestSpeedLimitUpdater.updateByRoadLinks(municipalityCode, newRoadLinks, changeInfo)
       newRoadLinks.sortBy(_.linkId).foreach { roadLink =>
         val asset = service.getExistingAssetByRoadLink(roadLink, false)
@@ -98,7 +96,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
         administrativeClass, trafficDirection, CarRoad_IIIa, None, Map(), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface, 5)))
       service.create(Seq(NewLimit(oldLinkId1, 0.0, 10.0), NewLimit(oldLinkId2, 0.0, 10.0),
         NewLimit(oldLinkId2, 0.0, 5.0)), SpeedLimitValue(30), "test", (_, _) => Unit)
-      when(mockRoadLinkClient.roadLinkData.fetchByLinkIds(any[Set[String]])).thenReturn(Seq())
+      when(mockRoadLinkService.fetchVVHRoadlinks(any[Set[String]])).thenReturn(Seq())
       TestSpeedLimitUpdater.updateByRoadLinks(municipalityCode, Seq(newRoadLink), changeInfo)
       val newAsset = service.getExistingAssetByRoadLink(newRoadLink, false).head
       newAsset.linkId should be(newRoadLink.linkId)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -26,7 +26,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
   object TestSpeedLimitUpdater extends SpeedLimitUpdater(mockEventBus, mockRoadLinkClient, mockRoadLinkService, service) {
-    override val dao: PostGISSpeedLimitDao = new PostGISSpeedLimitDao(mockRoadLinkClient, mockRoadLinkService)
+    override val dao: PostGISSpeedLimitDao = new PostGISSpeedLimitDao(mockRoadLinkService)
   }
 
   test("Should map the speed limit of an old link to three new links") {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -1,8 +1,9 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater
 
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.FeatureClass.CarRoad_IIIa
-import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, OldVVHRoadLinkClient, RoadLinkClient, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.client.FeatureClass.CarRoad_IIIa
+import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo
+import fi.liikennevirasto.digiroad2.client.{RoadLinkClient, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.dao.linearasset.{PostGISLinearAssetDao, PostGISSpeedLimitDao}
 import fi.liikennevirasto.digiroad2.linearasset.{NewLimit, RoadLink, SpeedLimitValue}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -20,7 +20,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val linearAssetDao = new PostGISLinearAssetDao()
-  val service = new SpeedLimitService(mockEventBus, mockRoadLinkClient, mockRoadLinkService)
+  val service = new SpeedLimitService(mockEventBus, mockRoadLinkService)
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
   object TestSpeedLimitUpdater extends SpeedLimitUpdater(mockEventBus, mockRoadLinkService, service) {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -20,7 +20,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers{
   val mockEventBus = MockitoSugar.mock[DigiroadEventBus]
   val mockRoadLinkClient = MockitoSugar.mock[RoadLinkClient]
   val mockRoadLinkData = MockitoSugar.mock[OldVVHRoadLinkClient]
-  val linearAssetDao = new PostGISLinearAssetDao(mockRoadLinkClient, mockRoadLinkService)
+  val linearAssetDao = new PostGISLinearAssetDao()
   when(mockRoadLinkClient.roadLinkData).thenReturn(mockRoadLinkData)
   val service = new SpeedLimitService(mockEventBus, mockRoadLinkClient, mockRoadLinkService)
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)


### PR DESCRIPTION
RoadlinkClient irrotus vvh koodista ja siirto omaan paikaan. KGV koodi omaan kansioon. Timestamp muutoksen jälkeen turhiksi muuttuneen roadlinkclient tai roadlinkservice injectiot poistettu.