### PR TITLE
DROTH-3441 fix asset split cancel bug

### DIFF
--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -457,7 +457,7 @@
       {
         typeId: assetType.roadWidth,
         singleElementEventCategory: 'roadWidth',
-        multiElementEventCategory: 'roadWidth',
+        multiElementEventCategory: 'roadWidths',
         layerName: 'roadWidth',
         title: 'Leveys',
         newTitle: 'Uusi leveys',
@@ -822,7 +822,7 @@
       {
         typeId: assetType.carryingCapacity,
         singleElementEventCategory: 'carryingCapacity',
-        multiElementEventCategory: 'carryingCapacity',
+        multiElementEventCategory: 'carryingCapacities',
         layerName: 'carryingCapacity',
         title: 'Kantavuus',
         newTitle: 'Uusi Kantavuus',


### PR DESCRIPTION
Tien leveydessä ja kantavuudessa oli nimetty single- ja multiElementEvent samalla tavalla, johon ohjelma kaatui muokkauksen perumisessa. Nämä nimetty nyt eri nimillä.