### PR TITLE
Droth 3451 separate fix operations

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/DamagedByThawFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/DamagedByThawFiller.scala
@@ -12,7 +12,7 @@ class DamagedByThawFiller extends AssetFiller {
   val formatter = DateTimeFormat.forPattern(dateFormat)
   val today: DateTime = DateTime.now()
 
-  override protected def updateValues(roadLink: RoadLink, assets: Seq[PersistedLinearAsset], changeSet: ChangeSet): (Seq[PersistedLinearAsset], ChangeSet) = {
+  override def updateValues(roadLink: RoadLink, assets: Seq[PersistedLinearAsset], changeSet: ChangeSet): (Seq[PersistedLinearAsset], ChangeSet) = {
 
     def getProperties(publicId: String, propertyData: Seq[DynamicProperty]): Seq[DynamicPropertyValue] = {
       propertyData.find(p => p.publicId == publicId) match {

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetFiller.scala
@@ -21,5 +21,14 @@ object LinearAssetFiller {
         this.expiredAssetIds.isEmpty &&
         this.valueAdjustments.isEmpty
     }
+
+    def filterGeneratedAssets: ChangeSet = {
+      ChangeSet(this.droppedAssetIds.filterNot(_ == 0),
+        this.adjustedMValues.filterNot(_.assetId == 0),
+        this.adjustedVVHChanges.filterNot(_.assetId == 0),
+        this.adjustedSideCodes.filterNot(_.assetId == 0),
+        this.expiredAssetIds.filterNot(_ == 0),
+        this.valueAdjustments.filterNot(_.asset.id == 0))
+    }
   }
 }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetFiller.scala
@@ -12,5 +12,14 @@ object LinearAssetFiller {
                        adjustedVVHChanges: Seq[VVHChangesAdjustment],
                        adjustedSideCodes: Seq[SideCodeAdjustment],
                        expiredAssetIds: Set[Long],
-                       valueAdjustments: Seq[ValueAdjustment])
+                       valueAdjustments: Seq[ValueAdjustment]){
+    def isEmpty: Boolean = {
+      this.droppedAssetIds.isEmpty &&
+        this.adjustedMValues.isEmpty &&
+        this.adjustedVVHChanges.isEmpty &&
+        this.adjustedSideCodes.isEmpty &&
+        this.expiredAssetIds.isEmpty &&
+        this.valueAdjustments.isEmpty
+    }
+  }
 }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
@@ -116,7 +116,7 @@ object SpeedLimitFiller {
     }
   }
 
