### PR TITLE
DROTH-3484 Fix bug with filtering projected new assets

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -259,7 +259,7 @@ trait LinearAssetOperations {
         filledTopology
       case false if counter <= 3 =>
         assetUpdater.updateChangeSet(adjustmentsChangeSet)
-        val linearAssetsToAdjust = filledTopology.filterNot(_.id <= 0).groupBy(_.linkId)
+        val linearAssetsToAdjust = filledTopology.filterNot(asset => asset.id <= 0 && asset.value.isEmpty).groupBy(_.linkId)
         adjustLinearAssets(roadLinks, linearAssetsToAdjust, typeId, None, geometryChanged, counter + 1)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -254,7 +254,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
         filledTopology
       case false if counter <= 3 =>
         speedLimitUpdater.updateChangeSet(cleanedChangeSet)
-        val speedLimitsToAdjust = filledTopology.filterNot(_.id <= 0).groupBy(_.linkId)
+        val speedLimitsToAdjust = filledTopology.filterNot(speedLimit => speedLimit.id <= 0 && speedLimit.value.isEmpty).groupBy(_.linkId)
         adjustSpeedLimitsAndGenerateUnknowns(roadLinksFiltered, speedLimitsToAdjust, None, geometryChanged, counter + 1)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -87,7 +87,7 @@ class SpeedLimitUpdater(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       case false if counter <= 3 =>
         updateChangeSet(cleanedChangeSet)
         purgeUnknown(cleanedChangeSet.adjustedMValues.map(_.linkId).toSet, oldRoadLinkIds)
-        val speedLimitsToAdjust = filledTopology.filterNot(_.id <= 0).groupBy(_.linkId)
+        val speedLimitsToAdjust = filledTopology.filterNot(speedLimit => speedLimit.id <= 0 && speedLimit.value.isEmpty).groupBy(_.linkId)
         handleChangesAndUnknowns(topology, speedLimitsToAdjust, None ,oldRoadLinkIds, geometryChanged, counter + 1)
     }
   }


### PR DESCRIPTION
Lisätty .value.isEmpty, suodatukseen, jotta ei suodateta pois vanhoilta tielinkeiltä uusille projektoituja assetteja