### PR TITLE
Droth 3097 lane work list

### DIFF
--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -1075,7 +1075,7 @@
       $.ajax({
         contentType: "application/json",
         type: "DELETE",
-        url: "api/laneWorkList/delete",
+        url: "api/laneWorkList/",
         data: JSON.stringify(data),
         dataType: "json",
         success: success,

--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -1075,7 +1075,7 @@
       $.ajax({
         contentType: "application/json",
         type: "DELETE",
-        url: "api/laneWorkList/",
+        url: "api/laneWorkList",
         data: JSON.stringify(data),
         dataType: "json",
         success: success,

--- a/UI/src/view/laneWorkList.js
+++ b/UI/src/view/laneWorkList.js
@@ -51,9 +51,7 @@
             var trafficDirectionHeader = $('<h2/>').html("Tielinkin liikennevirran suuntaa muutettu");
             var linkTypeHeader = $('<h2/>').html("<br>Tielinkin tyypin muutos vaikuttaa kaistojen lukumäärään");
             var tableContentRows = function (items) {
-                var itemsSorted = _.sortBy(items, function (item) {
-                    return item.createdAt;
-                });
+                var itemsSorted = _.sortBy(items, ["createdAt", "linkId"]);
                 return _.map(itemsSorted, function (item) {
                     return $('<tr/>')
                         .append(checkbox(item.id))

--- a/UI/src/view/link_property/linkPropertyForm.js
+++ b/UI/src/view/link_property/linkPropertyForm.js
@@ -80,7 +80,7 @@
 
     var laneConfirmationPopUp = function (target, selectedValue) {
       return {
-        message: "Vastakkaisen suunnan kaistat lakkautetaan.",
+        message: "Tielinkki nousee kaistojen tarkastuslistalle.",
         type: "confirm",
         yesButtonLbl: 'Kyllä',
         noButtonLbl: 'Ei',

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -295,13 +295,8 @@ class TrafficSignUpdateAssets(trafficSignService: TrafficSignService, trafficSig
 
 class LaneWorkListInsertItem(laneWorkListService: LaneWorkListService) extends Actor {
   def receive = {
-    case x: (String, Option[Int],LinkProperties, VVHRoadlink, Option[String]) =>
-      val propertyName: String = x._1
-      val optionalExistingValue: Option[Int] = x._2
-      val linkProperty: LinkProperties = x._3
-      val vvhRoadLink: VVHRoadlink = x._4
-      val username: Option[String] = x._5
-      laneWorkListService.insertToLaneWorkList(propertyName, optionalExistingValue, linkProperty, vvhRoadLink, username)
+    case linkPropertyChange: LinkPropertyChange =>
+      laneWorkListService.insertToLaneWorkList(linkPropertyChange)
     case _ => println("LaneWorkListInsertItem: Received unknown message")
   }
 }

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -4,7 +4,8 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, ActorSystem, Props}
 import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
-import fi.liikennevirasto.digiroad2.client.vvh.VVHClient
+import fi.liikennevirasto.digiroad2.client.vvh.{VVHClient, VVHRoadlink}
+import fi.liikennevirasto.digiroad2.dao.lane.LaneWorkListItem
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.dao.pointasset.PostGISPointMassLimitationDao
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, MassTransitStopDao, MunicipalityDao}
@@ -17,7 +18,7 @@ import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.process.{WidthLimitValidator, _}
 import fi.liikennevirasto.digiroad2.service._
 import fi.liikennevirasto.digiroad2.service.feedback.{FeedbackApplicationService, FeedbackDataService}
-import fi.liikennevirasto.digiroad2.service.lane.LaneService
+import fi.liikennevirasto.digiroad2.service.lane.{LaneService, LaneWorkListService}
 import fi.liikennevirasto.digiroad2.service.linearasset.{LinearTotalWeightLimitService, _}
 import fi.liikennevirasto.digiroad2.service.pointasset._
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop._
@@ -27,6 +28,7 @@ import fi.liikennevirasto.digiroad2.util.Digiroad2Properties
 import fi.liikennevirasto.digiroad2.vallu.ValluSender
 import org.apache.http.impl.client.HttpClientBuilder
 import org.slf4j.LoggerFactory
+
 import scala.concurrent.duration.FiniteDuration
 
 
@@ -291,6 +293,19 @@ class TrafficSignUpdateAssets(trafficSignService: TrafficSignService, trafficSig
   }
 }
 
+class LaneWorkListInsertItem(laneWorkListService: LaneWorkListService) extends Actor {
+  def receive = {
+    case x: (String, Option[Int],LinkProperties, VVHRoadlink, Option[String]) =>
+      val propertyName: String = x._1
+      val optionalExistingValue: Option[Int] = x._2
+      val linkProperty: LinkProperties = x._3
+      val vvhRoadLink: VVHRoadlink = x._4
+      val username: Option[String] = x._5
+      laneWorkListService.insertToLaneWorkList(propertyName, optionalExistingValue, linkProperty, vvhRoadLink, username)
+    case _ => println("LaneWorkListInsertItem: Received unknown message")
+  }
+}
+
 object Digiroad2Context {
   val logger = LoggerFactory.getLogger(getClass)
 
@@ -373,6 +388,9 @@ object Digiroad2Context {
 
   val trafficSignUpdate = system.actorOf(Props(classOf[TrafficSignUpdateAssets], trafficSignService, trafficSignManager), name = "trafficSignUpdate")
   eventbus.subscribe(trafficSignUpdate, "trafficSign:update")
+
+  val laneWorkListInsert = system.actorOf(Props(classOf[LaneWorkListInsertItem], laneWorkListService), name = "laneWorkListInsert")
+  eventbus.subscribe(laneWorkListInsert, "laneWorkList:insert")
 
   val hazmatTransportProhibitionVerifier = system.actorOf(Props(classOf[HazmatTransportProhibitionValidation], hazmatTransportProhibitionValidator), name = "hazmatTransportProhibitionValidator")
   eventbus.subscribe(hazmatTransportProhibitionVerifier, "hazmatTransportProhibition:Validator")
@@ -589,6 +607,10 @@ object Digiroad2Context {
 
   lazy val trafficSignService: TrafficSignService = {
     new TrafficSignService(roadLinkService, eventbus)
+  }
+
+  lazy val laneWorkListService: LaneWorkListService = {
+    new LaneWorkListService()
   }
 
   lazy val manoeuvreService = {

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1501,7 +1501,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     val userHasRights = user.isLaneMaintainer() || user.isOperator()
     val itemIdsToDelete = userHasRights match{
       case true => parsedBody.extractOpt[Set[Long]]
-      case false => halt(BadRequest("User not authorized to delete items from lane work list"))
+      case false => halt(Forbidden("User not authorized to delete items from lane work list"))
     }
     itemIdsToDelete match {
       case Some(ids) =>
@@ -1515,7 +1515,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     val userHasRights = user.isLaneMaintainer() || user.isOperator()
     val workListItems = userHasRights match {
       case true => laneWorkListService.getLaneWorkList
-      case false => halt(BadRequest("User not authorized to get items from lane work list"))
+      case false => halt(Forbidden("User not authorized to get items from lane work list"))
     }
 
     Map("items" -> workListItems.groupBy(_.propertyName)

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1496,7 +1496,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     }
   }
 
-  delete("/laneWorkList/") {
+  delete("/laneWorkList") {
     val user = userProvider.getCurrentUser()
     val userHasRights = user.isLaneMaintainer() || user.isOperator()
     val itemIdsToDelete = userHasRights match{

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1496,7 +1496,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     }
   }
 
-  delete("/laneWorkList/delete") {
+  delete("/laneWorkList/") {
     val user = userProvider.getCurrentUser()
     val itemIdsToDelete = if (user.isLaneMaintainer() || user.isOperator()) parsedBody.extractOpt[Set[Long]]
     else None

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -14,7 +14,7 @@ import fi.liikennevirasto.digiroad2.lane._
 import fi.liikennevirasto.digiroad2.linearasset.{SpeedLimitValue, _}
 import fi.liikennevirasto.digiroad2.service._
 import fi.liikennevirasto.digiroad2.service.feedback.{Feedback, FeedbackApplicationService, FeedbackDataService}
-import fi.liikennevirasto.digiroad2.service.lane.LaneService
+import fi.liikennevirasto.digiroad2.service.lane.{LaneService, LaneWorkListService}
 import fi.liikennevirasto.digiroad2.service.linearasset.{ProhibitionService, _}
 import fi.liikennevirasto.digiroad2.service.pointasset._
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.{MassTransitStopException, MassTransitStopService, NewMassTransitStop, ServicePointStopService}
@@ -90,7 +90,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
                    val parkingProhibitionService: ParkingProhibitionService = Digiroad2Context.parkingProhibitionService,
                    val cyclingAndWalkingService: CyclingAndWalkingService = Digiroad2Context.cyclingAndWalkingService,
                    val laneService: LaneService = Digiroad2Context.laneService,
-                   val servicePointStopService: ServicePointStopService = Digiroad2Context.servicePointStopService)
+                   val servicePointStopService: ServicePointStopService = Digiroad2Context.servicePointStopService,
+                   val laneWorkListService: LaneWorkListService = Digiroad2Context.laneWorkListService)
 
   extends ScalatraServlet
     with JacksonJsonSupport
@@ -1501,7 +1502,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     else None
     itemIdsToDelete match {
       case Some(ids) =>
-        laneService.deleteFromLaneWorkList(ids)
+        laneWorkListService.deleteFromLaneWorkList(ids)
         true
       case None => false
     }
@@ -1509,7 +1510,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
 
   get("/laneWorkList") {
     val user = userProvider.getCurrentUser()
-    val workListItems = if(user.isLaneMaintainer() || user.isOperator()) laneService.getLaneWorkList()
+    val workListItems = if(user.isLaneMaintainer() || user.isOperator()) laneWorkListService.getLaneWorkList
     else Seq()
 
     Map("items" -> workListItems.groupBy(_.propertyName)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.digiroad2.GeometryUtils.Projection
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.{MassQueryParams, VKMClient}
 import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType, VVHClient}
-import fi.liikennevirasto.digiroad2.dao.lane.{LaneDao, LaneHistoryDao, LaneWorkListDAO, LaneWorkListItem}
+import fi.liikennevirasto.digiroad2.dao.lane.{LaneDao, LaneHistoryDao}
 import fi.liikennevirasto.digiroad2.dao.MunicipalityDao
 import fi.liikennevirasto.digiroad2.lane.LaneFiller._
 import fi.liikennevirasto.digiroad2.lane._
@@ -31,7 +31,6 @@ class LaneService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEv
   override def polygonTools: PolygonTools = new PolygonTools()
   override def vkmClient: VKMClient = new VKMClient
   override def roadAddressService: RoadAddressService = roadAddressServiceImpl
-  override def workListDao: LaneWorkListDAO = new LaneWorkListDAO
 
 }
 
@@ -49,7 +48,6 @@ trait LaneOperations {
   def laneFiller: LaneFiller = new LaneFiller
   def vkmClient: VKMClient
   def roadAddressService: RoadAddressService
-  def workListDao: LaneWorkListDAO
 
 
   val logger = LoggerFactory.getLogger(getClass)
@@ -108,17 +106,6 @@ trait LaneOperations {
     getSegmentedViewOnlyLanes(allLanes, filteredRoadLinks)
   }
 
-  def getLaneWorkList(): Seq[LaneWorkListItem] = {
-    withDynTransaction {
-      workListDao.getAllItems
-    }
-  }
-
-  def deleteFromLaneWorkList(itemsToDelete: Set[Long]): Unit = {
-    withDynTransaction {
-      workListDao.deleteItemsById(itemsToDelete)
-    }
-  }
 
   /**
     * Use lanes measures to create segments with lanes with same link id and side code

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListService.scala
@@ -45,9 +45,10 @@ class LaneWorkListService {
     }
   }
 
-  def deleteFromLaneWorkList(itemsToDelete: Set[Long]): Unit = {
+  def deleteFromLaneWorkList(itemsToDelete: Set[Long]): Set[Long] = {
     PostGISDatabase.withDynTransaction {
       workListDao.deleteItemsById(itemsToDelete)
     }
+    itemsToDelete
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListService.scala
@@ -1,0 +1,53 @@
+package fi.liikennevirasto.digiroad2.service.lane
+
+import fi.liikennevirasto.digiroad2.client.vvh.VVHRoadlink
+import fi.liikennevirasto.digiroad2.dao.lane.{LaneWorkListDAO, LaneWorkListItem}
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.service.LinkProperties
+import fi.liikennevirasto.digiroad2.util.MainLanePopulationProcess.twoWayLanes
+import org.joda.time.DateTime
+
+class LaneWorkListService {
+   def workListDao: LaneWorkListDAO = new LaneWorkListDAO
+
+  def getLaneWorkList: Seq[LaneWorkListItem] = {
+    PostGISDatabase.withDynTransaction {
+      workListDao.getAllItems
+    }
+  }
+
+  def insertToLaneWorkList(propertyName: String, optionalExistingValue: Option[Int], linkProperty: LinkProperties, vvhRoadLink: VVHRoadlink, username: Option[String]): Unit = {
+    propertyName match {
+      case "traffic_direction" =>
+        val newValue = linkProperty.trafficDirection.value
+        val oldValue = optionalExistingValue.getOrElse(vvhRoadLink.trafficDirection.value)
+        val timeStamp = DateTime.now()
+        val createdBy = username.getOrElse("")
+        val itemToInsert = LaneWorkListItem(0, vvhRoadLink.linkId, propertyName, oldValue, newValue, timeStamp, createdBy)
+        if(newValue != oldValue) {
+          PostGISDatabase.withDynTransaction {
+            workListDao.insertItem(itemToInsert)}
+        }
+      case "link_type" =>
+        val newValue = linkProperty.linkType.value
+        val oldValue = optionalExistingValue.getOrElse(99)
+        val timeStamp = DateTime.now()
+        val createdBy = username.getOrElse("")
+        val itemToInsert = LaneWorkListItem(0, vvhRoadLink.linkId, propertyName, oldValue, newValue, timeStamp, createdBy)
+
+        val twoWayLaneLinkTypeChange = twoWayLanes.map(_.value).contains(newValue) || twoWayLanes.map(_.value).contains(oldValue)
+        if(twoWayLaneLinkTypeChange && (newValue != oldValue)) {
+          PostGISDatabase.withDynTransaction {
+            workListDao.insertItem(itemToInsert)
+          }
+        }
+      case _ =>
+    }
+  }
+
+  def deleteFromLaneWorkList(itemsToDelete: Set[Long]): Unit = {
+    PostGISDatabase.withDynTransaction {
+      workListDao.deleteItemsById(itemsToDelete)
+    }
+  }
+}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListService.scala
@@ -16,18 +16,17 @@ class LaneWorkListService {
     }
   }
 
-  def insertToLaneWorkList(propertyName: String, optionalExistingValue: Option[Int], linkProperty: LinkProperties, vvhRoadLink: VVHRoadlink, username: Option[String]): Unit = {
-    propertyName match {
+  def insertToLaneWorkList(propertyName: String, optionalExistingValue: Option[Int], linkProperty: LinkProperties,
+                           vvhRoadLink: VVHRoadlink, username: Option[String], newTransaction: Boolean = true): Unit = {
+    val itemToInsert = propertyName match {
       case "traffic_direction" =>
         val newValue = linkProperty.trafficDirection.value
         val oldValue = optionalExistingValue.getOrElse(vvhRoadLink.trafficDirection.value)
         val timeStamp = DateTime.now()
         val createdBy = username.getOrElse("")
         val itemToInsert = LaneWorkListItem(0, vvhRoadLink.linkId, propertyName, oldValue, newValue, timeStamp, createdBy)
-        if(newValue != oldValue) {
-          PostGISDatabase.withDynTransaction {
-            workListDao.insertItem(itemToInsert)}
-        }
+        if(newValue != oldValue) Some(itemToInsert)
+        else None
       case "link_type" =>
         val newValue = linkProperty.linkType.value
         val oldValue = optionalExistingValue.getOrElse(99)
@@ -36,19 +35,28 @@ class LaneWorkListService {
         val itemToInsert = LaneWorkListItem(0, vvhRoadLink.linkId, propertyName, oldValue, newValue, timeStamp, createdBy)
 
         val twoWayLaneLinkTypeChange = twoWayLanes.map(_.value).contains(newValue) || twoWayLanes.map(_.value).contains(oldValue)
-        if(twoWayLaneLinkTypeChange && (newValue != oldValue)) {
-          PostGISDatabase.withDynTransaction {
-            workListDao.insertItem(itemToInsert)
-          }
+        if(twoWayLaneLinkTypeChange && (newValue != oldValue)) Some(itemToInsert)
+        else None
+      case _ => None
+    }
+
+    if (itemToInsert.isDefined) {
+      if (newTransaction) {
+        PostGISDatabase.withDynTransaction {
+          workListDao.insertItem(itemToInsert.get)
         }
-      case _ =>
+      }
+      else workListDao.insertItem(itemToInsert.get)
     }
   }
 
-  def deleteFromLaneWorkList(itemsToDelete: Set[Long]): Set[Long] = {
-    PostGISDatabase.withDynTransaction {
-      workListDao.deleteItemsById(itemsToDelete)
+  def deleteFromLaneWorkList(itemsToDelete: Set[Long], newTransaction: Boolean = true): Set[Long] = {
+    if (newTransaction) {
+      PostGISDatabase.withDynTransaction {
+        workListDao.deleteItemsById(itemsToDelete)
+      }
     }
+    else workListDao.deleteItemsById(itemsToDelete)
     itemsToDelete
   }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadLinkServiceSpec.scala
@@ -1356,4 +1356,18 @@ class RoadLinkServiceSpec extends FunSuite with Matchers with BeforeAndAfter {
       linkTypes.size should be (3)
     }
   }
+
+  test("road link property change triggers event bus 2 times") {
+    runWithRollback {
+      when(mockRoadLinkDao.fetchByLinkId(1l))
+        .thenReturn(Some(VVHRoadlink(1l, 91, Nil, State, TrafficDirection.TowardsDigitizing, FeatureClass.AllOthers)))
+      val service = new TestService(mockVVHClient, mockEventBus)
+      val linkProperty = LinkProperties(1, 99, BidirectionalLaneCarriageWay, TrafficDirection.BothDirections, State, None, None, None)
+      val roadLink = service.updateLinkProperties(linkProperty, Option("testuser"), { (_, _) => })
+      verify(mockEventBus, times(2)).publish(
+        org.mockito.ArgumentMatchers.eq("laneWorkList:insert"),
+        org.mockito.ArgumentMatchers.any[LinkPropertyChange])
+    }
+  }
+
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -5,7 +5,7 @@ import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.VKMClient
 import fi.liikennevirasto.digiroad2.client.vvh.VVHClient
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao}
-import fi.liikennevirasto.digiroad2.dao.lane.{LaneDao, LaneHistoryDao, LaneWorkListDAO}
+import fi.liikennevirasto.digiroad2.dao.lane.{LaneDao, LaneHistoryDao}
 import fi.liikennevirasto.digiroad2.lane.LaneFiller.{ChangeSet, SideCodeAdjustment}
 import fi.liikennevirasto.digiroad2.lane.{LaneChangeType, LaneFiller, LaneNumberOneDigit, LaneProperty, LanePropertyValue, NewLane, PersistedLane, PieceWiseLane, SideCodesForLinkIds}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
@@ -30,7 +30,6 @@ class LaneTestSupporter extends FunSuite with Matchers {
   val mockVKMClient = MockitoSugar.mock[VKMClient]
   val mockRoadAddressService = MockitoSugar.mock[RoadAddressService]
   val mockLaneService = MockitoSugar.mock[LaneService]
-  val mockLaneWorkListDao = MockitoSugar.mock[LaneWorkListDAO]
 
   val laneDao = new LaneDao(mockVVHClient, mockRoadLinkService)
   val laneHistoryDao = new LaneHistoryDao(mockVVHClient, mockRoadLinkService)
@@ -71,7 +70,6 @@ class LaneTestSupporter extends FunSuite with Matchers {
     override def municipalityDao: MunicipalityDao = mockMunicipalityDao
     override def vkmClient: VKMClient = mockVKMClient
     override def roadAddressService: RoadAddressService = mockRoadAddressService
-    override def workListDao: LaneWorkListDAO = mockLaneWorkListDao
 
   }
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListServiceSpec.scala
@@ -1,0 +1,103 @@
+package fi.liikennevirasto.digiroad2.service.lane
+
+import fi.liikennevirasto.digiroad2.asset.TrafficDirection.{AgainstDigitizing, BothDirections, TowardsDigitizing}
+import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, VVHRoadlink}
+import fi.liikennevirasto.digiroad2.dao.lane.LaneWorkListDAO
+import fi.liikennevirasto.digiroad2.service.LinkProperties
+import fi.liikennevirasto.digiroad2.util.TestTransactions
+import org.scalatest.{FunSuite, Matchers}
+
+class LaneWorkListServiceSpec extends FunSuite with Matchers {
+  val laneWorkListDao: LaneWorkListDAO = new LaneWorkListDAO
+  val laneWorkListService: LaneWorkListService = new LaneWorkListService
+
+  def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
+
+  val user: String = "testuser"
+
+
+  test("traffic direction change with NO already existing overridden value should be identified and saved to lane work list") {
+    val linkProperty = LinkProperties(1, 5, PedestrianZone, BothDirections, Private)
+    val vvhRoadLink = VVHRoadlink(1l, 91, Nil, Municipality, TowardsDigitizing, FeatureClass.AllOthers)
+    runWithRollback {
+      val itemsBeforeOperation = laneWorkListDao.getAllItems
+      laneWorkListService.insertToLaneWorkList("traffic_direction", None, linkProperty, vvhRoadLink, Some(user), false)
+      val itemsAfterOperation = laneWorkListDao.getAllItems
+
+      itemsBeforeOperation.size should equal(0)
+      itemsAfterOperation.size should equal(1)
+
+      itemsAfterOperation.head.propertyName should equal("traffic_direction")
+      itemsAfterOperation.head.oldValue should equal(TowardsDigitizing.value)
+      itemsAfterOperation.head.newValue should equal(BothDirections.value)
+      itemsAfterOperation.head.createdBy should equal(user)
+    }
+  }
+
+  test("traffic direction change with already existing overridden value should be identified and saved to lane work list") {
+    runWithRollback {
+      val linkProperty = LinkProperties(1, 5, PedestrianZone, BothDirections, Private)
+      val vvhRoadLink = VVHRoadlink(1l, 91, Nil, Municipality, TowardsDigitizing, FeatureClass.AllOthers)
+      val existingOverriddenValue = Option(3)
+      val itemsBeforeOperation = laneWorkListDao.getAllItems
+
+      laneWorkListService.insertToLaneWorkList("traffic_direction", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      val itemsAfterOperation = laneWorkListDao.getAllItems
+
+      itemsBeforeOperation.size should equal(0)
+      itemsAfterOperation.size should equal(1)
+
+      itemsAfterOperation.head.propertyName should equal("traffic_direction")
+      itemsAfterOperation.head.oldValue should equal(AgainstDigitizing.value)
+      itemsAfterOperation.head.newValue should equal(BothDirections.value)
+      itemsAfterOperation.head.createdBy should equal(user)
+    }
+  }
+
+  test("link type change with already existing overridden value should be identified and saved to lane work list") {
+    runWithRollback {
+      val linkProperty = LinkProperties(1, 5, BidirectionalLaneCarriageWay, TowardsDigitizing, Private)
+      val vvhRoadLink = VVHRoadlink(1l, 91, Nil, Municipality, TowardsDigitizing, FeatureClass.AllOthers)
+      val existingOverriddenValue = Option(3)
+      val itemsBeforeOperation = laneWorkListDao.getAllItems
+
+      laneWorkListService.insertToLaneWorkList("link_type", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      val itemsAfterOperation = laneWorkListDao.getAllItems
+
+      itemsBeforeOperation.size should equal(0)
+      itemsAfterOperation.size should equal(1)
+
+      itemsAfterOperation.head.propertyName should equal("link_type")
+      itemsAfterOperation.head.oldValue should equal(SingleCarriageway.value)
+      itemsAfterOperation.head.newValue should equal(BidirectionalLaneCarriageWay.value)
+      itemsAfterOperation.head.createdBy should equal(user)
+    }
+  }
+
+  test("link type and traffic direction should be identified and saved to lane work list and link type change deleted") {
+    runWithRollback {
+      val linkProperty = LinkProperties(1, 5, BidirectionalLaneCarriageWay, BothDirections, Private)
+      val vvhRoadLink = VVHRoadlink(1l, 91, Nil, Municipality, TowardsDigitizing, FeatureClass.AllOthers)
+      val existingOverriddenValue = None
+      val itemsBeforeOperation = laneWorkListDao.getAllItems
+
+      laneWorkListService.insertToLaneWorkList("link_type", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      laneWorkListService.insertToLaneWorkList("traffic_direction", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      val itemsAfterOperation = laneWorkListDao.getAllItems
+
+      itemsBeforeOperation.size should equal(0)
+      itemsAfterOperation.size should equal(2)
+
+      val linkTypeItem = itemsAfterOperation.find(_.propertyName == "link_type").get
+      laneWorkListService.deleteFromLaneWorkList(Set(linkTypeItem.id), false)
+      val itemsAfterDelete = laneWorkListDao.getAllItems
+      itemsAfterDelete.size should equal(1)
+
+      itemsAfterDelete.head.propertyName should equal("traffic_direction")
+      itemsAfterDelete.head.oldValue should equal(TowardsDigitizing.value)
+      itemsAfterDelete.head.newValue should equal(BothDirections.value)
+      itemsAfterDelete.head.createdBy should equal(user)
+    }
+  }
+}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneWorkListServiceSpec.scala
@@ -4,7 +4,7 @@ import fi.liikennevirasto.digiroad2.asset.TrafficDirection.{AgainstDigitizing, B
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.vvh.{FeatureClass, VVHRoadlink}
 import fi.liikennevirasto.digiroad2.dao.lane.LaneWorkListDAO
-import fi.liikennevirasto.digiroad2.service.LinkProperties
+import fi.liikennevirasto.digiroad2.service.{LinkProperties, LinkPropertyChange}
 import fi.liikennevirasto.digiroad2.util.TestTransactions
 import org.scalatest.{FunSuite, Matchers}
 
@@ -22,7 +22,7 @@ class LaneWorkListServiceSpec extends FunSuite with Matchers {
     val vvhRoadLink = VVHRoadlink(1l, 91, Nil, Municipality, TowardsDigitizing, FeatureClass.AllOthers)
     runWithRollback {
       val itemsBeforeOperation = laneWorkListDao.getAllItems
-      laneWorkListService.insertToLaneWorkList("traffic_direction", None, linkProperty, vvhRoadLink, Some(user), false)
+      laneWorkListService.insertToLaneWorkList(LinkPropertyChange("traffic_direction", None, linkProperty, vvhRoadLink, Some(user)), false)
       val itemsAfterOperation = laneWorkListDao.getAllItems
 
       itemsBeforeOperation.size should equal(0)
@@ -42,7 +42,7 @@ class LaneWorkListServiceSpec extends FunSuite with Matchers {
       val existingOverriddenValue = Option(3)
       val itemsBeforeOperation = laneWorkListDao.getAllItems
 
-      laneWorkListService.insertToLaneWorkList("traffic_direction", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      laneWorkListService.insertToLaneWorkList(LinkPropertyChange("traffic_direction", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user)), false)
       val itemsAfterOperation = laneWorkListDao.getAllItems
 
       itemsBeforeOperation.size should equal(0)
@@ -62,7 +62,7 @@ class LaneWorkListServiceSpec extends FunSuite with Matchers {
       val existingOverriddenValue = Option(3)
       val itemsBeforeOperation = laneWorkListDao.getAllItems
 
-      laneWorkListService.insertToLaneWorkList("link_type", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      laneWorkListService.insertToLaneWorkList(LinkPropertyChange("link_type", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user)), false)
       val itemsAfterOperation = laneWorkListDao.getAllItems
 
       itemsBeforeOperation.size should equal(0)
@@ -82,8 +82,8 @@ class LaneWorkListServiceSpec extends FunSuite with Matchers {
       val existingOverriddenValue = None
       val itemsBeforeOperation = laneWorkListDao.getAllItems
 
-      laneWorkListService.insertToLaneWorkList("link_type", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
-      laneWorkListService.insertToLaneWorkList("traffic_direction", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user), false)
+      laneWorkListService.insertToLaneWorkList(LinkPropertyChange("link_type", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user)), false)
+      laneWorkListService.insertToLaneWorkList(LinkPropertyChange("traffic_direction", existingOverriddenValue, linkProperty, vvhRoadLink, Some(user)), false)
       val itemsAfterOperation = laneWorkListDao.getAllItems
 
       itemsBeforeOperation.size should equal(0)


### PR DESCRIPTION
Muutoksia Sasun kommenttien perusteella edellisestä pullarista. Luotu LaneWorkListService, ja LaneWorkListServiceSpec. Käytetään Akka actor ohjaamaan linkkien property muutoksien tunnistus ja tallennus servicelle. Lisätty LinkID + Pvm. mukaan järjestäminen työlistalla UI:lla. Poistettu turha /delete api endpointista. 