-  private def dropShortLimits(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
+  def dropShortLimits(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
     val limitsToDrop = speedLimits.filter { limit => GeometryUtils.geometryLength(limit.geometry) < MinAllowedSpeedLimitLength &&
       roadLink.length > MinAllowedSpeedLimitLength }.map(_.id).toSet
     val limits = speedLimits.filterNot { x => limitsToDrop.contains(x.id) }
@@ -160,7 +160,7 @@ object SpeedLimitFiller {
     * @param changeSet Original changeset
     * @return Sequence of SpeedLimits and ChangeSet containing the changes done here
     */
-  private def combine(roadLink: RoadLink, limits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
+  def combine(roadLink: RoadLink, limits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
 
     def replaceUnknownAssetIds(asset: SpeedLimit, pseudoId: Long) = {
       asset.id match {
@@ -320,7 +320,7 @@ object SpeedLimitFiller {
     * @param changeSet Changes done previously
     * @return List of speed limits and a change set
     */
-  private def fuse(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
+   def fuse(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
     val sortedList = speedLimits.sortBy(_.startMeasure)
     if (speedLimits.nonEmpty) {
       val origin = sortedList.head
@@ -357,7 +357,7 @@ object SpeedLimitFiller {
     * @param changeSet Set of changes
     * @return List of speed limits and change set so that there are no small gaps between speed limits
     */
-  private def fillHoles(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
+  def fillHoles(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
     def firstAndLastLimit(speedLimits: Seq[SpeedLimit], sideCode: SideCode) = {
       val filtered = speedLimits.filter(_.sideCode == sideCode)
       (filtered.sortBy(_.startMeasure).headOption,

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
@@ -83,7 +83,7 @@ object SpeedLimitFiller {
     (passThroughSegments ++ cappedSegments.map(_._1), changeSet.copy(adjustedMValues = changeSet.adjustedMValues ++ cappedSegments.map(_._2)))
   }
 
-  private def adjustLopsidedLimit(roadLink: RoadLink, segments: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
+  def adjustLopsidedLimit(roadLink: RoadLink, segments: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
     val onlyLimitOnLink = segments.length == 1 && segments.head.sideCode != SideCode.BothDirections
     if (onlyLimitOnLink) {
       val segment = segments.head
@@ -417,7 +417,7 @@ object SpeedLimitFiller {
     * @param changeSet
     * @return
     */
-  private def clean(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
+  def clean(roadLink: RoadLink, speedLimits: Seq[SpeedLimit], changeSet: ChangeSet): (Seq[SpeedLimit], ChangeSet) = {
     /**
       * Remove adjustments that were overwritten later (new version appears later in the sequence)
       * @param adj list of adjustments

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LaneFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/lane/LaneFillerSpec.scala
@@ -45,12 +45,12 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
-
-    filledTopology should have size 1
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value))
-    filledTopology.map(_.id) should be (Seq(0L))
-    filledTopology.map(_.linkId) should be (Seq(linkId1))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(5.0, 0.0), Point(7.5, 0.0))))
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
+    pieceWiseTopology should have size 1
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value))
+    pieceWiseTopology.map(_.id) should be (Seq(0L))
+    pieceWiseTopology.map(_.linkId) should be (Seq(linkId1))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(5.0, 0.0), Point(7.5, 0.0))))
 
     changeSet.expiredLaneIds should be (Set(1L))
   }
@@ -78,12 +78,12 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
-
-    filledTopology should have size 2
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value, SideCode.BothDirections.value))
-    filledTopology.map(_.id) should be (Seq(0L, 0L))
-    filledTopology.map(_.linkId) should be (Seq(roadLinkTowards1.linkId, roadLinkTowards1.linkId))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(5.0, 0.0), Point(7.5, 0.0)), Seq(Point(5.0, 0.0), Point(7.5, 0.0))))
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
+    pieceWiseTopology should have size 2
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value, SideCode.BothDirections.value))
+    pieceWiseTopology.map(_.id) should be (Seq(0L, 0L))
+    pieceWiseTopology.map(_.linkId) should be (Seq(roadLinkTowards1.linkId, roadLinkTowards1.linkId))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(5.0, 0.0), Point(7.5, 0.0)), Seq(Point(5.0, 0.0), Point(7.5, 0.0))))
 
     changeSet.expiredLaneIds should be (Set(1L, 2L, 3L))
   }
@@ -101,12 +101,12 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
-
-    filledTopology should have size 1
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value))
-    filledTopology.map(_.id) should be (Seq(1L))
-    filledTopology.map(_.linkId) should be (Seq(linkId1))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(0, 0.0), Point(10.0, 0.0))))
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
+    pieceWiseTopology should have size 1
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value))
+    pieceWiseTopology.map(_.id) should be (Seq(1L))
+    pieceWiseTopology.map(_.linkId) should be (Seq(linkId1))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(0, 0.0), Point(10.0, 0.0))))
 
     changeSet.expiredLaneIds should be (Set())
   }
@@ -136,12 +136,13 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
 
-    filledTopology should have size 3
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.TowardsDigitizing.value, SideCode.AgainstDigitizing.value, SideCode.BothDirections.value))
-    filledTopology.map(_.id) should be (Seq(1L, 2L, 20L))
-    filledTopology.map(_.linkId) should be (Seq(linkId3, linkId3, linkId1))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(5.0, 0.0), Point(10.0, 0.0)), Seq(Point(5.0, 0.0), Point(10.0, 0.0))))
+    pieceWiseTopology should have size 3
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.TowardsDigitizing.value, SideCode.AgainstDigitizing.value, SideCode.BothDirections.value))
+    pieceWiseTopology.map(_.id) should be (Seq(1L, 2L, 20L))
+    pieceWiseTopology.map(_.linkId) should be (Seq(linkId3, linkId3, linkId1))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(5.0, 0.0), Point(10.0, 0.0)), Seq(Point(5.0, 0.0), Point(10.0, 0.0))))
 
     changeSet.expiredLaneIds should be (Set())
   }
@@ -169,12 +170,13 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
 
-    filledTopology should have size 2
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value,  SideCode.BothDirections.value))
-    filledTopology.map(_.id) should be (Seq(20L, 21L))
-    filledTopology.map(_.linkId) should be (Seq( linkId1, linkId1))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(4.0, 0.0), Point(10.0, 0.0)) ))
+    pieceWiseTopology should have size 2
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value,  SideCode.BothDirections.value))
+    pieceWiseTopology.map(_.id) should be (Seq(20L, 21L))
+    pieceWiseTopology.map(_.linkId) should be (Seq( linkId1, linkId1))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(4.0, 0.0), Point(10.0, 0.0)) ))
 
     changeSet.expiredLaneIds should be (Set(22L))
   }
@@ -199,12 +201,13 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
 
-    filledTopology should have size 1
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value ))
-    filledTopology.map(_.id) should be (Seq(21L))
-    filledTopology.map(_.linkId) should be (Seq( linkId1))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(8.0, 0.0), Point(10.0, 0.0)) ))
+    pieceWiseTopology should have size 1
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value ))
+    pieceWiseTopology.map(_.id) should be (Seq(21L))
+    pieceWiseTopology.map(_.linkId) should be (Seq( linkId1))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(8.0, 0.0), Point(10.0, 0.0)) ))
 
     changeSet.expiredLaneIds should be (Set(20L))
   }
@@ -265,12 +268,13 @@ class LaneFillerSpec extends FunSuite with Matchers {
     )
 
     val (filledTopology, changeSet) = laneFiller.fillTopology(topology, linearAssets)
+    val pieceWiseTopology = laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, topology)
 
-    filledTopology should have size 3
-    filledTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value, SideCode.BothDirections.value, SideCode.BothDirections.value))
-    filledTopology.map(_.id).sorted should be (Seq(1L, 2L, 4L))
-    filledTopology.map(_.linkId) should be (Seq(roadLinkTowards1.linkId, roadLinkTowards1.linkId, roadLinkTowards1.linkId))
-    filledTopology.map(_.geometry) should be (Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(5.0, 0.0), Point(10.0, 0.0))))
+    pieceWiseTopology should have size 3
+    pieceWiseTopology.map(_.sideCode) should be (Seq(SideCode.BothDirections.value, SideCode.BothDirections.value, SideCode.BothDirections.value))
+    pieceWiseTopology.map(_.id).sorted should be (Seq(1L, 2L, 4L))
+    pieceWiseTopology.map(_.linkId) should be (Seq(roadLinkTowards1.linkId, roadLinkTowards1.linkId, roadLinkTowards1.linkId))
+    pieceWiseTopology.map(_.geometry) should be (Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(0.0, 0.0), Point(10.0, 0.0)), Seq(Point(5.0, 0.0), Point(10.0, 0.0))))
 
     changeSet.expiredLaneIds should be (Set(3L))
   }

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -7,8 +7,9 @@ import fi.liikennevirasto.digiroad2.asset.ProhibitionClass.Motorcycle
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.asset.SideCode.{AgainstDigitizing, BothDirections, TowardsDigitizing}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment, SideCodeAdjustment}
+import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment, SideCodeAdjustment, VVHChangesAdjustment, ValueAdjustment}
 import org.scalatest._
+
 import java.util.UUID
 import scala.util.Random
 
@@ -20,6 +21,27 @@ class AssetFillerSpec extends FunSuite with Matchers {
 
   val (linkId1, linkId2, linkId3) = (generateRandomLinkId(), generateRandomLinkId(), generateRandomLinkId())
 
+  test("create non-existent linear assets on empty road links") {
+    val topology = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality,
+        1, TrafficDirection.BothDirections, Motorway, None, None))
+    val changeSet = ChangeSet(droppedAssetIds = Set.empty[Long],
+      expiredAssetIds = Set.empty[Long],
+      adjustedMValues = Seq.empty[MValueAdjustment],
+      adjustedVVHChanges = Seq.empty[VVHChangesAdjustment],
+      adjustedSideCodes = Seq.empty[SideCodeAdjustment],
+      valueAdjustments = Seq.empty[ValueAdjustment])
+    val linearAssets = Map.empty[String, Seq[PersistedLinearAsset]]
+    val adjustedAssets = assetFiller.adjustAssets(topology, changeSet, linearAssets, 30)._1
+    val filledTopology = assetFiller.toLinearAsset(adjustedAssets, topology.head)
+
+    filledTopology should have size 1
+    filledTopology.map(_.sideCode) should be(Seq(BothDirections))
+    filledTopology.map(_.value) should be(Seq(None))
+    filledTopology.map(_.id) should be(Seq(0))
+    filledTopology.map(_.linkId) should be(Seq(linkId1))
+    filledTopology.map(_.geometry) should be(Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0))))
+  }
 
   test("expire assets that fall completely outside topology") {
     val topology = Seq(

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -20,19 +20,6 @@ class AssetFillerSpec extends FunSuite with Matchers {
 
   val (linkId1, linkId2, linkId3) = (generateRandomLinkId(), generateRandomLinkId(), generateRandomLinkId())
 
-  test("create non-existent linear assets on empty road links") {
-    val topology = Seq(
-      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality,
-        1, TrafficDirection.BothDirections, Motorway, None, None))
-    val linearAssets = Map.empty[String, Seq[PersistedLinearAsset]]
-    val filledTopology = assetFiller.fillRoadLinksWithoutAsset(topology, linearAssets, 30)
-    filledTopology should have size 1
-    filledTopology.map(_.sideCode) should be(Seq(BothDirections))
-    filledTopology.map(_.value) should be(Seq(None))
-    filledTopology.map(_.id) should be(Seq(0))
-    filledTopology.map(_.linkId) should be(Seq(linkId1))
-    filledTopology.map(_.geometry) should be(Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0))))
-  }
 
   test("expire assets that fall completely outside topology") {
     val topology = Seq(

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -32,7 +32,7 @@ class AssetFillerSpec extends FunSuite with Matchers {
       adjustedSideCodes = Seq.empty[SideCodeAdjustment],
       valueAdjustments = Seq.empty[ValueAdjustment])
     val linearAssets = Map.empty[String, Seq[PersistedLinearAsset]]
-    val adjustedAssets = assetFiller.adjustAssets(topology, changeSet, linearAssets, 30)._1
+    val adjustedAssets = assetFiller.fillTopology(topology, linearAssets, 30, Some(changeSet), false)._1
     val filledTopology = assetFiller.toLinearAsset(adjustedAssets, topology.head)
 
     filledTopology should have size 1
@@ -63,7 +63,8 @@ class AssetFillerSpec extends FunSuite with Matchers {
     val linearAssets = Map(
       linkId1 -> Seq(PersistedLinearAsset(1l, linkId1, 1, Some(NumericValue(1)), 0.0, 15.0, None, None, None, None, false, 110, 0, None, linkSource = NormalLinkInterface, None, None, None)))
 
-    val (filledTopology, changeSet) = assetFiller.fillTopology(topology, linearAssets, 110)
+    val (persistedLinearAssets, changeSet) = assetFiller.fillTopology(topology, linearAssets, 110)
+    val filledTopology = assetFiller.toLinearAssetsOnMultipleLinks(persistedLinearAssets, topology)
 
     filledTopology should have size 1
     filledTopology.map(_.sideCode) should be(Seq(BothDirections))
@@ -115,8 +116,8 @@ class AssetFillerSpec extends FunSuite with Matchers {
     val linearAssets = Map(
       linkId1 -> Seq(PersistedLinearAsset(1l, linkId1, 2, Some(NumericValue(1)), 0.0, 10.0, None, None, None, None, false, 110, 0, None, linkSource = NormalLinkInterface, None, None, None)))
 
-    val (filledTopology, changeSet) = assetFiller.fillTopology(topology, linearAssets, 110)
-
+    val (persistedFilledTopology, changeSet) = assetFiller.fillTopology(topology, linearAssets, 110)
+    val filledTopology = assetFiller.toLinearAssetsOnMultipleLinks(persistedFilledTopology, topology)
     filledTopology should have size 1
 
     filledTopology.filter(_.id == 1).map(_.sideCode) should be(Seq(BothDirections))

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -32,7 +32,7 @@ class AssetFillerSpec extends FunSuite with Matchers {
       adjustedSideCodes = Seq.empty[SideCodeAdjustment],
       valueAdjustments = Seq.empty[ValueAdjustment])
     val linearAssets = Map.empty[String, Seq[PersistedLinearAsset]]
-    val adjustedAssets = assetFiller.fillTopology(topology, linearAssets, 30, Some(changeSet), false)._1
+    val adjustedAssets = assetFiller.fillTopology(topology, linearAssets, 30, Some(changeSet), geometryChanged = false)._1
     val filledTopology = assetFiller.toLinearAsset(adjustedAssets, topology.head)
 
     filledTopology should have size 1

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/OneWayAssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/OneWayAssetFillerSpec.scala
@@ -72,7 +72,7 @@ class OneWayAssetFillerSpec extends FunSuite with Matchers {
       adjustedSideCodes = Seq.empty[SideCodeAdjustment],
       valueAdjustments = Seq.empty[ValueAdjustment])
 
-    val adjustedAssets = oneWayAssetFiller.fillTopology(topology, linearAssets, 110, Some(changeSet), false)._1
+    val adjustedAssets = oneWayAssetFiller.fillTopology(topology, linearAssets, 110, Some(changeSet), geometryChanged = false)._1
     val filledTopology = oneWayAssetFiller.toLinearAsset(adjustedAssets, topology.head)
 
     filledTopology should have size 2

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/OneWayAssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/OneWayAssetFillerSpec.scala
@@ -72,7 +72,7 @@ class OneWayAssetFillerSpec extends FunSuite with Matchers {
       adjustedSideCodes = Seq.empty[SideCodeAdjustment],
       valueAdjustments = Seq.empty[ValueAdjustment])
 
-    val adjustedAssets = oneWayAssetFiller.adjustAssets(topology, changeSet, linearAssets, 110)._1
+    val adjustedAssets = oneWayAssetFiller.fillTopology(topology, linearAssets, 110, Some(changeSet), false)._1
     val filledTopology = oneWayAssetFiller.toLinearAsset(adjustedAssets, topology.head)
 
     filledTopology should have size 2

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/OneWayAssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/OneWayAssetFillerSpec.scala
@@ -56,23 +56,4 @@ class OneWayAssetFillerSpec extends FunSuite with Matchers {
       SideCodeAdjustment(3l, SideCode.BothDirections, PavedRoad.typeId)))
   }
 
-  test("generate one-sided asset when two-way road link only has asset on the other side") {
-    val linkId = generateRandomLinkId()
-    val topology = Seq(
-      RoadLink(linkId, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality,
-        1, TrafficDirection.BothDirections, Motorway, None, None))
-    val linearAssets = Map(
-      linkId -> Seq(PersistedLinearAsset(1l, linkId, TowardsDigitizing.value, Some(NumericValue(1)), 0.0, 10.0, None, None, None, None, false, 110, 0, None, linkSource = NormalLinkInterface, None, None, None)))
-
-    val filledTopology = oneWayAssetFiller.fillRoadLinksWithoutAsset(topology, linearAssets, 110)
-
-    filledTopology should have size 2
-    filledTopology.filter(_.id == 1).map(_.sideCode) should be(Seq(TowardsDigitizing))
-    filledTopology.filter(_.id == 1).map(_.value) should be(Seq(Some(NumericValue(1))))
-    filledTopology.filter(_.id == 1).map(_.geometry) should be(Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0))))
-
-    filledTopology.filter(_.id == 0).map(_.sideCode) should be(Seq(AgainstDigitizing))
-    filledTopology.filter(_.id == 0).map(_.value) should be(Seq(None))
-    filledTopology.filter(_.id == 0).map(_.geometry) should be(Seq(Seq(Point(0.0, 0.0), Point(10.0, 0.0))))
-  }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -9,7 +9,7 @@ import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.TrafficSignInfo
-import fi.liikennevirasto.digiroad2.util.assetUpdater.LinearAssetUpdateProcess.{getAssetUpdater, linearAssetUpdater}
+import fi.liikennevirasto.digiroad2.util.assetUpdater.LinearAssetUpdateProcess.{getAssetUpdater}
 import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, LogUtils, PolygonTools}
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -245,15 +245,7 @@ trait LinearAssetOperations {
 
   def adjustLinearAssets(roadLinks: Seq[RoadLink], linearAssets: Map[String, Seq[PersistedLinearAsset]], typeId: Int): Seq[PieceWiseLinearAsset] = {
     val assetUpdater = getAssetUpdater(typeId)
-
-    val changeSet = ChangeSet( droppedAssetIds = Set.empty[Long],
-      expiredAssetIds = Set.empty[Long],
-      adjustedMValues = Seq.empty[MValueAdjustment],
-      adjustedVVHChanges = Seq.empty[VVHChangesAdjustment],
-      adjustedSideCodes = Seq.empty[SideCodeAdjustment],
-      valueAdjustments = Seq.empty[ValueAdjustment])
-
-    val (filledTopology, adjustmentsChangeSet) = assetFiller.fillTopology(roadLinks, linearAssets,  typeId, Some(changeSet), false)
+    val (filledTopology, adjustmentsChangeSet) = assetFiller.fillTopology(roadLinks, linearAssets,  typeId, geometryChanged = false)
     if(adjustmentsChangeSet.isEmpty) {
       assetFiller.toLinearAssetsOnMultipleLinks(filledTopology, roadLinks)
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
@@ -124,9 +124,10 @@ class MaintenanceService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
       }
 
     val groupedAssets = existingAssets.groupBy(_.linkId)
-    val filledTopology = assetFiller.fillRoadLinksWithoutAsset(roadLinks, groupedAssets, typeId)
-
-    filledTopology
+    val adjustedAssets = withDynTransaction {
+      adjustLinearAssets(roadLinks, groupedAssets, typeId)
+    }
+    adjustedAssets
   }
 
   def getPotencialServiceAssets: Seq[PersistedLinearAsset] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -7,7 +7,7 @@ import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
-import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
+import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, LogUtils, PolygonTools}
 import org.joda.time.DateTime
 
 class ProhibitionCreationException(val response: Set[String]) extends RuntimeException {}
@@ -64,7 +64,9 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
 
     val groupedAssets = existingAssets.groupBy(_.linkId)
     val adjustedAssets = withDynTransaction {
-      adjustLinearAssets(roadLinks, groupedAssets, typeId)
+      LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
+        adjustLinearAssets(roadLinks, groupedAssets, typeId)
+      }
     }
     adjustedAssets
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -3,10 +3,8 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 import fi.liikennevirasto.digiroad2.asset.ProhibitionClass._
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.vvh.ChangeInfo 
 import fi.liikennevirasto.digiroad2.dao.{MunicipalityDao, PostGISAssetDao}
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISLinearAssetDao
-import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.{LinearAssetUtils, PolygonTools}
@@ -65,9 +63,10 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
       }.filterNot(_.expired)
 
     val groupedAssets = existingAssets.groupBy(_.linkId)
-    val filledTopology = assetFiller.fillRoadLinksWithoutAsset(roadLinks, groupedAssets, typeId)
-
-    filledTopology
+    val adjustedAssets = withDynTransaction {
+      adjustLinearAssets(roadLinks, groupedAssets, typeId)
+    }
+    adjustedAssets
   }
 
   override def updateWithoutTransaction(ids: Seq[Long], value: Value, username: String, timeStamp: Option[Long] = None, sideCode: Option[Int] = None, measures: Option[Measures] = None, informationSource: Option[Int] = None): Seq[Long] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
@@ -8,7 +8,6 @@ import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.{LogUtils, PolygonTools}
-import fi.liikennevirasto.digiroad2.util.assetUpdater.LinearAssetUpdateProcess.linearAssetUpdater
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 
 class RoadWidthService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/RoadWidthService.scala
@@ -7,7 +7,7 @@ import fi.liikennevirasto.digiroad2.dao.linearasset.{AssetLastModification, Post
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
-import fi.liikennevirasto.digiroad2.util.PolygonTools
+import fi.liikennevirasto.digiroad2.util.{LogUtils, PolygonTools}
 import fi.liikennevirasto.digiroad2.util.assetUpdater.LinearAssetUpdateProcess.linearAssetUpdater
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 
@@ -31,7 +31,9 @@ class RoadWidthService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
       }
     val groupedAssets = existingAssets.groupBy(_.linkId)
     val adjustedAssets = withDynTransaction {
-      adjustLinearAssets(roadLinks, groupedAssets, typeId)
+      LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
+        adjustLinearAssets(roadLinks, groupedAssets, typeId)
+      }
     }
     adjustedAssets
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -264,7 +264,8 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
     }
 
     speedLimitUpdater.updateChangeSet(adjustmentsChangeSet)
-    filledTopology
+    if(adjustmentsChangeSet.isEmpty) filledTopology
+    else adjustSpeedLimitsAndGenerateUnknowns(roadLinksFiltered, filledTopology.groupBy(_.linkId))
   }
 
   def getAssetsAndPoints(existingAssets: Seq[SpeedLimit], roadLinks: Seq[RoadLink], changeInfo: (ChangeInfo, RoadLink)): Seq[(Point, SpeedLimit)] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
@@ -37,9 +37,10 @@ class PavedRoadService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
       }.filterNot(_.expired)
 
     val groupedAssets = existingAssets.groupBy(_.linkId)
-    val filledTopology = assetFiller.fillRoadLinksWithoutAsset(roadLinks, groupedAssets, typeId)
-
-    filledTopology
+    val adjustedAssets = withDynTransaction {
+      adjustLinearAssets(roadLinks, groupedAssets, typeId)
+    }
+    adjustedAssets
   }
 
   def getPavedRoadAssetChanges(existingLinearAssets: Seq[PersistedLinearAsset], roadLinks: Seq[RoadLink],

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PavedRoadService.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.{DynamicLinearAssetService, LinearAssetTypes, Measures}
-import fi.liikennevirasto.digiroad2.util.PolygonTools
+import fi.liikennevirasto.digiroad2.util.{LogUtils, PolygonTools}
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import org.joda.time.DateTime
 
@@ -38,7 +38,9 @@ class PavedRoadService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Digir
 
     val groupedAssets = existingAssets.groupBy(_.linkId)
     val adjustedAssets = withDynTransaction {
-      adjustLinearAssets(roadLinks, groupedAssets, typeId)
+      LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
+        adjustLinearAssets(roadLinks, groupedAssets, typeId)
+      }
     }
     adjustedAssets
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ChangeLanesAccordingToVvhChanges.scala
@@ -72,10 +72,9 @@ object ChangeLanesAccordingToVvhChanges {
     val allLanes = assetsOnChangedLinks.filterNot(a => projectedLanes.exists(_.linkId == a.linkId)) ++ projectedLanes ++ lanesWithoutChangedLinks
     val groupedAssets = allLanes.groupBy(_.linkId)
     val (changedLanes, changeSet) = laneFiller.fillTopology(roadLinks, groupedAssets, Some(changedSet))
-    val persistedChangedLanes = pieceWiseLanesToPersistedLane(changedLanes)
 
     val changeSetFilteredExpired = filterExpiredIds(changeSet)
-    (changeSetFilteredExpired, persistedChangedLanes)
+    (changeSetFilteredExpired, changedLanes)
   }
 
   def filterExpiredIds(set: ChangeSet): ChangeSet = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -51,31 +51,21 @@ object LinearAssetUpdateProcess {
     }
   }
 
-  def dynamicLinearAssetUpdater(typeId: Int) = new DynamicLinearAssetUpdater(getDynamicLinearAssetService(typeId))
-
-  def linearAssetUpdater(typeId: Int) = new LinearAssetUpdater(getLinearAssetService(typeId))
-
   def getAssetUpdater(typeId: Int): LinearAssetUpdater = {
     typeId match {
-      case MaintenanceRoadAsset.typeId => maintenanceRoadUpdater
-      case PavedRoad.typeId => pavedRoadUpdater
-      case Prohibition.typeId => prohibitionUpdater
-      case HazmatTransportProhibition.typeId => hazMatTransportProhibitionUpdater
-      case RoadWidth.typeId => roadWidthUpdater
-      case NumberOfLanes.typeId => linearAssetUpdater(typeId)
-      case TrafficVolume.typeId => linearAssetUpdater(typeId)
-      case WinterSpeedLimit.typeId => linearAssetUpdater(typeId)
-      case EuropeanRoads.typeId => linearAssetUpdater(typeId)
-      case ExitNumbers.typeId => linearAssetUpdater(typeId)
-      case _ => dynamicLinearAssetUpdater(typeId)
+      case MaintenanceRoadAsset.typeId => new MaintenanceRoadUpdater(maintenanceService)
+      case PavedRoad.typeId => new PavedRoadUpdater(pavedRoadService)
+      case Prohibition.typeId => new ProhibitionUpdater(prohibitionService)
+      case HazmatTransportProhibition.typeId => new HazMatTransportProhibitionUpdater(hazMatTransportProhibitionService)
+      case RoadWidth.typeId => new RoadWidthUpdater(roadWidthService)
+      case NumberOfLanes.typeId => new LinearAssetUpdater(getLinearAssetService(typeId))
+      case TrafficVolume.typeId => new LinearAssetUpdater(getLinearAssetService(typeId))
+      case WinterSpeedLimit.typeId => new LinearAssetUpdater(getLinearAssetService(typeId))
+      case EuropeanRoads.typeId => new LinearAssetUpdater(getLinearAssetService(typeId))
+      case ExitNumbers.typeId => new LinearAssetUpdater(getLinearAssetService(typeId))
+      case _ => new DynamicLinearAssetUpdater(getDynamicLinearAssetService(typeId))
     }
   }
-
-  lazy val maintenanceRoadUpdater = new MaintenanceRoadUpdater(maintenanceService)
-  lazy val pavedRoadUpdater = new PavedRoadUpdater(pavedRoadService)
-  lazy val prohibitionUpdater = new ProhibitionUpdater(prohibitionService)
-  lazy val hazMatTransportProhibitionUpdater = new HazMatTransportProhibitionUpdater(hazMatTransportProhibitionService)
-  lazy val roadWidthUpdater = new RoadWidthUpdater(roadWidthService)
   lazy val speedLimitUpdater = new SpeedLimitUpdater(eventbus, roadLinkService, speedLimitService)
 
   def main(args: Array[String]): Unit = {
@@ -93,32 +83,32 @@ object LinearAssetUpdateProcess {
       val assetName = args(0)
 
       assetName match {
-        case "animal_warnings" => linearAssetUpdater(AnimalWarnings.typeId).updateLinearAssets(AnimalWarnings.typeId)
-        case "care_class" => dynamicLinearAssetUpdater(CareClass.typeId).updateLinearAssets(CareClass.typeId)
-        case "carrying_capacity" => dynamicLinearAssetUpdater(CarryingCapacity.typeId).updateLinearAssets(CarryingCapacity.typeId)
-        case "damaged_by_thaw" => dynamicLinearAssetUpdater(DamagedByThaw.typeId).updateLinearAssets(DamagedByThaw.typeId)
-        case "height_limit" => dynamicLinearAssetUpdater(HeightLimit.typeId).updateLinearAssets(HeightLimit.typeId)
-        case "length_limit" => dynamicLinearAssetUpdater(LengthLimit.typeId).updateLinearAssets(LengthLimit.typeId)
-        case "width_limit" => dynamicLinearAssetUpdater(WidthLimit.typeId).updateLinearAssets(WidthLimit.typeId)
-        case "total_weight_limit" => dynamicLinearAssetUpdater(TotalWeightLimit.typeId).updateLinearAssets(TotalWeightLimit.typeId)
-        case "trailer_truck_weight_limit" => dynamicLinearAssetUpdater(TrailerTruckWeightLimit.typeId).updateLinearAssets(TrailerTruckWeightLimit.typeId)
-        case "axle_weight_limit" => dynamicLinearAssetUpdater(AxleWeightLimit.typeId).updateLinearAssets(AxleWeightLimit.typeId)
-        case "bogie_weight_limit" => dynamicLinearAssetUpdater(BogieWeightLimit.typeId).updateLinearAssets(BogieWeightLimit.typeId)
-        case "mass_transit_lane" => dynamicLinearAssetUpdater(MassTransitLane.typeId).updateLinearAssets(MassTransitLane.typeId)
-        case "parking_prohibition" => dynamicLinearAssetUpdater(ParkingProhibition.typeId).updateLinearAssets(ParkingProhibition.typeId)
-        case "cycling_and_walking" => dynamicLinearAssetUpdater(CyclingAndWalking.typeId).updateLinearAssets(CyclingAndWalking.typeId)
-        case "lit_road" => dynamicLinearAssetUpdater(LitRoad.typeId).updateLinearAssets(LitRoad.typeId)
-        case "road_work_asset" => dynamicLinearAssetUpdater(RoadWorksAsset.typeId).updateLinearAssets(RoadWorksAsset.typeId)
-        case "number_of_lanes" => linearAssetUpdater(NumberOfLanes.typeId).updateLinearAssets(NumberOfLanes.typeId)
-        case "traffic_volume" => linearAssetUpdater(TrafficVolume.typeId).updateLinearAssets(TrafficVolume.typeId)
-        case "winter_speed_limit" => linearAssetUpdater(WinterSpeedLimit.typeId).updateLinearAssets(WinterSpeedLimit.typeId)
-        case "european_roads" => linearAssetUpdater(EuropeanRoads.typeId).updateLinearAssets(EuropeanRoads.typeId)
-        case "exit_numbers" => linearAssetUpdater(ExitNumbers.typeId).updateLinearAssets(ExitNumbers.typeId)
-        case "maintenance_roads" => maintenanceRoadUpdater.updateLinearAssets(MaintenanceRoadAsset.typeId)
-        case "paved_roads" => pavedRoadUpdater.updateLinearAssets(PavedRoad.typeId)
-        case "prohibition" => prohibitionUpdater.updateLinearAssets(Prohibition.typeId)
-        case "hazmat_prohibition" => hazMatTransportProhibitionUpdater.updateLinearAssets(HazmatTransportProhibition.typeId)
-        case "road_width" => roadWidthUpdater.updateLinearAssets(RoadWidth.typeId)
+        case "animal_warnings" => getAssetUpdater(AnimalWarnings.typeId).updateLinearAssets(AnimalWarnings.typeId)
+        case "care_class" => getAssetUpdater(CareClass.typeId).updateLinearAssets(CareClass.typeId)
+        case "carrying_capacity" => getAssetUpdater(CarryingCapacity.typeId).updateLinearAssets(CarryingCapacity.typeId)
+        case "damaged_by_thaw" => getAssetUpdater(DamagedByThaw.typeId).updateLinearAssets(DamagedByThaw.typeId)
+        case "height_limit" => getAssetUpdater(HeightLimit.typeId).updateLinearAssets(HeightLimit.typeId)
+        case "length_limit" => getAssetUpdater(LengthLimit.typeId).updateLinearAssets(LengthLimit.typeId)
+        case "width_limit" => getAssetUpdater(WidthLimit.typeId).updateLinearAssets(WidthLimit.typeId)
+        case "total_weight_limit" => getAssetUpdater(TotalWeightLimit.typeId).updateLinearAssets(TotalWeightLimit.typeId)
+        case "trailer_truck_weight_limit" => getAssetUpdater(TrailerTruckWeightLimit.typeId).updateLinearAssets(TrailerTruckWeightLimit.typeId)
+        case "axle_weight_limit" => getAssetUpdater(AxleWeightLimit.typeId).updateLinearAssets(AxleWeightLimit.typeId)
+        case "bogie_weight_limit" => getAssetUpdater(BogieWeightLimit.typeId).updateLinearAssets(BogieWeightLimit.typeId)
+        case "mass_transit_lane" => getAssetUpdater(MassTransitLane.typeId).updateLinearAssets(MassTransitLane.typeId)
+        case "parking_prohibition" => getAssetUpdater(ParkingProhibition.typeId).updateLinearAssets(ParkingProhibition.typeId)
+        case "cycling_and_walking" => getAssetUpdater(CyclingAndWalking.typeId).updateLinearAssets(CyclingAndWalking.typeId)
+        case "lit_road" => getAssetUpdater(LitRoad.typeId).updateLinearAssets(LitRoad.typeId)
+        case "road_work_asset" => getAssetUpdater(RoadWorksAsset.typeId).updateLinearAssets(RoadWorksAsset.typeId)
+        case "number_of_lanes" => getAssetUpdater(NumberOfLanes.typeId).updateLinearAssets(NumberOfLanes.typeId)
+        case "traffic_volume" => getAssetUpdater(TrafficVolume.typeId).updateLinearAssets(TrafficVolume.typeId)
+        case "winter_speed_limit" => getAssetUpdater(WinterSpeedLimit.typeId).updateLinearAssets(WinterSpeedLimit.typeId)
+        case "european_roads" => getAssetUpdater(EuropeanRoads.typeId).updateLinearAssets(EuropeanRoads.typeId)
+        case "exit_numbers" => getAssetUpdater(ExitNumbers.typeId).updateLinearAssets(ExitNumbers.typeId)
+        case "maintenance_roads" => getAssetUpdater(MaintenanceRoadAsset.typeId).updateLinearAssets(MaintenanceRoadAsset.typeId)
+        case "paved_roads" => getAssetUpdater(PavedRoad.typeId).updateLinearAssets(PavedRoad.typeId)
+        case "prohibition" => getAssetUpdater(Prohibition.typeId).updateLinearAssets(Prohibition.typeId)
+        case "hazmat_prohibition" => getAssetUpdater(HazmatTransportProhibition.typeId).updateLinearAssets(HazmatTransportProhibition.typeId)
+        case "road_width" => getAssetUpdater(RoadWidth.typeId).updateLinearAssets(RoadWidth.typeId)
         case "speed_limit" => speedLimitUpdater.updateSpeedLimits()
         case _ => throw new IllegalArgumentException("Invalid asset name.")
       }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -29,18 +29,6 @@ object LinearAssetUpdateProcess {
     typeId match {
       case EuropeanRoads.typeId | ExitNumbers.typeId => new TextValueLinearAssetService(roadLinkService, eventbus)
       case NumberOfLanes.typeId => new NumberOfLanesService(roadLinkService, eventbus)
-      case HeightLimit.typeId => new LinearHeightLimitService(roadLinkService, eventbus)
-      case LengthLimit.typeId => new LinearLengthLimitService(roadLinkService, eventbus)
-      case WidthLimit.typeId => new LinearWidthLimitService(roadLinkService, eventbus)
-      case TotalWeightLimit.typeId => new LinearTotalWeightLimitService(roadLinkService, eventbus)
-      case TrailerTruckWeightLimit.typeId => new LinearTrailerTruckWeightLimitService(roadLinkService, eventbus)
-      case AxleWeightLimit.typeId => new LinearAxleWeightLimitService(roadLinkService, eventbus)
-      case BogieWeightLimit.typeId => new LinearBogieWeightLimitService(roadLinkService, eventbus)
-      case MassTransitLane.typeId => new MassTransitLaneService(roadLinkService, eventbus)
-      case DamagedByThaw.typeId => new DamagedByThawService(roadLinkService, eventbus)
-      case RoadWorksAsset.typeId => new RoadWorkService(roadLinkService, eventbus)
-      case ParkingProhibition.typeId => new ParkingProhibitionService(roadLinkService, eventbus)
-      case CyclingAndWalking.typeId => new CyclingAndWalkingService(roadLinkService, eventbus)
       case _ => linearAssetService
     }
   }
@@ -74,7 +62,12 @@ object LinearAssetUpdateProcess {
       case Prohibition.typeId => prohibitionUpdater
       case HazmatTransportProhibition.typeId => hazMatTransportProhibitionUpdater
       case RoadWidth.typeId => roadWidthUpdater
-      case _ => linearAssetUpdater(typeId)
+      case NumberOfLanes.typeId => linearAssetUpdater(typeId)
+      case TrafficVolume.typeId => linearAssetUpdater(typeId)
+      case WinterSpeedLimit.typeId => linearAssetUpdater(typeId)
+      case EuropeanRoads.typeId => linearAssetUpdater(typeId)
+      case ExitNumbers.typeId => linearAssetUpdater(typeId)
+      case _ => dynamicLinearAssetUpdater(typeId)
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -29,6 +29,18 @@ object LinearAssetUpdateProcess {
     typeId match {
       case EuropeanRoads.typeId | ExitNumbers.typeId => new TextValueLinearAssetService(roadLinkService, eventbus)
       case NumberOfLanes.typeId => new NumberOfLanesService(roadLinkService, eventbus)
+      case HeightLimit.typeId => new LinearHeightLimitService(roadLinkService, eventbus)
+      case LengthLimit.typeId => new LinearLengthLimitService(roadLinkService, eventbus)
+      case WidthLimit.typeId => new LinearWidthLimitService(roadLinkService, eventbus)
+      case TotalWeightLimit.typeId => new LinearTotalWeightLimitService(roadLinkService, eventbus)
+      case TrailerTruckWeightLimit.typeId => new LinearTrailerTruckWeightLimitService(roadLinkService, eventbus)
+      case AxleWeightLimit.typeId => new LinearAxleWeightLimitService(roadLinkService, eventbus)
+      case BogieWeightLimit.typeId => new LinearBogieWeightLimitService(roadLinkService, eventbus)
+      case MassTransitLane.typeId => new MassTransitLaneService(roadLinkService, eventbus)
+      case DamagedByThaw.typeId => new DamagedByThawService(roadLinkService, eventbus)
+      case RoadWorksAsset.typeId => new RoadWorkService(roadLinkService, eventbus)
+      case ParkingProhibition.typeId => new ParkingProhibitionService(roadLinkService, eventbus)
+      case CyclingAndWalking.typeId => new CyclingAndWalkingService(roadLinkService, eventbus)
       case _ => linearAssetService
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -67,6 +67,17 @@ object LinearAssetUpdateProcess {
 
   def linearAssetUpdater(typeId: Int) = new LinearAssetUpdater(getLinearAssetService(typeId))
 
+  def getAssetUpdater(typeId: Int): LinearAssetUpdater = {
+    typeId match {
+      case MaintenanceRoadAsset.typeId => maintenanceRoadUpdater
+      case PavedRoad.typeId => pavedRoadUpdater
+      case Prohibition.typeId => prohibitionUpdater
+      case HazmatTransportProhibition.typeId => hazMatTransportProhibitionUpdater
+      case RoadWidth.typeId => roadWidthUpdater
+      case _ => linearAssetUpdater(typeId)
+    }
+  }
+
   lazy val maintenanceRoadUpdater = new MaintenanceRoadUpdater(maintenanceService)
   lazy val pavedRoadUpdater = new PavedRoadUpdater(pavedRoadService)
   lazy val prohibitionUpdater = new ProhibitionUpdater(prohibitionService)


### PR DESCRIPTION
Tuotu viivamaisten kohteiden korjausoperaatiot takaisin haun yhteyteen. Erotettu ne operaatiot tähän jotka oleellisia ilman geometria muutoksia. Nostettu korjauksessa assetin ja linkin pituuksien erotuksen toleranssi 2.0. Tyhjien assettien täyttäminen tielinkeille joilla ei assettia siirretty korjausoperaatioiden kanssa samaan funktioon. Käydään rekursiivisesti korjausoperaatioita läpi linkille kunnes korjattavaa ei ole. 