### PR TITLE
DROTH-3419 Use roadlink filter function to not generate speed limits …

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -225,11 +225,12 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
 
   private def getByRoadLinks(roadLinks: Seq[RoadLink], change: Seq[ChangeInfo], showSpeedLimitsHistory: Boolean = false, roadFilterFunction: RoadLink => Boolean) = {
 
-    val (speedLimitLinks, topology) = dao.getSpeedLimitLinksByRoadLinks(roadLinks.filter(roadFilterFunction), showSpeedLimitsHistory)
+    val roadLinksFiltered = roadLinks.filter(roadFilterFunction)
+    val (speedLimitLinks, topology) = dao.getSpeedLimitLinksByRoadLinks(roadLinksFiltered, showSpeedLimitsHistory)
     val speedLimits = (speedLimitLinks).groupBy(_.linkId)
     val roadLinksByLinkId = topology.groupBy(_.linkId).mapValues(_.head)
 
-    val filledTopology = roadLinks.filter(roadFilterFunction).foldLeft(Seq.empty[SpeedLimit]) { case (existingSegments, roadLink) =>
+    val filledTopology = roadLinksFiltered.foldLeft(Seq.empty[SpeedLimit]) { case (existingSegments, roadLink) =>
       val currentSegments = speedLimits.getOrElse(roadLink.linkId, Nil)
       val generatedSpeedLimits = generateUnknownSpeedLimitsForLink(roadLink, currentSegments)
       existingSegments ++ currentSegments ++ generatedSpeedLimits

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -229,7 +229,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
     val speedLimits = (speedLimitLinks).groupBy(_.linkId)
     val roadLinksByLinkId = topology.groupBy(_.linkId).mapValues(_.head)
 
-    val filledTopology = roadLinks.foldLeft(Seq.empty[SpeedLimit]) { case (existingSegments, roadLink) =>
+    val filledTopology = roadLinks.filter(roadFilterFunction).foldLeft(Seq.empty[SpeedLimit]) { case (existingSegments, roadLink) =>
       val currentSegments = speedLimits.getOrElse(roadLink.linkId, Nil)
       val generatedSpeedLimits = generateUnknownSpeedLimitsForLink(roadLink, currentSegments)
       existingSegments ++ currentSegments ++ generatedSpeedLimits


### PR DESCRIPTION
Lisätty filteröinti, jotta tuntemattomien nopeusrajoitusten luonnin toiminta pysyy samana kuin silloin kun tämä oli osa fillTopologyä. 