### PR TITLE
DROTH-3553 fix ChangeApi type cast

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -588,8 +588,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
       val lane = laneChange.lane
       val oldLane = laneChange.oldLane.get
 
-      val roadStartAddr = roadLink.attributes.get("START_ADDR").toString.toDouble
-      val roadEndAddr = roadLink.attributes.get("END_ADDR").toString.toDouble
+      val roadStartAddr = roadLink.attributes("START_ADDR").toString.toDouble
+      val roadEndAddr = roadLink.attributes("END_ADDR").toString.toDouble
 
       val laneStartAddr = (roadStartAddr + lane.startMeasure).toInt
       val laneEndAddr = (roadEndAddr - (roadLink.length - lane.endMeasure)).toInt


### PR DESCRIPTION
Korjattu virhe ChangeApissa. Virhe oli tullut kun TEMP tieosoitteiden käyttö poistettu. Aikaisemmin oli .getOrElse, oli vahingossa tullut .get, joka palauttaa Option. Tielinkit on tässä vaiheessa koodia jo suodatettu tieosoitteellisuuden mukaan, joten ei tarvetta option.