### PR TITLE
Droth 3528 instructions cleanup and improvements

### DIFF
--- a/lambda/asset-history-processor/aws/cloudformation/cicd/cicd-stack.yaml
+++ b/lambda/asset-history-processor/aws/cloudformation/cicd/cicd-stack.yaml
@@ -20,6 +20,9 @@ Parameters:
   LambdaName:
     Description: Name of lambda function updated with pipeline
     Type: String
+  LambdaFolder:
+    Description: Path to folder where lambda code is contained
+    Type: String
   GitRepoName:
     Description: The Git repository name
     Type: String
@@ -185,11 +188,13 @@ Resources:
             Value: !Ref AWS::AccountId
           - Name: LAMBDA_NAME
             Value: !Ref LambdaName
+          - Name: LAMBDA_FOLDER
+            Value: !Ref LambdaFolder
           - Name: ECR_TAG
             Value: !Ref EcrTag
       Source:
         Type: CODEPIPELINE
-        BuildSpec: lambda/asset-history-processor/aws/codebuild/buildspec.yml
+        BuildSpec: !Sub ${LambdaFolder}/aws/codebuild/buildspec.yml
       Artifacts:
         Name: !Ref PipelineName
         Type: CODEPIPELINE

--- a/lambda/asset-history-processor/aws/codebuild/buildspec.yml
+++ b/lambda/asset-history-processor/aws/codebuild/buildspec.yml
@@ -9,7 +9,7 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - cd lambda/asset-history-processor
+      - cd $LAMBDA_FOLDER
       - echo Building the Docker image...
       - docker build -t $ECR_REPOSITORY_NAME:$ECR_TAG .
       - docker tag $ECR_REPOSITORY_NAME:$ECR_TAG $ECR_REPOSITORY_URI:$ECR_TAG

--- a/lambda/asset-history-processor/aws/dev/README.md
+++ b/lambda/asset-history-processor/aws/dev/README.md
@@ -37,20 +37,6 @@ aws cloudformation create-stack \
 --capabilities CAPABILITY_NAMED_IAM
 ```
 
-### Laita lambdan event ajastus pois päältä
-Disabloi lambdan käynnistävä EventBridge sääntö.
-*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
-```
-aws events disable-rule --name dev-digiroad2-start-asset-history-processor-event
-```
-
-### Laita lambdan event ajastus päälle
-Laita lambdan käynnistävä EventBridge sääntö takaisin päälle siinä vaiheessa, kun lambdan toteutus on valmis.
-*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
-```
-aws events enable-rule --name dev-digiroad2-start-asset-history-processor-event
-```
-
 ### Luo kehitys pipeline
 *Huom.* Korvaa GitHubWebhookSecret oikealla arvolla
 ```

--- a/lambda/asset-history-processor/aws/dev/cicd-parameter.json
+++ b/lambda/asset-history-processor/aws/dev/cicd-parameter.json
@@ -24,6 +24,10 @@
     "ParameterValue": "dev-digiroad2-asset-history-processor"
   },
   {
+    "ParameterKey": "LambdaFolder",
+    "ParameterValue": "lambda/asset-history-processor"
+  },
+  {
     "ParameterKey": "GitRepoName",
     "ParameterValue": "digiroad2"
   },

--- a/lambda/asset-history-processor/aws/qa/README.md
+++ b/lambda/asset-history-processor/aws/qa/README.md
@@ -18,7 +18,7 @@ aws cloudformation create-stack \
 --tags file://aws/qa/tags.json
 ```
 
-### Vie ensimmäinen palvelun image uuteen ECR repositoryyn tagilla "latest"
+### Vie ensimmäinen palvelun image uuteen ECR repositoryyn tagilla "qa"
 ```
 docker build -t asset-history-image .
 docker run asset-history-image

--- a/lambda/asset-history-processor/aws/qa/README.md
+++ b/lambda/asset-history-processor/aws/qa/README.md
@@ -37,20 +37,6 @@ aws cloudformation create-stack \
 --capabilities CAPABILITY_NAMED_IAM
 ```
 
-### Laita lambdan event ajastus pois päältä
-Disabloi lambdan käynnistävä EventBridge sääntö.
-*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
-```
-aws events disable-rule --name qa-digiroad2-start-asset-history-processor-event
-```
-
-### Laita lambdan event ajastus päälle
-Laita lambdan käynnistävä EventBridge sääntö takaisin päälle siinä vaiheessa, kun lambdan toteutus on valmis.
-*Huom.* Varmista että eventin nimi vastaa lambda-resources.yaml:lla luotua
-```
-aws events enable-rule --name qa-digiroad2-start-asset-history-processor-event
-```
-
 ### Luo testi pipeline
 *Huom.* Korvaa GitHubWebhookSecret oikealla arvolla
 ```

--- a/lambda/asset-history-processor/aws/qa/cicd-parameter.json
+++ b/lambda/asset-history-processor/aws/qa/cicd-parameter.json
@@ -24,6 +24,10 @@
     "ParameterValue": "qa-digiroad2-asset-history-processor"
   },
   {
+    "ParameterKey": "LambdaFolder",
+    "ParameterValue": "lambda/asset-history-processor"
+  },
+  {
     "ParameterKey": "GitRepoName",
     "ParameterValue": "digiroad2"
   },


### PR DESCRIPTION
Poistettu ylimääräisiä ohjeita sekä parametrisoitu lambdan koodin sisältävä kansio cicd putkessa.