### PR TITLE
DROTH-3488 override inherited function to fix double rendering

### DIFF
--- a/UI/src/view/navigationpanel/massTransitStopBox.js
+++ b/UI/src/view/navigationpanel/massTransitStopBox.js
@@ -120,6 +120,8 @@
       return roadTypePanel.concat(constructionTypePanel).concat(massTransitStopPanel).concat(pointAssetTypePanel);
     };
 
+    this.constructionTypeLabeling = function () {};
+
     this.checkboxPanel = function () {
       return [
         '  <div class="panel-section roadLink-complementary-checkbox">',


### PR DESCRIPTION
Bussipysäkkien legendissä näytetään kaikki constructiontypet paitsi käytössä. Lisäksi uusi "väliaikaisesti poissa käytöstä" label tulee nyt tuplana perinnän kautta. Ylikirjoitetaan peritty funktio tyhjällä funktiolla ongelman korjaamiseksi.