### PR TITLE
DROTH-3461 fix bug with road address value calculation

### DIFF
--- a/UI/src/controller/laneModellingCollection.js
+++ b/UI/src/controller/laneModellingCollection.js
@@ -28,11 +28,10 @@
     };
 
     self.getMainLaneByLinkIdAndSideCode = function(linkId, sideCode) {
-      return _.head(_.find(self.linearAssets, function(linearAssetGroup) {
-        return _.find(linearAssetGroup, function(lane) {
+      return _.find(_.flatten(self.linearAssets), function(lane) {
           var laneCode = _.head(Property.getPropertyByPublicId(lane.properties, 'lane_code').values).value;
-          return lane.linkId === linkId && laneCode === 1 && lane.sideCode === sideCode;});
-      }));
+          return lane.linkId === linkId && laneCode === 1 && lane.sideCode === sideCode;
+      });
     };
 
     self.fetchViewOnlyLanes = function(boundingBox, zoom) {

--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -374,13 +374,17 @@
       // how long is '1 road address meter' on current link's geometry
       var coefficient = (mainLane.endAddrMValue - mainLane.startAddrMValue) / roadLinkLength;
 
-      if(roadAddressSideCode === 3) {
-        lane.endAddrMValue = mainLane.endAddrMValue - Math.round(lane.startMeasure * coefficient);
-        lane.startAddrMValue = mainLane.endAddrMValue - Math.round(lane.endMeasure * coefficient);
-      }
-      else if(roadAddressSideCode === 2) {
+      // If road address side code is towards digitizing(2) startAddrMValue points to lane's start measure (southern end-point)
+      // and endAddrMValue points to lane's end measure (northern  end-point)
+      if (roadAddressSideCode === 2) {
         lane.startAddrMValue = mainLane.startAddrMValue + Math.round(lane.startMeasure * coefficient);
         lane.endAddrMValue = mainLane.startAddrMValue + Math.round(lane.endMeasure * coefficient);
+      }
+      // If road address side code is against digitizing(3) startAddrMValue points to lane's  end measure (northern end-point)
+      // and endAddrMValue points to lane's start measure (southern point)
+      else if (roadAddressSideCode === 3) {
+        lane.endAddrMValue = mainLane.endAddrMValue - Math.round(lane.startMeasure * coefficient);
+        lane.startAddrMValue = mainLane.endAddrMValue - Math.round(lane.endMeasure * coefficient);
       }
 
       return lane;

--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -368,15 +368,21 @@
     this.getAddressValuesForCutLane = function(lane) {
       var mainLane = collection.getMainLaneByLinkIdAndSideCode(lane.linkId, lane.sideCode);
       var roadLinkLength = mainLane.endMeasure;
+      var roadAddressSideCode = mainLane.roadAddressSideCode;
 
       // A coefficient is needed because road address and geometry lengths don't match exactly. Coefficient tells
       // how long is '1 road address meter' on current link's geometry
       var coefficient = (mainLane.endAddrMValue - mainLane.startAddrMValue) / roadLinkLength;
 
-      var startAddressM = Math.round(mainLane.startAddrMValue + (coefficient * lane.startMeasure));
-      var endAddressM = Math.round(mainLane.endAddrMValue + (coefficient * (lane.endMeasure - roadLinkLength)));
-      lane.startAddrMValue = startAddressM;
-      lane.endAddrMValue = endAddressM;
+      if(roadAddressSideCode === 3) {
+        lane.endAddrMValue = mainLane.endAddrMValue - Math.round(lane.startMeasure * coefficient);
+        lane.startAddrMValue = mainLane.endAddrMValue - Math.round(lane.endMeasure * coefficient);
+      }
+      else if(roadAddressSideCode === 2) {
+        lane.startAddrMValue = mainLane.startAddrMValue + Math.round(lane.startMeasure * coefficient);
+        lane.endAddrMValue = mainLane.startAddrMValue + Math.round(lane.endMeasure * coefficient);
+      }
+
       return lane;
     };
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1145,6 +1145,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
           "track" -> lane.attributes.get("TRACK"),
           "startAddrMValue" -> lane.attributes.get("START_ADDR"),
           "endAddrMValue" ->  lane.attributes.get("END_ADDR"),
+          "roadAddressSideCode" -> lane.attributes.get("SIDECODE"),
           "administrativeClass" -> lane.administrativeClass.value,
           "linkType" -> lane.attributes.getOrElse("linkType", 99),
           "constructionType" -> lane.attributes.getOrElse("constructionType", 99)


### PR DESCRIPTION
korjattu getMainLaneByLinkIdAndSideCode toimimaan oikein, korjattu tieosoite etäisyyksien lasku toimimaan  oikein, tuodaan tieosoitteen sideCode frontEndille, pakollinen tieto kun lasketaan etäisyyksiä katkotuille kaistoille.