### PR TITLE
DROTH-3560 Lambda qa setup

### DIFF
--- a/lambda/asset-history-processor/aws/cloudformation/cicd/cicd-stack.yaml
+++ b/lambda/asset-history-processor/aws/cloudformation/cicd/cicd-stack.yaml
@@ -14,8 +14,8 @@ Parameters:
   CodeBuildImage:
     Description: Image used for CodeBuild project
     Type: String
-  BuildSpecPath:
-    Description: Path to lambda function buildspec file in git repository
+  EcrTag:
+    Description: Tag used to mark current version
     Type: String
   LambdaName:
     Description: Name of lambda function updated with pipeline
@@ -185,9 +185,11 @@ Resources:
             Value: !Ref AWS::AccountId
           - Name: LAMBDA_NAME
             Value: !Ref LambdaName
+          - Name: ECR_TAG
+            Value: !Ref EcrTag
       Source:
         Type: CODEPIPELINE
-        BuildSpec: !Ref BuildSpecPath
+        BuildSpec: lambda/asset-history-processor/aws/codebuild/buildspec.yml
       Artifacts:
         Name: !Ref PipelineName
         Type: CODEPIPELINE

--- a/lambda/asset-history-processor/aws/cloudformation/ecr/ecr.yaml
+++ b/lambda/asset-history-processor/aws/cloudformation/ecr/ecr.yaml
@@ -1,12 +1,18 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Elastic Container Repository template for Digiroad road link change handler dev environment
 
+Parameters:
+  Environment:
+    Description: Environment where resources are created. Used when tagging the resources
+    Type: String
+    AllowedValues: ["dev", "qa"]
+
 Resources:
   ECR:
     Type: AWS::ECR::Repository
     DeletionPolicy: Retain
     Properties:
-      RepositoryName: digiroad2-asset-history-processor-lambda
+      RepositoryName: !Sub ${Environment}-digiroad2-asset-history-processor-lambda
       ImageScanningConfiguration:
         ScanOnPush: true
       RepositoryPolicyText:
@@ -98,4 +104,4 @@ Resources:
           }
       Tags:
         - Key: Name
-          Value: digiroad2-asset-history-processor-lambda-dev-ecr-repo
+          Value: !Sub digiroad2-asset-history-processor-lambda-${Environment}-ecr-repo

--- a/lambda/asset-history-processor/aws/codebuild/buildspec.yml
+++ b/lambda/asset-history-processor/aws/codebuild/buildspec.yml
@@ -11,14 +11,14 @@ phases:
       - echo Build started on `date`
       - cd lambda/asset-history-processor
       - echo Building the Docker image...
-      - docker build -t $ECR_REPOSITORY_NAME .
-      - docker tag $ECR_REPOSITORY_NAME:latest $ECR_REPOSITORY_URI:latest
-      - docker tag $ECR_REPOSITORY_NAME:latest $ECR_REPOSITORY_URI:$COMMIT_HASH
+      - docker build -t $ECR_REPOSITORY_NAME:$ECR_TAG .
+      - docker tag $ECR_REPOSITORY_NAME:$ECR_TAG $ECR_REPOSITORY_URI:$ECR_TAG
+      - docker tag $ECR_REPOSITORY_NAME:$ECR_TAG $ECR_REPOSITORY_URI:$COMMIT_HASH
   post_build:
     commands:
       - echo Build completed on `date`
       - echo Pushing the Docker image...
-      - docker push $ECR_REPOSITORY_URI:latest
+      - docker push $ECR_REPOSITORY_URI:$ECR_TAG
       - docker push $ECR_REPOSITORY_URI:$COMMIT_HASH
       - echo Updating lambda function...
       - aws lambda update-function-code --function-name $LAMBDA_NAME --image-uri $ECR_REPOSITORY_URI:$COMMIT_HASH

--- a/lambda/asset-history-processor/aws/dev/README.md
+++ b/lambda/asset-history-processor/aws/dev/README.md
@@ -55,7 +55,7 @@ aws events enable-rule --name dev-digiroad2-start-asset-history-processor-event
 ```
 aws cloudformation create-stack \
 --stack-name [esim. dev-digiroad2-asset-history-pipeline] \ 
---template-body file://aws/cloudformation/cicd/dev-cicd-template.yaml \
+--template-body file://aws/cloudformation/cicd/cicd-stack.yaml \
 --parameters file://aws/dev/cicd-parameter.json \
 --tags file://aws/dev/tags.json \
 --capabilities CAPABILITY_NAMED_IAM
@@ -72,7 +72,7 @@ aws cloudformation create-stack \
 ```
 aws cloudformation update-stack \
 --stack-name [esim. dev-digiroad2-asset-history-pipeline] \ 
---template-body file://aws/cloudformation/cicd/dev-cicd-template.yaml \
+--template-body file://aws/cloudformation/cicd/cicd-stack.yaml \
 --parameters file://aws/dev/cicd-parameter.json \
 --tags file://aws/dev/tags.json \
 --capabilities CAPABILITY_NAMED_IAM

