### PR TITLE
DROTH-3481 Remove extra closings of divs

### DIFF
--- a/UI/src/view/navigationpanel/manoeuvreBox.js
+++ b/UI/src/view/navigationpanel/manoeuvreBox.js
@@ -22,7 +22,6 @@
     var manoeuvreSignsCheckBox = [
       '<div class="check-box-container">' +
       '<input id="manoeuvreSignsCheckBox" type="checkbox" /> <lable>Näytä liikennemerkit</lable>' +
-      '</div>' +
       '</div>'
     ].join('');
 

--- a/UI/src/view/navigationpanel/speedLimitBox.js
+++ b/UI/src/view/navigationpanel/speedLimitBox.js
@@ -41,7 +41,6 @@
       var speedLimitSignsCheckBox = [
         '<div class="check-box-container">' +
         '<input id="trafficSignsCheckbox" type="checkbox" /> <lable>Näytä liikennemerkit</lable>' +
-        '</div>' +
         '</div>'
       ].join('');
 


### PR DESCRIPTION
Poistettu ylimääräisiksi DROTH-3196 jälkeen jääneet divien sulkemiset, jotka hajottivat muokkaustilaan siirtymisen nopeusrajoituksilla ja kääntymisrajoituksilla.