### PR TITLE
DROTH-3497 Add cloudformation templates and initialize lambda

### DIFF
--- a/lambda/road-link-change-handler/.dockerignore
+++ b/lambda/road-link-change-handler/.dockerignore
@@ -1,0 +1,17 @@
+# Git
+.gitignore
+.git/
+
+# IntelliJ IDEA
+.idea/
+*.idea
+
+# Development
+dist/
+node_modules/
+schemas/
+aws/
+.aws-sam/
+env*
+events/
+*.log

--- a/lambda/road-link-change-handler/Dockerfile
+++ b/lambda/road-link-change-handler/Dockerfile
@@ -8,7 +8,7 @@ COPY . ${LAMBDA_TASK_ROOT}
 RUN npm run compile
 
 # Run unit tests
-# RUN npm run test
+RUN npm run test
 
 # Remove unnecessary files from image
 RUN npm prune --production

--- a/lambda/road-link-change-handler/Dockerfile
+++ b/lambda/road-link-change-handler/Dockerfile
@@ -1,0 +1,20 @@
+FROM public.ecr.aws/lambda/nodejs:18
+
+COPY package*.json ${LAMBDA_TASK_ROOT}/
+RUN npm install
+COPY . ${LAMBDA_TASK_ROOT}
+
+# Compile typescript code
+RUN npm run compile
+
+# Run unit tests
+# RUN npm run test
+
+# Remove unnecessary files from image
+RUN npm prune --production
+RUN npm run post-compile
+
+# Move dist directory contents to root and remove empty directory
+RUN mv dist/* ${LAMBDA_TASK_ROOT} && rmdir dist
+
+CMD ["index.handler"]

--- a/lambda/road-link-change-handler/README.md
+++ b/lambda/road-link-change-handler/README.md
@@ -1,0 +1,1 @@
+# Tielinkkien muutosten kyselijä lambda

--- a/lambda/road-link-change-handler/aws/cloudformation/ecr/dev.yaml
+++ b/lambda/road-link-change-handler/aws/cloudformation/ecr/dev.yaml
@@ -1,0 +1,101 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Elastic Container Repository template for Digiroad road link change handler dev environment
+
+Resources:
+  ECR:
+    Type: AWS::ECR::Repository
+    DeletionPolicy: Retain
+    Properties:
+      RepositoryName: digiroad2-road-link-change-lambda
+      ImageScanningConfiguration:
+        ScanOnPush: true
+      RepositoryPolicyText:
+        Version: 2012-10-17
+        Statement:
+          - Sid: LambdaECRImageRetrievalPolicy
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Condition:
+              StringLike:
+                aws:sourceArn: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:*"
+            Action:
+              - ecr:BatchGetImage
+              - ecr:DeleteRepositoryPolicy
+              - ecr:GetDownloadUrlForLayer
+              - ecr:GetRepositoryPolicy
+              - ecr:SetRepositoryPolicy
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+              {
+                "rulePriority": 1,
+                "description": "Retain image tagged with latest",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["latest"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 1
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 2,
+                "description": "Retain 10 images tagged with qa",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["qa"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 3,
+                "description": "Retain 10 images tagged with prod",
+                "selection": {
+                  "tagStatus": "tagged",
+                  "tagPrefixList": ["prod"],
+                  "countType": "imageCountMoreThan",
+                  "countNumber": 10
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 4,
+                "description": "Expire untagged images after one day",
+                "selection": {
+                  "tagStatus": "untagged",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 1
+                },
+                "action": {
+                  "type": "expire"
+                }
+              },
+              {
+                "rulePriority": 5,
+                "description": "Expire images not tagged with prod or latest after 90 days",
+                "selection": {
+                  "tagStatus": "any",
+                  "countType": "sinceImagePushed",
+                  "countUnit": "days",
+                  "countNumber": 90
+                },
+                "action": {
+                  "type": "expire"
+                }
+              }
+            ]
+          }
+      Tags:
+        - Key: Name
+          Value: digiroad2-road-link-change-lambda-dev-ecr-repo

--- a/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
+++ b/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
@@ -1,0 +1,192 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Template for resources that are used to fetch changes in road links.
+
+Parameters:
+  ApplicationName:
+    Description: Name of the application. Used when tagging the resources
+    Type: String
+  Environment:
+    Description: Environment where resources are created. Used when tagging the resources
+    Type: String
+    AllowedValues: ["dev", "qa", "prod"]
+  OrganizationPrefix:
+    Description: Prefix for organization
+    Type: String
+  ECRRepository:
+    Type: String
+    Description: Name of ECR repository
+  ECRImageTag:
+    Type: String
+    Description: ECR image tag name
+
+Conditions:
+  IsDev:
+    "Fn::Equals":
+      - !Ref Environment
+      - dev
+
+Resources:
+  ### S3 ###
+  ChangeBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    Properties:
+      BucketName: !Sub ${Environment}-${OrganizationPrefix}-${ApplicationName}-road-link-change-bucket
+      ObjectLockEnabled: false
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: DeleteIncompleteMultipartUploads
+            AbortIncompleteMultipartUpload:
+              DaysAfterInitiation: 1
+            Status: Enabled
+      # TODO: NotificationConfiguration: -- add notification configuration to new object notify uploads
+      Tags:
+        - Key: Name
+          Value: !Sub ${ApplicationName}-${Environment}-road-link-change-bucket
+
+  ChangeBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    DependsOn:
+      - LambdaRole
+    Properties:
+      Bucket: !Ref ChangeBucket
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: LambdaPolicy
+            Effect: Allow
+            Principal:
+              AWS:
+                - !GetAtt LambdaRole.Arn
+            Action:
+              - s3:ListBucket   # Needed for defining time window for changes
+              - s3:PutObject    # Allows new object uploads
+            Resource:
+              - !GetAtt ChangeBucket.Arn
+              - !Join ['', [!GetAtt ChangeBucket.Arn, '/*']]
+          # TODO: Add permission for batch role to list and get objects
+
+
+  ### LAMBDA ###
+  Lambda:
+    DependsOn: LambdaRole
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub "${Environment}-${ApplicationName}-road-link-change-handler"
+      Description: Lambda for fetching road link changes, saving them and generating change sets
+      MemorySize: 128 # Increase according to need
+      Timeout: 30     # Increase according to need
+      Role: !GetAtt LambdaRole.Arn
+      PackageType: Image
+      Code:
+        ImageUri: !Sub ${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/${ECRRepository}:${ECRImageTag}
+      ImageConfig:
+        Command:
+          - index.handler
+      Environment:
+        Variables:
+          CHANGES_FROM:   ""  # For testing purposes
+          CHANGES_TO:     ""  # For testing purposes
+          CHANGE_BUCKET:  !Sub ${Environment}-${OrganizationPrefix}-${ApplicationName}-road-link-change-bucket
+      Tags:
+        - Key: Name
+          Value: !Sub ${ApplicationName}-${Environment}-road-link-change-lambda-role
+
+  StartLambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt Lambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/${Environment}-${ApplicationName}-start-road-link-change-handler-event
+
+
+  ### EVENTS ###
+
+  StartLambdaEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub "${Environment}-${ApplicationName}-start-road-link-change-handler-event"
+      Description: "Scheduled event to start fetching of road link changes"
+      ScheduleExpression: "cron(0 1 ? * 1-5 *)" # Runs every weekday at 01:00 UTC
+      State: ENABLED
+      Targets:
+        - Arn: !GetAtt Lambda.Arn
+          Id: !Sub "${Environment}-${ApplicationName}-road-link-change-event-target"
+
+
+  # TODO: Add event to handle s3 put events
+
+  ### IAM ###
+
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub ${Environment}-${ApplicationName}-road-link-change-handler-lambda-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+          - !If
+            - IsDev # Allows dev role to be assumed locally for testing purposes
+            - Effect: Allow
+              Principal:
+                AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+              Action: sts:AssumeRole
+              Condition:
+                StringLike:
+                  aws:PrincipalArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-reserved/sso.amazonaws.com/${AWS::Region}/AWSReservedSSO_DigiroadOthAdmin*"
+            - !Ref AWS::NoValue
+      Policies:
+        - PolicyName: PutS3ObjectToBucket
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                Resource: !Sub arn:aws:s3:::${Environment}-${OrganizationPrefix}-${ApplicationName}-road-link-change-bucket/*
+        - PolicyName: ListS3BucketObjects
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:ListBucket
+                Resource: !Sub arn:aws:s3:::${Environment}-${OrganizationPrefix}-${ApplicationName}-road-link-change-bucket
+      Tags:
+        - Key: Name
+          Value: !Sub ${ApplicationName}-${Environment}-road-link-change-lambda-role
+
+  CloudWatchAccessPolicy:
+    Type: AWS::IAM::Policy
+    DependsOn:
+      - LambdaRole
+    Properties:
+      PolicyName: !Sub ${Environment}-${ApplicationName}-CloudWatchAccessPolicy
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+              - logs:CreateLogStream
+              - logs:PutLogEvents
+            Resource: '*'
+      Roles:
+        - !Ref LambdaRole
+
+  LambdaFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    DependsOn: Lambda
+    Properties:
+      RetentionInDays: 180
+      LogGroupName: !Sub "/aws/lambda/${Lambda}"

--- a/lambda/road-link-change-handler/aws/dev/README.md
+++ b/lambda/road-link-change-handler/aws/dev/README.md
@@ -1,0 +1,69 @@
+# Kehitysympäristön pystytys
+
+## Siirry Digiroad projektin juuresta lambda funktion omaan kansioon
+```
+cd lambda/road-link-change-handler
+```
+
+## AWS CLI komennot
+
+*HUOM.* Tarkista ennen jokaista create-stack komentoa parametritiedostojen sisältö.
+
+### Luo ECR repository
+```
+aws cloudformation create-stack \
+--stack-name [esim. dev-digiroad2-road-link-change-lambda-ecr] \
+--template-body file://aws/cloudformation/ecr/dev.yaml \
+--tags file://aws/dev/tags.json
+```
+
+### Vie ensimmäinen palvelun image uuteen ECR repositoryyn tagilla "latest"
+```
+docker build -t image .
+docker run image
+aws ecr get-login-password --region [AWS_REGION] | docker login --username AWS --password-stdin [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com
+docker tag image [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/digiroad2-road-link-change-lambda:latest
+docker push [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/digiroad2-road-link-change-lambda:latest
+```
+
+### Luo tarvittavat resurssit
+```
+aws cloudformation create-stack \
+--stack-name [esim. dev-digiroad2-road-link-change-handler] \
+--template-body file://aws/cloudformation/lambda-resources.yaml \
+--parameters file://aws/dev/lambda-resources.json \
+--tags file://aws/dev/tags.json \
+--capabilities CAPABILITY_NAMED_IAM
+```
+
+### Laita lambdan event ajastus pois päältä
+Disabloi lambdan käynnistävä EventBridge sääntö.
+*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
+```
+aws events disable-rule --name dev-digiroad2-start-road-link-change-handler-event
+```
+
+### Laita lambdan event ajastus päälle
+Laita lambdan käynnistävä EventBridge sääntö takaisin päälle siinä vaiheessa, kun lambdan toteutus on valmis.
+*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
+```
+aws events enable-rule --name dev-digiroad2-start-road-link-change-handler-event
+```
+
+
+# Kehitysympäristön päivitys
+
+## AWS CLI komennot
+
+*HUOM.* Tarkista ennen jokaista update-stack komentoa parametritiedostojen sisältö.
+
+### Päivitä resurssit
+*Huom.* Korvaa parametrit sisältävän tiedoston parametri "ECRImageTag" uudella ECRImageTag parametrin arvolla jos lambdan koodissa on tapahtunut muutoksia.
+```
+aws cloudformation update-stack \
+--stack-name [esim. dev-digiroad2-road-link-change-handler] \
+--template-body file://aws/cloudformation/lambda-resources.yaml \
+--parameters file://aws/dev/lambda-resources.json \
+--capabilities CAPABILITY_NAMED_IAM
+```
+Lisää komentoon mukaan *--tags file://aws/dev/tags.json* mikäli halutaan päivittää myös tagit.

--- a/lambda/road-link-change-handler/aws/dev/lambda-resources.json
+++ b/lambda/road-link-change-handler/aws/dev/lambda-resources.json
@@ -1,0 +1,22 @@
+[
+  {
+    "ParameterKey": "ApplicationName",
+    "ParameterValue": "digiroad2"
+  },
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "dev"
+  },
+  {
+    "ParameterKey": "OrganizationPrefix",
+    "ParameterValue": "vaylapilvi"
+  },
+  {
+    "ParameterKey": "ECRRepository",
+    "ParameterValue": "digiroad2-road-link-change-lambda"
+  },
+  {
+    "ParameterKey": "ECRImageTag",
+    "ParameterValue": "latest"
+  }
+]

--- a/lambda/road-link-change-handler/aws/dev/tags.json
+++ b/lambda/road-link-change-handler/aws/dev/tags.json
@@ -1,0 +1,18 @@
+[
+  {
+    "Key": "Environment",
+    "Value": "dev"
+  },
+  {
+    "Key": "Administrator",
+    "Value": "kehitys@digiroad.fi"
+  },
+  {
+    "Key": "System Owner",
+    "Value": "vayla"
+  },
+  {
+    "Key": "Project",
+    "Value": "digiroad2"
+  }
+]

--- a/lambda/road-link-change-handler/package.json
+++ b/lambda/road-link-change-handler/package.json
@@ -4,9 +4,10 @@
   "description": "Lambda for fetching road link changes, saving them and generating change sets",
   "main": "index.js",
   "scripts": {
+    "test": "mocha --recursive --require mocha-suppress-logs",
     "compile": "tsc",
     "watch": "tsc -w --preserveWatchOutput",
-    "post-compile": "rm .dockerignore Dockerfile README.md tsconfig.json"
+    "post-compile": "rm .dockerignore Dockerfile README.md tsconfig.json && rm -r src test"
   },
   "author": "",
   "license": "ISC",
@@ -15,6 +16,9 @@
     "@types/aws-lambda": "^8.10.109",
     "@types/node": "^18.11.10",
     "aws-sdk": "^2.1266.0",
+    "chai": "^4.3.7",
+    "mocha": "^10.1.0",
+    "mocha-suppress-logs": "^0.3.1",
     "typescript": "^4.9.3"
   }
 }

--- a/lambda/road-link-change-handler/package.json
+++ b/lambda/road-link-change-handler/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "road-link-change-handler",
+  "version": "1.0.0",
+  "description": "Lambda for fetching road link changes, saving them and generating change sets",
+  "main": "index.js",
+  "scripts": {
+    "compile": "tsc",
+    "watch": "tsc -w --preserveWatchOutput",
+    "post-compile": "rm .dockerignore Dockerfile README.md tsconfig.json"
+  },
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@tsconfig/node18": "^1.0.1",
+    "@types/aws-lambda": "^8.10.109",
+    "@types/node": "^18.11.10",
+    "aws-sdk": "^2.1266.0",
+    "typescript": "^4.9.3"
+  }
+}

--- a/lambda/road-link-change-handler/src/index.ts
+++ b/lambda/road-link-change-handler/src/index.ts
@@ -1,0 +1,5 @@
+
+export const handler = async () => {
+    // Replace with lambda logic
+    console.info("Run Road Link Change Handler");
+}

--- a/lambda/road-link-change-handler/test/index_test.js
+++ b/lambda/road-link-change-handler/test/index_test.js
@@ -1,0 +1,7 @@
+const assert = require('chai').assert;
+
+describe('Road Link Change Handler', function() {
+    it('Dummy test (Remove after more test have been added)', function() {
+        assert.equal(true, true);
+    });
+});

--- a/lambda/road-link-change-handler/tsconfig.json
+++ b/lambda/road-link-change-handler/tsconfig.json
@@ -5,7 +5,11 @@
     "esModuleInterop": true,
     "moduleResolution": "node",
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "removeComments": true,
+    "noImplicitAny": true,
+    "noImplicitOverride": true,
+    "noImplicitThis": true
   },
   "include": ["src/**/*.ts", "src/**/*.js"],
   "exclude": ["node_modules"]

--- a/lambda/road-link-change-handler/tsconfig.json
+++ b/lambda/road-link-change-handler/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "inlineSourceMap": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Alustettu tielinkkien muutosten kyselijä -lambda ja sen CloudFormation templatet.

Viedään muutokset omaan development branchiin, joka tulee CI/CD putken toteuttamisen jälkeen käynnistämään lambdan dev-pipelinen. 