### PR TITLE
DROTH-3389 Special handling for RestAreas

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/MainLanePopulationProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/MainLanePopulationProcess.scala
@@ -74,7 +74,8 @@ object MainLanePopulationProcess {
         Seq(roadLink.copy(trafficDirection = TrafficDirection.TowardsDigitizing),
             roadLink.copy(trafficDirection = TrafficDirection.AgainstDigitizing))
       case _ if twoWayLane =>
-        Seq(roadLink.copy(trafficDirection = TrafficDirection.BothDirections))
+        if (roadLink.linkType == RestArea) Seq(roadLink)
+        else Seq(roadLink.copy(trafficDirection = TrafficDirection.BothDirections))
       case _ =>
         Seq(roadLink)
     }


### PR DESCRIPTION
Levähdysalueille halutaan luoda 31-kaista vain, jos liikennevirran suunta on linkillä kumpaankin suuntaan. Muuten luodaan liikennöinti suunnan mukainen kaista. Toteutettu tämä