### PR TITLE
DROTH-3403 Remove fetching of sourceinfo from table

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
@@ -43,7 +43,6 @@ class ComplementaryLinkDAO extends RoadLinkDAO {
       val surfaceType = r.nextInt()
       val subType = r.nextInt()
       val objectId = r.nextLong()
-      val sourceInfo = r.nextInt()
       val length  = r.nextDouble()
       val custOwner = r.nextLongOption()
 
@@ -95,7 +94,7 @@ class ComplementaryLinkDAO extends RoadLinkDAO {
       sql"""select linkid, municipalitycode, shape, adminclass, directiontype, mtkclass, roadname_fi, roadname_se,
                  roadname_sm, roadnumber, roadpartnumber, constructiontype, verticallevel, horizontalaccuracy,
                  verticalaccuracy, created_date, last_edited_date, from_left, to_left, from_right, to_right, validfrom,
-                 geometry_edited_date, surfacetype, subtype, objectid, sourceinfo, geometrylength, cust_owner
+                 geometry_edited_date, surfacetype, subtype, objectid, geometrylength, cust_owner
           from roadlinkex
           where subtype = 3 and #$filter
           """.as[VVHRoadlink].list

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -143,7 +143,6 @@ class RoadLinkDAO {
       val objectId = r.nextLong()
       val startNode = r.nextLong()
       val endNode = r.nextLong()
-      val sourceInfo = r.nextInt()
       val length  = r.nextDouble()
 
       val geometry = path.map(point => Point(point(0), point(1), point(2)))
@@ -188,7 +187,7 @@ class RoadLinkDAO {
 
       VVHRoadlink(linkId, municipality, geometry, AdministrativeClass.apply(administrativeClass),
         extractTrafficDirection(directionType), featureClass, modifiedAt, attributes,
-        ConstructionType.apply(constructionType), LinkGeomSource.apply(sourceInfo), length)
+        ConstructionType.apply(constructionType), LinkGeomSource.NormalLinkInterface, length)
     }
   }
 
@@ -334,7 +333,7 @@ class RoadLinkDAO {
      sql"""select linkid, mtkid, mtkhereflip, municipalitycode, shape, adminclass, directiontype, mtkclass, roadname_fi,
                  roadname_se, roadname_sm, roadnumber, roadpartnumber, constructiontype, verticallevel, horizontalaccuracy,
                  verticalaccuracy, created_date, last_edited_date, from_left, to_left, from_right, to_right, validfrom,
-                 geometry_edited_date, surfacetype, subtype, objectid, startnode, endnode, sourceinfo, geometrylength
+                 geometry_edited_date, surfacetype, subtype, objectid, startnode, endnode, geometrylength
           from roadlink
           where #$filter and constructiontype in (${ConstructionType.InUse.value},
                                                   ${ConstructionType.UnderConstruction.value},


### PR DESCRIPTION
Käytetään kannasta haettavilla normaaleilla tielinkeillä suoraan linkSource arvona NormalLinkInterface. Ei tarvetta hakea kannasta sourceinfo arvoa.