### PR TITLE
DROTH-3477 Prevent infinite loop, no asset adjustments for Integratio…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -103,7 +103,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
 
   def lanesInMunicipalityToApi(municipalityNumber: Int): Seq[Map[String, Any]] = {
     val roadLinks = roadLinkService.getRoadLinksByMunicipalityUsingCache(municipalityNumber)
-    val lanes = laneService.getLanesByRoadLinks(roadLinks)
+    val lanes = laneService.getLanesByRoadLinks(roadLinks, adjust = false)
 
     val lanesWithRoadAddress = roadAddressService.laneWithRoadAddress(lanes).filter(_.attributes.contains("ROAD_NUMBER"))
     val twoDigitLanes = laneService.pieceWiseLanesToTwoDigitWithMassQuery(lanesWithRoadAddress).flatten
@@ -152,7 +152,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
       val correctLinks = roadLinksWithRoadAddress.filter(roadLink => roadLink.attributes("ROAD_NUMBER") == params.roadNumber
         && (roadPartRange contains roadLink.attributes("ROAD_PART_NUMBER")) && roadLink.attributes("TRACK") == params.track.value)
 
-      val lanesOnRoadLinks = laneService.getLanesByRoadLinks(correctLinks)
+      val lanesOnRoadLinks = laneService.getLanesByRoadLinks(correctLinks, adjust = false)
       val lanesWithRoadAddress = roadAddressService.laneWithRoadAddress(lanesOnRoadLinks).filter(_.attributes.contains("ROAD_NUMBER"))
 
       val twoDigitLanes = laneService.pieceWiseLanesToTwoDigitWithMassQuery(lanesWithRoadAddress).flatten

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -225,6 +225,8 @@ class AssetFiller {
 
   protected def updateValuesWithoutChangeSet(roadLink: RoadLink, segments: Seq[PersistedLinearAsset]): Seq[PersistedLinearAsset] = segments
 
+  //  TODO Due to a bug in combine, the operation divides asset to smaller segments which are then combined in fuse operation back together
+  //   causes an infinite loop when fillTopology is called recursively
   private def combine(roadLink: RoadLink, segments: Seq[PersistedLinearAsset], changeSet: ChangeSet): (Seq[PersistedLinearAsset], ChangeSet) = {
 
     def replaceUnknownAssetIds(asset: PersistedLinearAsset, pseudoId: Long) = {
@@ -533,7 +535,8 @@ class AssetFiller {
     }
   }
 
-  def fillTopology(topology: Seq[RoadLink], linearAssets: Map[String, Seq[PersistedLinearAsset]], typeId: Int, changedSet: Option[ChangeSet] = None, geometryChanged: Boolean = true): (Seq[PersistedLinearAsset], ChangeSet) = {
+  def fillTopology(topology: Seq[RoadLink], linearAssets: Map[String, Seq[PersistedLinearAsset]], typeId: Int,
+                   changedSet: Option[ChangeSet] = None, geometryChanged: Boolean = true): (Seq[PersistedLinearAsset], ChangeSet) = {
     val operations = getOperations(typeId, geometryChanged)
 
     val changeSet = changedSet match {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -134,24 +134,31 @@ trait LaneOperations {
     }.toSeq
   }
 
-   def getLanesByRoadLinks(roadLinks: Seq[RoadLink]): Seq[PieceWiseLane] = {
+   def getLanesByRoadLinks(roadLinks: Seq[RoadLink], adjust: Boolean = true): Seq[PieceWiseLane] = {
     val lanes = LogUtils.time(logger, "TEST LOG Fetch lanes from DB")(fetchExistingLanesByLinkIds(roadLinks.map(_.linkId).distinct))
-    val lanesMapped = lanes.groupBy(_.linkId)
-    val filledTopology = LogUtils.time(logger, "Check for and adjust possible lane adjustments on " + roadLinks.size + " roadLinks")(adjustLanes(roadLinks, lanesMapped))
-
-    filledTopology
+    if(adjust){
+      val lanesMapped = lanes.groupBy(_.linkId)
+      val filledTopology = LogUtils.time(logger, "Check for and adjust possible lane adjustments on " + roadLinks.size + " roadLinks"){
+        adjustLanes(roadLinks, lanesMapped, geometryChanged = false)
+      }
+      filledTopology
+    }
+    else laneFiller.toLPieceWiseLaneOnMultipleLinks(lanes, roadLinks)
   }
 
-  def adjustLanes(roadLinks: Seq[RoadLink], lanes: Map[String, Seq[PersistedLane]]): Seq[PieceWiseLane] = {
-    val (filledTopology, adjustmentsChangeSet) = laneFiller.fillTopology(roadLinks, lanes, geometryChanged = false)
-    if(adjustmentsChangeSet.isEmpty) {
-      laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, roadLinks)
-    }
-    else {
-      withDynTransaction {
+  def adjustLanes(roadLinks: Seq[RoadLink], lanes: Map[String, Seq[PersistedLane]], geometryChanged: Boolean, counter: Int = 1): Seq[PieceWiseLane] = {
+    val (filledTopology, adjustmentsChangeSet) = laneFiller.fillTopology(roadLinks, lanes, None, geometryChanged)
+
+    adjustmentsChangeSet.isEmpty match {
+      case true => laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, roadLinks)
+      case false if counter > 3 =>
         updateChangeSet(adjustmentsChangeSet)
-      }
-      adjustLanes(roadLinks, filledTopology.groupBy(_.linkId))
+        laneFiller.toLPieceWiseLaneOnMultipleLinks(filledTopology, roadLinks)
+      case false if counter <= 3 =>
+        withDynTransaction {
+          updateChangeSet(adjustmentsChangeSet)
+        }
+        adjustLanes(roadLinks, filledTopology.groupBy(_.linkId), geometryChanged, counter + 1)
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/MaintenanceService.scala
@@ -112,7 +112,7 @@ class MaintenanceService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
     }
   }
 
-  override protected def getByRoadLinks(typeId: Int, roadLinks: Seq[RoadLink]): Seq[PieceWiseLinearAsset] = {
+  override protected def getByRoadLinks(typeId: Int, roadLinks: Seq[RoadLink], adjust: Boolean = true): Seq[PieceWiseLinearAsset] = {
 
     // Filter high functional classes from maintenance roads
     val roads: Seq[RoadLink] = roadLinks.filter(_.functionalClass > 4)
@@ -123,13 +123,17 @@ class MaintenanceService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
         dynamicLinearAssetDao.fetchDynamicLinearAssetsByLinkIds(MaintenanceRoadAsset.typeId, linkIds).filterNot(_.expired)
       }
 
-    val groupedAssets = existingAssets.groupBy(_.linkId)
-    val adjustedAssets = withDynTransaction {
-      LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
-        adjustLinearAssets(roadLinks, groupedAssets, typeId)
+    if(adjust) {
+      val groupedAssets = existingAssets.groupBy(_.linkId)
+      val adjustedAssets = withDynTransaction {
+        LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
+          val filledTopology = adjustLinearAssets(roadLinks, groupedAssets, typeId, geometryChanged = false)
+          assetFiller.toLinearAssetsOnMultipleLinks(filledTopology, roadLinks)
+        }
       }
+      adjustedAssets
     }
-    adjustedAssets
+    else assetFiller.toLinearAssetsOnMultipleLinks(existingAssets, roadLinks)
   }
 
   def getPotencialServiceAssets: Seq[PersistedLinearAsset] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -54,7 +54,7 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
     }.filterNot(_.expired)
   }
 
-  override protected def getByRoadLinks(typeId: Int, roadLinks: Seq[RoadLink]): Seq[PieceWiseLinearAsset] = {
+  override protected def getByRoadLinks(typeId: Int, roadLinks: Seq[RoadLink], adjust: Boolean = true): Seq[PieceWiseLinearAsset] = {
     val linkIds = roadLinks.map(_.linkId)
 
     val existingAssets =
@@ -62,13 +62,17 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
         dao.fetchProhibitionsByLinkIds(typeId, linkIds)
       }.filterNot(_.expired)
 
-    val groupedAssets = existingAssets.groupBy(_.linkId)
-    val adjustedAssets = withDynTransaction {
-      LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
-        adjustLinearAssets(roadLinks, groupedAssets, typeId)
+    if (adjust) {
+      val groupedAssets = existingAssets.groupBy(_.linkId)
+      val adjustedAssets = withDynTransaction {
+        LogUtils.time(logger, "Check for and adjust possible linearAsset adjustments on " + roadLinks.size + " roadLinks. TypeID: " + typeId) {
+          val filledTopology = adjustLinearAssets(roadLinks, groupedAssets, typeId, geometryChanged = false)
+          assetFiller.toLinearAssetsOnMultipleLinks(filledTopology, roadLinks)
+        }
       }
+      adjustedAssets
     }
-    adjustedAssets
+    else assetFiller.toLinearAssetsOnMultipleLinks(existingAssets, roadLinks)
   }
 
   override def updateWithoutTransaction(ids: Seq[Long], value: Value, username: String, timeStamp: Option[Long] = None, sideCode: Option[Int] = None, measures: Option[Measures] = None, informationSource: Option[Int] = None): Seq[Long] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdater.scala
@@ -34,9 +34,7 @@ class MaintenanceRoadUpdater(service: MaintenanceService) extends DynamicLinearA
         combinedAssets, assetsOnChangedLinks, changes, initChangeSet, existingAssets)
 
       val groupedAssets = (existingAssets.filterNot(a => newAssets.exists(_.linkId == a.linkId)) ++ newAssets ++ assetsWithoutChangedLinks).groupBy(_.linkId)
-      val (filledTopology, changeSet) = assetFiller.fillTopology(roads, groupedAssets, typeId, Some(changedSet))
-
-      updateChangeSet(changeSet)
+      service.adjustLinearAssets(roads, groupedAssets, typeId, Some(changedSet), geometryChanged = true)
       persistProjectedLinearAssets(newAssets.filter(_.id == 0))
       logger.info(s"Updated maintenance roads in municipality $municipality.")
     } catch {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdater.scala
@@ -36,9 +36,7 @@ class PavedRoadUpdater(service: PavedRoadService) extends DynamicLinearAssetUpda
       val newAssets = newAndUpdatedPavedRoadAssets.filterNot(a => projectedAssets.exists(f => f.linkId == a.linkId)) ++ projectedAssets
 
       val groupedAssets = (existingAssets.filterNot(a => expiredIds.contains(a.id) || newAssets.exists(_.linkId == a.linkId)) ++ newAssets ++ assetsWithoutChangedLinks).groupBy(_.linkId)
-      val (filledTopology, changeSet) = assetFiller.fillTopology(roadLinks, groupedAssets, typeId, Some(changedSet))
-
-      updateChangeSet(changeSet)
+      service.adjustLinearAssets(roadLinks, groupedAssets, typeId, Some(changedSet), geometryChanged = true)
       persistProjectedLinearAssets(newAssets.filter(_.id == 0))
       logger.info(s"Updated paved roads in municipality $municipality.")
     } catch {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ProhibitionUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ProhibitionUpdater.scala
@@ -38,9 +38,7 @@ class ProhibitionUpdater(service: ProhibitionService) extends LinearAssetUpdater
         logger.info("Transferred %d assets in %d ms ".format(newAssets.length, System.currentTimeMillis - timing))
       }
       val groupedAssets = (existingAssets.filterNot(a => newAssets.exists(_.linkId == a.linkId)) ++ newAssets ++ assetsWithoutChangedLinks).groupBy(_.linkId)
-      val (filledTopology, changeSet) = assetFiller.fillTopology(roadLinks, groupedAssets, typeId, Some(changedSet))
-      updateChangeSet(changeSet)
-
+      service.adjustLinearAssets(roadLinks, groupedAssets, typeId, Some(changedSet), geometryChanged = true)
       persistProjectedLinearAssets(newAssets.filter(_.id == 0))
 
       logger.info(s"Updated asset $typeId in municipality $municipality.")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdater.scala
@@ -40,10 +40,9 @@ class RoadWidthUpdater(service: RoadWidthService) extends DynamicLinearAssetUpda
         newRoadWidthAssets
 
       val groupedAssets = (existingAssets.filterNot(a => changedSet.expiredAssetIds.contains(a.id) || newAssets.exists(_.linkId == a.linkId)) ++ newAssets).groupBy(_.linkId)
-      val (filledTopology, changeSet) = assetFiller.fillTopology(roadLinks, groupedAssets, typeId, Some(changedSet))
-
-      updateChangeSet(changeSet)
+      service.adjustLinearAssets(roadLinks, groupedAssets, typeId, Some(changedSet), geometryChanged = true)
       persistProjectedLinearAssets(newAssets.filter(_.id == 0))
+
       logger.info(s"Updated road widths in municipality $municipality.")
     } catch {
       case e => logger.error(s"Updating road widths in municipality $municipality failed due to ${e.getMessage}.")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -6,6 +6,7 @@ import fi.liikennevirasto.digiroad2.client.vvh.ChangeType.New
 import fi.liikennevirasto.digiroad2.client.vvh.{ChangeInfo, ChangeType}
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
+import fi.liikennevirasto.digiroad2.linearasset.SpeedLimitFiller.fillTopology
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
@@ -52,17 +53,32 @@ class SpeedLimitUpdater(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       speedLimitsOnChangedLinks, changes, initChangeSet, speedLimitLinks)
 
     val speedLimits = (speedLimitLinks ++ newSpeedLimits).groupBy(_.linkId)
+    handleChangesAndUnknowns(topology, speedLimits, Some(projectedChangeSet), oldRoadLinkIds, geometryChanged = true)
+  }
+
+  def handleChangesAndUnknowns(topology: Seq[RoadLink], speedLimits: Map[String, Seq[SpeedLimit]],
+                               changeSet:Option[ChangeSet] = None, oldRoadLinkIds: Seq[String], geometryChanged: Boolean, counter: Int = 1): Seq[SpeedLimit] = {
+    val (filledTopology, adjustmentsChangeSet) = fillTopology(topology, speedLimits, changeSet, geometryChanged)
     val roadLinksByLinkId = topology.groupBy(_.linkId).mapValues(_.head)
-
-    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(topology, speedLimits, Some(projectedChangeSet))
-
     val newSpeedLimitsWithValue = filledTopology.filter(sl => sl.id <= 0 && sl.value.nonEmpty)
-    // Expire all assets that are dropped or expired. No more floating speed limits.
-    updateChangeSet(changeSet.copy(expiredAssetIds = changeSet.expiredAssetIds ++ changeSet.droppedAssetIds, droppedAssetIds = Set()))
-    persistProjectedLimit(newSpeedLimitsWithValue)
-    purgeUnknown(changeSet.adjustedMValues.map(_.linkId).toSet, oldRoadLinkIds)
     val unknownLimits = createUnknownLimits(filledTopology, roadLinksByLinkId)
-    persistUnknown(unknownLimits)
+
+    adjustmentsChangeSet.equals(changeSet.get) match {
+      case true =>
+        persistProjectedLimit(newSpeedLimitsWithValue)
+        persistUnknown(unknownLimits)
+        filledTopology
+      case false if counter > 3 =>
+        updateChangeSet(adjustmentsChangeSet)
+        persistProjectedLimit(newSpeedLimitsWithValue)
+        purgeUnknown(adjustmentsChangeSet.adjustedMValues.map(_.linkId).toSet, oldRoadLinkIds)
+        persistUnknown(unknownLimits)
+        filledTopology
+      case false if counter <= 3 =>
+        updateChangeSet(adjustmentsChangeSet)
+        purgeUnknown(adjustmentsChangeSet.adjustedMValues.map(_.linkId).toSet, oldRoadLinkIds)
+        handleChangesAndUnknowns(topology, filledTopology.groupBy(_.linkId), None ,oldRoadLinkIds, geometryChanged, counter + 1)
+    }
   }
 
   def updateChangeSet(changeSet: ChangeSet) : Unit = {


### PR DESCRIPTION
DRAFT

Tehty:
-Estetty mahdollisuus loputtomalle silmukalle korjausoperaatioita suorittaessa 
-Lisätty parametrisoitu halutaanko suorittaa korjaukset getByRoadLinks haun yhteydessä (UI;n boundingBox hauille true, 
  IntegrationApin municipality haulle false). 
-Samuutusbatchit kutsuvat nyt adjustLinearAssets, sen sijaan, että kutsuvat suoraan fillTopology. 

Loputtoman silmukan aihettanut bugi kuvattu tiketissä, tämä korjattu nyt filtteröimällä turhat MValueAdjustmentit pois korjausoperaatioiden jälkeen

TODO:
-SpeedLimitUpdaterille muiden LinearAssetUpdater kaltainen tapa kutsua fillTopologya rekursiivisesti, jotta saadaan tehtyä korjausoperaatiot kunnes niille ei enää tarvetta tai looppien raja (3) tulee vastaan. 
-Korjaus suoraan combine operaatioon, filtteröinnin sijaan jos mahdollista ilman suurempaa operaation uudelleen kirjoittamista 

