### PR TITLE
Droth 3274 remove vvh from roadlink override dao

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_10__rename_vvh_administrative_class_column.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_10__rename_vvh_administrative_class_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE administrative_class RENAME COLUMN vvh_administrative_class to master_data_administrative_class;

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -813,7 +813,7 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
         insertLinkProperty(propertyName, linkProperty, roadLinkFetched, username, latestModifiedAt, latestModifiedBy)
 
       case (None, Some(masterDataValue)) =>
-        if (masterDataValue != RoadLinkOverrideDAO.getValue(propertyName, linkProperty)) // only save if it overrides VVH provided value
+        if (masterDataValue != RoadLinkOverrideDAO.getValue(propertyName, linkProperty)) // only save if it overrides master data value
           insertLinkProperty(propertyName, linkProperty, roadLinkFetched, username, latestModifiedAt, latestModifiedBy)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -806,14 +806,14 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
                                 roadLinkFetched: RoadLinkFetched, latestModifiedAt: Option[String],
                                 latestModifiedBy: Option[String]) = {
     val optionalExistingValue: Option[Int] = RoadLinkOverrideDAO.get(propertyName, linkProperty.linkId)
-    (optionalExistingValue, RoadLinkOverrideDAO.getVVHValue(propertyName, roadLinkFetched)) match {
+    (optionalExistingValue, RoadLinkOverrideDAO.getMasterDataValue(propertyName, roadLinkFetched)) match {
       case (Some(existingValue), _) =>
         RoadLinkOverrideDAO.update(propertyName, linkProperty, roadLinkFetched, username, existingValue, checkMMLId(roadLinkFetched))
       case (None, None) =>
         insertLinkProperty(propertyName, linkProperty, roadLinkFetched, username, latestModifiedAt, latestModifiedBy)
 
-      case (None, Some(vvhValue)) =>
-        if (vvhValue != RoadLinkOverrideDAO.getValue(propertyName, linkProperty)) // only save if it overrides VVH provided value
+      case (None, Some(masterDataValue)) =>
+        if (masterDataValue != RoadLinkOverrideDAO.getValue(propertyName, linkProperty)) // only save if it overrides VVH provided value
           insertLinkProperty(propertyName, linkProperty, roadLinkFetched, username, latestModifiedAt, latestModifiedBy)
     }
   }
@@ -1095,13 +1095,13 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
       val optionalExistingValues = RoadLinkOverrideDAO.getValues(propertyName, entries.map(_.linkProperty.linkId))
       for (entry <- entries) {
         val optionalExistingValue = optionalExistingValues.find(_.linkId == entry.linkProperty.linkId)
-        (optionalExistingValue, RoadLinkOverrideDAO.getVVHValue(entry.propertyName, entry.roadLinkFetched)) match {
+        (optionalExistingValue, RoadLinkOverrideDAO.getMasterDataValue(entry.propertyName, entry.roadLinkFetched)) match {
           case (Some(_), _) =>
             updateValues.append(entry)
           case (None, None) =>
             insertValues.append(entry)
-          case (None, Some(vvhValue)) =>
-            if (vvhValue != RoadLinkOverrideDAO.getValue(entry.propertyName, entry.linkProperty))
+          case (None, Some(masterDataValue)) =>
+            if (masterDataValue != RoadLinkOverrideDAO.getValue(entry.propertyName, entry.linkProperty))
               insertValues.append(entry) // only if it override vvh value
           case _ => Unit
         }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RedundantTrafficDirectionRemoval.scala
@@ -13,10 +13,10 @@ class RedundantTrafficDirectionRemoval(roadLinkService: RoadLinkService) {
 
     def findAndDeleteRedundant(roadLinkFetched: RoadLinkFetched): Unit = {
       val optionalExistingValue: Option[Int] = RoadLinkOverrideDAO.get(RoadLinkOverrideDAO.TrafficDirection, roadLinkFetched.linkId)
-      val optionalVVHValue: Option[Int] = RoadLinkOverrideDAO.getVVHValue(RoadLinkOverrideDAO.TrafficDirection, roadLinkFetched)
-      (optionalExistingValue, optionalVVHValue) match {
-        case (Some(existingValue), Some(vvhValue)) =>
-          if (existingValue == vvhValue) {
+      val optionalMasterDataValue: Option[Int] = RoadLinkOverrideDAO.getMasterDataValue(RoadLinkOverrideDAO.TrafficDirection, roadLinkFetched)
+      (optionalExistingValue, optionalMasterDataValue) match {
+        case (Some(existingValue), Some(masterDataValue)) =>
+          if (existingValue == masterDataValue) {
             RoadLinkOverrideDAO.delete(RoadLinkOverrideDAO.TrafficDirection, roadLinkFetched.linkId)
           }
         case (_, _) =>


### PR DESCRIPTION
Korvattu "vvh" termillä "masterData" roadlinkOverrideDAOssa ja sitä käyttävissä funktioissa sekä tietokannan administrative_class -taulussa.