### PR TITLE
DROTH-2830 Update F53 traffic sign enumerated value

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/TrafficSign.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/TrafficSign.scala
@@ -70,7 +70,7 @@ object TrafficSignType {
     CompulsoryTrackMotorSledges, CompulsoryTrackRidersHorseback, FreeWidth, FreeHeight, HeightElectricLine, SignAppliesBothDirections, SignAppliesBothDirectionsVertical, SignAppliesArrowDirections,
     RegulationBeginsFromSign, RegulationEndsToTheSign, HazmatProhibitionA, HazmatProhibitionB, ValidMonFri, ValidSat, ValidMultiplePeriod, TimeLimit, DistanceCompulsoryStop, DirectionOfPriorityRoad,
     CrossingLogTransportRoad, PassengerCar, Bus, Lorry, Van, VehicleForHandicapped, MotorCycle, Cycle, ParkingAgainstFee, ObligatoryUseOfParkingDisc, AdditionalPanelWithText,
-    DrivingInServicePurposesAllowed, NoThroughRoad, NoThroughRoadRight, SymbolOfMotorway, Parking, ItineraryForIndicatedVehicleCategory, ItineraryForPedestrians, ItineraryForHandicapped,
+    DrivingInServicePurposesAllowed, NoThroughRoad, NoThroughRoadRight, SymbolOfMotorway, Parking, ItineraryForIndicatedVehicleCategory, ItineraryForPedestrians, AccessibleRoute,
     LocationSignForTouristService, FirstAid, FillingStation, Restaurant, PublicLavatory, DistanceFromSignToPointWhichSignApplies, DistanceWhichSignApplies,
     AdvanceDirectionSign, AdvanceDirectionSignSmall, AdvisorySignDetour, AdvisorySignDetourLarge, Detour, RouteToBeFollowed, InformationOnTrafficLanes, BiDirectionalInformationOnTrafficLanes,
     EndOfLane, AdvanceDirectionSignAbove, ExitSignAbove, DirectionSign, ExitSign, DirectionSignOnPrivateRoad, LocationSign, DirectionSignForDetourWithText, DirectionSignForDetour,
@@ -2128,7 +2128,7 @@ case object ItineraryForPedestrians extends InformationSignsType {
   override val NewLawCode = "F52"
 }
 
-case object ItineraryForHandicapped extends InformationSignsType {
+case object AccessibleRoute extends InformationSignsType {
   override val OTHvalue = 119
   override val TRvalue = 653 // UUSIASNR Value in TR
   override val OldLawCode: Option[Int] = Some(683)

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_18__update_traffic_sign_F53_enumerated_value.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_18__update_traffic_sign_F53_enumerated_value.sql
@@ -1,0 +1,1 @@
+UPDATE enumerated_value SET name_fi = E'F53 Esteetön reitti', modified_date = current_timestamp, modified_by = E'db_migration_v1_18' WHERE property_id = (select id from property where public_id = 'trafficSigns_type') AND value = 119;


### PR DESCRIPTION
Päivitetty F53 liikennemerkin nimeksi "F53 Esteetön reitti" (vanha "F53 Vammaiselle tarkoitettu reitti"). Päivitetty myös koodissa käytetty termi vastaamaan uutta nimeä.