### PR TITLE
Droth 3196 draw links temporarily out of use

### DIFF
--- a/UI/src/less/core/variables.less
+++ b/UI/src/less/core/variables.less
@@ -55,11 +55,13 @@
 @linear-asset-22:   #5dfac5; //mint
 
 //** Construction type colors
-@construction-type-1: #ff9900; //orange
-@construction-type-3: #cc99ff; //lilac
+@construction-type-1: #cc99ff; //lilac
+@construction-type-2: #ff9900; //orange
+@construction-type-4: #a2a8e4; //light blue
 
-@construction-type-node-1: #ffc266; //orange
-@construction-type-node-3: #b366ff; //lilac
+@construction-type-node-1: #b366ff; //lilac
+@construction-type-node-2: #ffc266; //orange
+@construction-type-node-4: #01b; //blue
 
 //** Speed limit colors
 @speed-limit-1: @linear-asset-1; //cyan

--- a/UI/src/less/site/action-panel.less
+++ b/UI/src/less/site/action-panel.less
@@ -549,7 +549,8 @@
       line-height: @line-height-base;
     }
     .construction-type-1 { .linear-asset-legend-entry(@construction-type-1, @construction-type-node-1); }
-    .construction-type-3 { .linear-asset-legend-entry(@construction-type-3, @construction-type-node-3); }
+    .construction-type-2 { .linear-asset-legend-entry(@construction-type-2, @construction-type-node-2); }
+    .construction-type-4 { .linear-asset-legend-entry(@construction-type-4, @construction-type-node-4); }
   }
 }
 

--- a/UI/src/view/link_property/linkPropertyForm.js
+++ b/UI/src/view/link_property/linkPropertyForm.js
@@ -70,7 +70,8 @@
     var constructionTypes= [
         [1, 'Suunnitteilla'], //Planned
         [2, 'Rakenteilla'], //Under Construction
-        [3, 'Käytössä'] //In Use
+        [3, 'Käytössä'], //In Use
+        [4, 'Väliaikaisesti poissa käytöstä'] //Temporarily out of use
     ];
 
     var linkSources= [

--- a/UI/src/view/link_property/linkPropertyLayerStyles.js
+++ b/UI/src/view/link_property/linkPropertyLayerStyles.js
@@ -60,7 +60,8 @@
 
     var linkStatusRules = [
       new StyleRule().where('constructionType').is(2).use({ stroke: { color: '#ff9900' } }),
-      new StyleRule().where('constructionType').is(1).use({ stroke: { color: '#cc99ff'} })
+      new StyleRule().where('constructionType').is(1).use({ stroke: { color: '#cc99ff'} }),
+      new StyleRule().where('constructionType').is(4).use({ stroke: { opacity: 0.3} })
     ];
 
     var linkTypeRules = [

--- a/UI/src/view/navigationpanel/massTransitStopBox.js
+++ b/UI/src/view/navigationpanel/massTransitStopBox.js
@@ -95,17 +95,21 @@
       ].join('');
 
       var constructionTypePanel = [
-      '   <div class="panel-section panel-legend linear-asset-legend construction-type-legend">',
+        '  <div class="panel-section panel-legend linear-asset-legend construction-type-legend">',
+        '    <div class="legend-entry">',
+        '      <div class="label">Suunnitteilla</div>',
+        '      <div class="symbol linear construction-type-1"/>',
+        '    </div>',
         '    <div class="legend-entry">',
         '      <div class="label">Rakenteilla</div>',
-        '      <div class="symbol linear construction-type-1"/>',
-        '   </div>',
-        '   <div class="legend-entry">',
-        '     <div class="label">Suunnitteilla</div>',
-        '     <div class="symbol linear construction-type-3"/>',
-        '   </div>',
-        ' </div>'
-      ].join('');
+        '      <div class="symbol linear construction-type-2"/>',
+        '    </div>',
+        '    <div class="legend-entry">',
+        '      <div class="label">Väliaikaisesti poissa käytöstä (haalennettu linkki)</div>',
+        '      <div class="symbol linear construction-type-4"/>',
+        '    </div>',
+        '  </div>'
+        ].join('');
 
       var massTransitStopPanel = '<div class="panel-section panel-legend limit-legend point-asset">';
       var pointAssetTypePanel = '<div class="panel-section panel-legend limit-legend point-asset service-points point-asset-legend">';

