### PR TITLE
DROTH-3373 New method for resolving data-value attribute value

### DIFF
--- a/UI/src/utils/text-utils.js
+++ b/UI/src/utils/text-utils.js
@@ -1,0 +1,14 @@
+(function (root) {
+    /**
+     * Removes scandic characters and replaces spaces with -
+     * i.e. "Linja- ja kuorma-autojen pysäköintialue" => "linja-ja-kuorma-autojen-pysakointialue"
+     */
+    root.toDataValue = function (text) {
+        return text.trim().toLowerCase()
+            .replace(/ä/g, 'a')
+            .replace(/ö/g, 'o')
+            .replace(/å/g, 'a')
+            .replace(/ /g, '-')
+            .replace(/--/g, '-');
+    };
+})(window.TextUtils = window.TextUtils || {});

--- a/UI/src/view/dynamicAssetForm.js
+++ b/UI/src/view/dynamicAssetForm.js
@@ -264,7 +264,7 @@
                 var selected = value.id.toString() === selectedValue ? " selected" : "";
                 var disabled = value.disabled ?  'disabled' : '';
                 var hidden = _.isUndefined(value.hidden) ? false : value.hidden(assetTypeConfiguration.selectedLinearAsset.get(), value.id);
-                return  hidden ? '' : '<option value="' + value.id + '" data-value="' + value.label + '" ' + selected + ' '+ disabled +'>' + value.label + '</option>';
+                return  hidden ? '' : '<option value="' + value.id + '" data-value="' + TextUtils.toDataValue(value.label) + '" ' + selected + ' '+ disabled +'>' + value.label + '</option>';
             }).join('');
 
             me.element = $(template({className: className, optionTags: optionTags, disabled: me.disabled(), name: field.publicId, fieldType: field.type, required: me.required()}));

--- a/UI/src/view/linear_asset/prohibitionFormElements.js
+++ b/UI/src/view/linear_asset/prohibitionFormElements.js
@@ -142,7 +142,7 @@
         function typeElement() {
           var optionTags = _.map(prohibitionValues, function (prohibitionValue) {
             var selected = prohibition.typeId === prohibitionValue.typeId ? 'selected' : '';
-            return '<option value="' + prohibitionValue.typeId + '" data-value="' + prohibitionValue.title + '" ' + selected + '>' + prohibitionValue.title + '</option>';
+            return '<option value="' + prohibitionValue.typeId + '" data-value="' + TextUtils.toDataValue(prohibitionValue.title) + '" ' + selected + '>' + prohibitionValue.title + '</option>';
           }).join('');
           return '' +
             '<div class="form-group prohibition-type">' +
@@ -273,7 +273,7 @@
         var elements = _.map(exceptionValues, function (exceptionValue) {
           var selected = exception && (exception === exceptionValue.typeId) ? 'selected' : '';
           return '' +
-            '<option value="' + exceptionValue.typeId + '" data-value="' + exceptionValue.title + '" ' + selected + '>' +
+            '<option value="' + exceptionValue.typeId + '" data-value="' + TextUtils.toDataValue(exceptionValue.title) + '" ' + selected + '>' +
             exceptionValue.title +
             '</option>';
         });
@@ -318,7 +318,7 @@
 
       function newProhibitionElement() {
         var optionTags = _.map(prohibitionValues, function (prohibitionValue) {
-          return '<option value="' + prohibitionValue.typeId + '" data-value="' + prohibitionValue.title + '">' + prohibitionValue.title + '</option>';
+          return '<option value="' + prohibitionValue.typeId + '" data-value="' + TextUtils.toDataValue(prohibitionValue.title) + '">' + prohibitionValue.title + '</option>';
         }).join('');
         return '' +
           '<li><div class="form-group new-prohibition">' +

--- a/UI/src/view/point_asset/servicePointForm.js
+++ b/UI/src/view/point_asset/servicePointForm.js
@@ -197,7 +197,7 @@
 
     var renderService = function (service) {
       var serviceTypeLabelOptions = _.map(serviceTypes, function(serviceType) {
-        return $('<option>', {value: serviceType.value, "data-value": serviceType.label, selected: service.serviceType === serviceType.value, text: serviceType.label})[0].outerHTML;
+        return $('<option>', {value: serviceType.value, "data-value": TextUtils.toDataValue(serviceType.label), selected: service.serviceType === serviceType.value, text: serviceType.label})[0].outerHTML;
       }).join('');
 
       var selectedServiceType = _.find(serviceTypes, { value: service.serviceType });
@@ -270,7 +270,7 @@
 
     function renderNewServiceElement() {
       var serviceTypeLabelOptions = _.map(serviceTypes, function(serviceType) {
-        return $('<option>', {value: serviceType.value, text: serviceType.label, "data-value": serviceType.label})[0].outerHTML;
+        return $('<option>', {value: serviceType.value, text: serviceType.label, "data-value": TextUtils.toDataValue(serviceType.label)})[0].outerHTML;
       }).join('');
 
       return '' +
@@ -286,7 +286,7 @@
       var extensions = serviceTypeExtensions[service.serviceType];
       if (extensions) {
         var extensionOptions = _.map(extensions, function(extension) {
-          return $('<option>', {value: extension.value, text: extension.label, "data-value": extension.label, selected: extension.value === service.typeExtension})[0].outerHTML;
+          return $('<option>', {value: extension.value, text: extension.label, "data-value": TextUtils.toDataValue(extension.label), selected: extension.value === service.typeExtension})[0].outerHTML;
         }).join('');
         var currentExtensionType = _.find(extensions, {value: service.typeExtension});
         return '' +

--- a/UI/test/integration-tests.html
+++ b/UI/test/integration-tests.html
@@ -24,6 +24,7 @@
     <script type="text/javascript" src="../src/utils/zoom-levels.js"></script>
     <script type="text/javascript" src="../src/utils/validity-directions.js"></script>
     <script type="text/javascript" src="../src/utils/laneUtils.js"></script>
+    <script type="text/javascript" src="../src/utils/text-utils.js"></script>
     <title>Digiroad 2 Integration Tests</title>
 </head>
 <body>

--- a/UI/tmpl/index.html
+++ b/UI/tmpl/index.html
@@ -98,6 +98,7 @@
 <script type="text/javascript" src="src/utils/zoom-levels.js"></script>
 <script type="text/javascript" src="src/utils/validity-directions.js"></script>
 <script type="text/javascript" src="src/utils/laneUtils.js"></script>
+<script type="text/javascript" src="src/utils/text-utils.js"></script>
 <script type="text/javascript" src="src/utils/roadAddressInfoPopup.js"></script>
 <script type="text/javascript" src="src/utils/data-import-backend.js"></script>
 <script type="text/javascript" src="src/authorizationpolicies/authorizationPolicy.js"></script>


### PR DESCRIPTION
Paranneltu data-value attribuutin muodostumista UI:lla. Luotu utils metodi joka korvaa merkkijonosta merkit å -> a, ä -> a, ö -> o sekä " " -> "-". Esim "Linja- ja kuorma-autojen pysäköintialue" => "linja-ja-kuorma-autojen-pysakointialue". Muutos koskee kaikkia tietolajeja, joihin on aiemmin lisätty data-value attribuutti.