--- a/lambda/asset-history-processor/aws/dev/README.md
+++ b/lambda/asset-history-processor/aws/dev/README.md
@@ -13,7 +13,8 @@ cd lambda/asset-history-processor
 ```
 aws cloudformation create-stack \
 --stack-name [esim. dev-digiroad2-asset-history-processor-lambda-ecr] \
---template-body file://aws/cloudformation/ecr/dev.yaml \
+--template-body file://aws/cloudformation/ecr/ecr.yaml \
+--parameters ParameterKey=Environment,ParameterValue=dev \
 --tags file://aws/dev/tags.json
 ```
 

--- a/lambda/asset-history-processor/aws/dev/README.md
+++ b/lambda/asset-history-processor/aws/dev/README.md
@@ -23,8 +23,8 @@ aws cloudformation create-stack \
 docker build -t asset-history-image .
 docker run asset-history-image
 aws ecr get-login-password --region [AWS_REGION] | docker login --username AWS --password-stdin [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com
-docker tag asset-history-image [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/digiroad2-asset-history-processor-lambda:latest
-docker push [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/digiroad2-asset-history-processor-lambda:latest
+docker tag asset-history-image [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/dev-digiroad2-asset-history-processor-lambda:latest
+docker push [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/dev-digiroad2-asset-history-processor-lambda:latest
 ```
 
 ### Luo tarvittavat resurssit

--- a/lambda/asset-history-processor/aws/dev/cicd-parameter.json
+++ b/lambda/asset-history-processor/aws/dev/cicd-parameter.json
@@ -16,8 +16,8 @@
     "ParameterValue": "aws/codebuild/standard:5.0"
   },
   {
-    "ParameterKey": "BuildSpecPath",
-    "ParameterValue": "lambda/asset-history-processor/aws/codebuild/dev.yml"
+    "ParameterKey": "EcrTag",
+    "ParameterValue": "latest"
   },
   {
     "ParameterKey": "LambdaName",

--- a/lambda/asset-history-processor/aws/dev/cicd-parameter.json
+++ b/lambda/asset-history-processor/aws/dev/cicd-parameter.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "EcrRepositoryName",
-    "ParameterValue": "digiroad2-asset-history-processor-lambda"
+    "ParameterValue": "dev-digiroad2-asset-history-processor-lambda"
   },
   {
     "ParameterKey": "CodeBuildImage",

--- a/lambda/asset-history-processor/aws/dev/lambda-resources.json
+++ b/lambda/asset-history-processor/aws/dev/lambda-resources.json
@@ -9,7 +9,7 @@
   },
   {
     "ParameterKey": "ECRRepository",
-    "ParameterValue": "digiroad2-asset-history-processor-lambda"
+    "ParameterValue": "dev-digiroad2-asset-history-processor-lambda"
   },
   {
     "ParameterKey": "ECRImageTag",

--- a/lambda/asset-history-processor/aws/qa/README.md
+++ b/lambda/asset-history-processor/aws/qa/README.md
@@ -1,0 +1,91 @@
+# Testiympäristön pystytys
+
+## Siirry Digiroad projektin juuresta lambda funktion omaan kansioon
+```
+cd lambda/asset-history-processor
+```
+
+## AWS CLI komennot
+
+*HUOM.* Tarkista ennen jokaista create-stack komentoa parametritiedostojen sisältö.
+
+### Luo ECR repository
+```
+aws cloudformation create-stack \
+--stack-name [esim. qa-digiroad2-asset-history-processor-lambda-ecr] \
+--template-body file://aws/cloudformation/ecr/ecr.yaml \
+--parameters ParameterKey=Environment,ParameterValue=qa \
+--tags file://aws/qa/tags.json
+```
+
+### Vie ensimmäinen palvelun image uuteen ECR repositoryyn tagilla "latest"
+```
+docker build -t asset-history-image .
+docker run asset-history-image
+aws ecr get-login-password --region [AWS_REGION] | docker login --username AWS --password-stdin [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com
+docker tag asset-history-image [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/qa-digiroad2-asset-history-processor-lambda:qa
+docker push [AWS_ACCOUNT_ID].dkr.ecr.[AWS_REGION].amazonaws.com/qa-digiroad2-asset-history-processor-lambda:qa
+```
+
+### Luo tarvittavat resurssit
+```
+aws cloudformation create-stack \
+--stack-name [esim. qa-digiroad2-asset-history-processor] \
+--template-body file://aws/cloudformation/lambda-resources.yaml \
+--parameters file://aws/qa/lambda-resources.json \
+--tags file://aws/qa/tags.json \
+--capabilities CAPABILITY_NAMED_IAM
+```
+
+### Laita lambdan event ajastus pois päältä
+Disabloi lambdan käynnistävä EventBridge sääntö.
+*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
+```
+aws events disable-rule --name qa-digiroad2-start-asset-history-processor-event
+```
+
+### Laita lambdan event ajastus päälle
+Laita lambdan käynnistävä EventBridge sääntö takaisin päälle siinä vaiheessa, kun lambdan toteutus on valmis.
+*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
+```
+aws events enable-rule --name qa-digiroad2-start-asset-history-processor-event
+```
+
+### Luo testi pipeline
+*Huom.* Korvaa GitHubWebhookSecret oikealla arvolla
+```
+aws cloudformation create-stack \
+--stack-name [esim. qa-digiroad2-asset-history-pipeline] \
+--template-body file://aws/cloudformation/cicd/cicd-stack.yaml \
+--parameters file://aws/qa/cicd-parameter.json \
+--tags file://aws/qa/tags.json \
+--capabilities CAPABILITY_NAMED_IAM
+```
+
+
+# Testiympäristön päivitys
+
+## AWS CLI komennot
+
+*HUOM.* Tarkista ennen jokaista update-stack komentoa parametritiedostojen sisältö.
+
+### Päivitä testi pipeline
+```
+aws cloudformation update-stack \
+--stack-name [esim. qa-digiroad2-asset-history-pipeline] \
+--template-body file://aws/cloudformation/cicd/cicd-stack.yaml \
+--parameters file://aws/qa/cicd-parameter.json \
+--tags file://aws/qa/tags.json \
+--capabilities CAPABILITY_NAMED_IAM
+```
+
+### Päivitä resurssit
+*Huom.* Mikäli myös lambdan koodi halutaan päivittää, korvaa parametrit sisältävän tiedoston parametri "ECRImageTag" uudella ECRImageTag parametrin arvolla.
+```
+aws cloudformation update-stack \
+--stack-name [esim. qa-digiroad2-asset-history-processor] \
+--template-body file://aws/cloudformation/lambda-resources.yaml \
+--parameters file://aws/qa/lambda-resources.json \
+--capabilities CAPABILITY_NAMED_IAM
+```
+Lisää komentoon mukaan *--tags file://aws/qa/tags.json* mikäli halutaan päivittää myös tagit.

--- a/lambda/asset-history-processor/aws/qa/cicd-parameter.json
+++ b/lambda/asset-history-processor/aws/qa/cicd-parameter.json
@@ -1,0 +1,42 @@
+[
+  {
+    "ParameterKey": "PipelineName",
+    "ParameterValue": "qa-digiroad2-asset-history-pipeline"
+  },
+  {
+    "ParameterKey": "ResourceStackName",
+    "ParameterValue": "qa-digiroad2-asset-history-processor"
+  },
+  {
+    "ParameterKey": "EcrRepositoryName",
+    "ParameterValue": "qa-digiroad2-asset-history-processor-lambda"
+  },
+  {
+    "ParameterKey": "CodeBuildImage",
+    "ParameterValue": "aws/codebuild/standard:5.0"
+  },
+  {
+    "ParameterKey": "EcrTag",
+    "ParameterValue": "qa"
+  },
+  {
+    "ParameterKey": "LambdaName",
+    "ParameterValue": "qa-digiroad2-asset-history-processor"
+  },
+  {
+    "ParameterKey": "GitRepoName",
+    "ParameterValue": "digiroad2"
+  },
+  {
+    "ParameterKey": "GitBranchName",
+    "ParameterValue": "qa-assetHistoryProcessor"
+  },
+  {
+    "ParameterKey": "GitHubOwner",
+    "ParameterValue": "finnishtransportagency"
+  },
+  {
+    "ParameterKey": "GitHubWebhookSecret",
+    "UsePreviousValue": true
+  }
+]

--- a/lambda/asset-history-processor/aws/qa/lambda-resources.json
+++ b/lambda/asset-history-processor/aws/qa/lambda-resources.json
@@ -1,0 +1,18 @@
+[
+  {
+    "ParameterKey": "ApplicationName",
+    "ParameterValue": "digiroad2"
+  },
+  {
+    "ParameterKey": "Environment",
+    "ParameterValue": "qa"
+  },
+  {
+    "ParameterKey": "ECRRepository",
+    "ParameterValue": "qa-digiroad2-asset-history-processor-lambda"
+  },
+  {
+    "ParameterKey": "ECRImageTag",
+    "ParameterValue": "qa"
+  }
+]

--- a/lambda/asset-history-processor/aws/qa/tags.json
+++ b/lambda/asset-history-processor/aws/qa/tags.json
@@ -1,0 +1,18 @@
+[
+  {
+    "Key": "Environment",
+    "Value": "qa"
+  },
+  {
+    "Key": "Administrator",
+    "Value": "kehitys@digiroad.fi"
+  },
+  {
+    "Key": "System Owner",
+    "Value": "vayla"
+  },
+  {
+    "Key": "Project",
+    "Value": "digiroad2"
+  }
+]


### PR DESCRIPTION
Tehty buildspecistä ja cicd stackista geneerisemmät, jotta samoja voidaan käyttää dev ja qa pipelinejen konfiguroinnissa. Lisätty qa määrittelyt ja ohjeet.