### PR TITLE
DROTH-3484 fix bug with unknown assets

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetFiller.scala
@@ -23,12 +23,12 @@ object LinearAssetFiller {
     }
 
     def filterGeneratedAssets: ChangeSet = {
-      ChangeSet(this.droppedAssetIds.filterNot(_ == 0),
-        this.adjustedMValues.filterNot(_.assetId == 0),
-        this.adjustedVVHChanges.filterNot(_.assetId == 0),
-        this.adjustedSideCodes.filterNot(_.assetId == 0),
-        this.expiredAssetIds.filterNot(_ == 0),
-        this.valueAdjustments.filterNot(_.asset.id == 0))
+      ChangeSet(this.droppedAssetIds.filterNot(_ <= 0),
+        this.adjustedMValues.filterNot(_.assetId <= 0),
+        this.adjustedVVHChanges.filterNot(_.assetId <= 0),
+        this.adjustedSideCodes.filterNot(_.assetId <= 0),
+        this.expiredAssetIds.filterNot(_ <= 0),
+        this.valueAdjustments.filterNot(_.asset.id <= 0))
     }
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -259,7 +259,8 @@ trait LinearAssetOperations {
         filledTopology
       case false if counter <= 3 =>
         assetUpdater.updateChangeSet(adjustmentsChangeSet)
-        adjustLinearAssets(roadLinks, filledTopology.groupBy(_.linkId), typeId, None, geometryChanged, counter + 1)
+        val linearAssetsToAdjust = filledTopology.filterNot(_.id <= 0).groupBy(_.linkId)
+        adjustLinearAssets(roadLinks, linearAssetsToAdjust, typeId, None, geometryChanged, counter + 1)
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -254,7 +254,8 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
         filledTopology
       case false if counter <= 3 =>
         speedLimitUpdater.updateChangeSet(cleanedChangeSet)
-        adjustSpeedLimitsAndGenerateUnknowns(roadLinksFiltered, filledTopology.groupBy(_.linkId), None, geometryChanged, counter + 1)
+        val speedLimitsToAdjust = filledTopology.filterNot(_.id <= 0).groupBy(_.linkId)
+        adjustSpeedLimitsAndGenerateUnknowns(roadLinksFiltered, speedLimitsToAdjust, None, geometryChanged, counter + 1)
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -87,7 +87,8 @@ class SpeedLimitUpdater(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       case false if counter <= 3 =>
         updateChangeSet(cleanedChangeSet)
         purgeUnknown(cleanedChangeSet.adjustedMValues.map(_.linkId).toSet, oldRoadLinkIds)
-        handleChangesAndUnknowns(topology, filledTopology.groupBy(_.linkId), None ,oldRoadLinkIds, geometryChanged, counter + 1)
+        val speedLimitsToAdjust = filledTopology.filterNot(_.id <= 0).groupBy(_.linkId)
+        handleChangesAndUnknowns(topology, speedLimitsToAdjust, None ,oldRoadLinkIds, geometryChanged, counter + 1)
     }
   }
 


### PR DESCRIPTION
Korjattu virhe korjausoperaatioissa. Filteröidään ennen uutta fillTopology kutsua generoidut unknown assetit pois, näille ei ole tarkoituksenmukaista tehdä korjausoperaatioita vaan generoidaan uudet korjausoperaatioiden lopuksi. Yhdenmukaistettu tuntemattomien filtteröinti käyttämään <= 0, koska korjausoperaatioissa annetaan juokseva negatiivinen numero pseudoID:ksi tuntemattomille.