### PR TITLE
DROTH-2640 Allow five additional panels for traffic sign

### DIFF
--- a/UI/src/view/point_asset/trafficSignForm.js
+++ b/UI/src/view/point_asset/trafficSignForm.js
@@ -152,7 +152,7 @@
         var panels = cont.children().size();
 
         cont.find('.remove-panel').toggle(panels !== 1);
-        cont.find('.add-panel').prop("disabled", panels === 3);
+        cont.find('.add-panel').prop("disabled", panels === 5);
       }
 
       rootElement.find('button#change-validity-direction').on('click', function() {

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_19__increase_maximum_number_of_additional_panels.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_19__increase_maximum_number_of_additional_panels.sql
@@ -1,0 +1,5 @@
+ALTER TABLE additional_panel DROP CONSTRAINT sys_c003961016;
+ALTER TABLE additional_panel ADD CONSTRAINT sys_c003961016 CHECK (form_position <= 5);
+
+ALTER TABLE additional_panel_history DROP CONSTRAINT sys_c003961116;
+ALTER TABLE additional_panel_history ADD CONSTRAINT sys_c003961116 CHECK (form_position <= 5);

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -49,7 +49,7 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
   lazy val trafficSignService: TrafficSignService = new TrafficSignService(roadLinkService, eventBusImpl)
 
   val minAdditionalPanels = 1
-  val maxAdditionalPanels = 3
+  val maxAdditionalPanels = 5
 
   private val longValueFieldMappings = coordinateMappings
 
@@ -129,7 +129,21 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
     "lisakilpi teksti 3"-> "additionalPanelText3",
     "lisakilpi koko 3" -> "additionalPanelSize3",
     "lisakilpi kalvon tyyppi 3" -> "additionalPanelCoatingType3",
-    "lisakilpi lisakilven vari 3" -> "additionalPanelColor3"
+    "lisakilpi lisakilven vari 3" -> "additionalPanelColor3",
+    "lisakilpi 4" -> "additionalPanelType4",
+    "lisakilpi arvo 4" -> "additionalPanelValue4",
+    "lisakilpi lisatieto 4" -> "additionalPanelInfo4",
+    "lisakilpi teksti 4"-> "additionalPanelText4",
+    "lisakilpi koko 4" -> "additionalPanelSize4",
+    "lisakilpi kalvon tyyppi 4" -> "additionalPanelCoatingType4",
+    "lisakilpi lisakilven vari 4" -> "additionalPanelColor4",
+    "lisakilpi 5" -> "additionalPanelType5",
+    "lisakilpi arvo 5" -> "additionalPanelValue5",
+    "lisakilpi lisatieto 5" -> "additionalPanelInfo5",
+    "lisakilpi teksti 5"-> "additionalPanelText5",
+    "lisakilpi koko 5" -> "additionalPanelSize5",
+    "lisakilpi kalvon tyyppi 5" -> "additionalPanelCoatingType5",
+    "lisakilpi lisakilven vari 5" -> "additionalPanelColor5"
   )
 
   private val codeValueFieldMappings = Map(

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISTrafficSignDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISTrafficSignDao.scala
@@ -432,7 +432,7 @@ object PostGISTrafficSignDao {
           updateSingleChoiceProperty(assetId, propertyId, propertyValues.head.asInstanceOf[PropertyValue].propertyValue.toLong).execute
         }
       case AdditionalPanelType =>
-        if (propertyValues.size > 3) throw new IllegalArgumentException("A maximum of 3 " + propertyPublicId + " allowed per traffic sign.")
+        if (propertyValues.size > 5) throw new IllegalArgumentException("A maximum of 5 " + propertyPublicId + " allowed per traffic sign.")
         deleteAdditionalPanelProperty(assetId).execute
         propertyValues.foreach{value =>
           val additionalPanel = value.asInstanceOf[AdditionalPanel]


### PR DESCRIPTION
Mahdollistetaan viiden lisäkilven lisääminen samalle päämerkille. Ennen sallittu ainoastaan kolme lisäkilpeä.