--- a/UI/src/view/navigationpanel/pointAssetBox.js
+++ b/UI/src/view/navigationpanel/pointAssetBox.js
@@ -67,17 +67,21 @@
       ].join('');
 
       var constructionTypePanel = [
-        '   <div class="panel-section panel-legend linear-asset-legend construction-type-legend">',
+        '  <div class="panel-section panel-legend linear-asset-legend construction-type-legend">',
+        '    <div class="legend-entry">',
+        '      <div class="label">Suunnitteilla</div>',
+        '      <div class="symbol linear construction-type-1"/>',
+        '    </div>',
         '    <div class="legend-entry">',
         '      <div class="label">Rakenteilla</div>',
-        '      <div class="symbol linear construction-type-1"/>',
-        '   </div>',
-        '   <div class="legend-entry">',
-        '     <div class="label">Suunnitteilla</div>',
-        '     <div class="symbol linear construction-type-3"/>',
-        '   </div>',
-        ' </div>'
-      ].join('');
+        '      <div class="symbol linear construction-type-2"/>',
+        '    </div>',
+        '    <div class="legend-entry">',
+        '      <div class="label">Väliaikaisesti poissa käytöstä (haalennettu linkki)</div>',
+        '      <div class="symbol linear construction-type-4"/>',
+        '    </div>',
+        '  </div>'
+        ].join('');
 
       return roadTypePanel.concat(constructionTypePanel);
     };

--- a/UI/src/view/navigationpanel/roadLinkBox.js
+++ b/UI/src/view/navigationpanel/roadLinkBox.js
@@ -139,8 +139,9 @@
 
     var constructionTypeLegend = $('<div class="panel-section panel-legend linear-asset-legend construction-type-legend"></div>');
     var constructionTypes = [
-      [1, 'Rakenteilla'], //Under construction
-      [3, 'Suunnitteilla'] //Planned
+      [1, 'Suunnitteilla'], //Planned
+      [2, 'Rakenteilla'], //Under construction
+      [4, 'Tilapäisesti poissa käytöstä (haalennettu linkki)'] // Temporarily out of use
     ];
     var constructionTypeLegendEntries = _.map(constructionTypes, function(constructionType) {
       return '<div class="legend-entry">' +

--- a/UI/src/view/navigationpanel/roadLinkBox.js
+++ b/UI/src/view/navigationpanel/roadLinkBox.js
@@ -141,7 +141,7 @@
     var constructionTypes = [
       [1, 'Suunnitteilla'], //Planned
       [2, 'Rakenteilla'], //Under construction
-      [4, 'Tilapäisesti poissa käytöstä (haalennettu linkki)'] // Temporarily out of use
+      [4, 'Väliaikaisesti poissa käytöstä (haalennettu linkki)'] // Temporarily out of use
     ];
     var constructionTypeLegendEntries = _.map(constructionTypes, function(constructionType) {
       return '<div class="legend-entry">' +

--- a/UI/src/view/point_asset/pointAssetLayerStyles.js
+++ b/UI/src/view/point_asset/pointAssetLayerStyles.js
@@ -20,7 +20,8 @@
 
     var linkStatusRules = [
       new StyleRule().where('constructionType').is(2).use({ stroke: { color: '#ff9900' } }),
-      new StyleRule().where('constructionType').is(1).use({ stroke: { color: '#cc99ff'} })
+      new StyleRule().where('constructionType').is(1).use({ stroke: { color: '#cc99ff'} }),
+      new StyleRule().where('constructionType').is(4).use({ stroke: { opacity: 0.3} })
     ];
 
     var featureTypeRules = [

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
@@ -33,7 +33,7 @@ sealed trait ConstructionType {
 }
 
 object ConstructionType{
-  val values = Set[ConstructionType](InUse, UnderConstruction, Planned, UnknownConstructionType)
+  val values = Set[ConstructionType](InUse, UnderConstruction, Planned, TemporarilyOutOfUse, UnknownConstructionType)
 
   def apply(intValue: Int): ConstructionType = {
     values.find(_.value == intValue).getOrElse(InUse)
@@ -42,6 +42,7 @@ object ConstructionType{
   case object Planned extends ConstructionType { def value = 1 }
   case object UnderConstruction extends ConstructionType { def value = 2 }
   case object InUse extends ConstructionType { def value = 3 }
+  case object TemporarilyOutOfUse extends ConstructionType { def value = 4 }
   case object UnknownConstructionType extends ConstructionType { def value = 99 }
 }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -322,7 +322,8 @@ class RoadLinkDAO {
           from kgv_roadlink
           where #$filter and constructiontype in (${ConstructionType.InUse.value},
                                                   ${ConstructionType.UnderConstruction.value},
-                                                  ${ConstructionType.Planned.value})
+                                                  ${ConstructionType.Planned.value},
+                                                  ${ConstructionType.TemporarilyOutOfUse.value})
           """.as[RoadLinkFetched].list
    }
   }


### PR DESCRIPTION
Linkki, joka on väliaikaisesti poissa käytöstä piirretään haaleammalla värillä. Sivupalkkeihin liittyvissä tiedostoissa oli vielä rakenteilla ja suunnitteilla vanhat arvot, joten nämä vaihdettu samalla.