### PR TITLE
DROTH-3565 LinearAssets use roadLink measures when within tolerance, …

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
@@ -1,11 +1,12 @@
 package fi.liikennevirasto.digiroad2
 
-import fi.liikennevirasto.digiroad2.linearasset.PolyLine
+import fi.liikennevirasto.digiroad2.linearasset.{PolyLine, RoadLink}
 
 object GeometryUtils {
 
   // Default value of minimum distance where locations are considered to be same
   final private val DefaultEpsilon = 0.01
+  final private val adjustmentTolerance = 2.0
 
   def getDefaultEpsilon(): Double = {
     DefaultEpsilon
@@ -15,6 +16,25 @@ object GeometryUtils {
     val difference = math.abs(measure2 - measure1)
     if(difference < tolerance) true
     else false
+  }
+
+  // Use roadLink measures and geometry if measures are within tolerance from road link end points,
+  // ensures connected geometry between assets in IntegrationApi responses
+  // TODO Possibly not needed after fillTopology methods are fixed to adjust and save all m-value deviations
+  def useRoadLinkMeasuresIfCloseEnough(startMeasure: Double, endMeasure: Double, roadLink: RoadLink): (Double, Double, Seq[Point]) = {
+    val startMeasureWithinTolerance = areMeasuresCloseEnough(startMeasure, 0.0, adjustmentTolerance)
+    val endMeasureWithinTolerance = areMeasuresCloseEnough(endMeasure, roadLink.length, adjustmentTolerance)
+
+    (startMeasureWithinTolerance, endMeasureWithinTolerance) match {
+      // Asset covers whole road link, and thus shares geometry with road link
+      case (true, true) => (0.0, roadLink.length, roadLink.geometry)
+      // Asset end measure was close enough to road link length, calculate new geometry with end measure being road link length
+      case (false, true) => (startMeasure, roadLink.length, truncateGeometry3D(roadLink.geometry, startMeasure, roadLink.length))
+      // Asset start measure was close enough to road link start (0.0), calculate new geometry with start measure being 0.0
+      case (true, false) => (0.0, endMeasure, truncateGeometry3D(roadLink.geometry, 0.0, endMeasure))
+      // Asset start and end measures are not close enough to road link end points, use original measures and geometry
+      case (false, false) => (startMeasure, endMeasure, truncateGeometry3D(roadLink.geometry, startMeasure, endMeasure))
+    }
   }
 
   def geometryEndpoints(geometry: Seq[Point]): (Point, Point) = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -159,7 +159,12 @@ trait LinearAssetOperations {
     */
   def getByMunicipality(typeId: Int, municipality: Int): Seq[PieceWiseLinearAsset] = {
     val roadLinks = roadLinkService.getRoadLinksWithComplementaryByMunicipalityUsingCache(municipality)
-    getByRoadLinks(typeId, roadLinks, adjust = false)
+    val linearAssets = getByRoadLinks(typeId, roadLinks, adjust = false)
+    linearAssets.map(asset => {
+      val roadLink = roadLinks.find(_.linkId == asset.linkId).get
+      val (startMeasure, endMeasure, geometry) = GeometryUtils.useRoadLinkMeasuresIfCloseEnough(asset.startMeasure, asset.endMeasure, roadLink)
+      asset.copy(startMeasure = startMeasure, endMeasure = endMeasure, geometry = geometry)
+    })
   }
 
   def getByMunicipalityAndRoadLinks(typeId: Int, municipality: Int): Seq[(PieceWiseLinearAsset, RoadLink)] = {


### PR DESCRIPTION
Käytetään tielinkin mittoja viivamaisilla kohteilla, joidenka m-arvot ovat toleranssin sisällä tielinkin mitoista. Vastaava toiminnallisuus ollut aikaisemmin viivamaisten kohteiden korjausoperaatioiden yhteydessä, joidenka suoritus siirrettiin pois Kalpa-Apin kutsujen yhteydestä. Yhtenäistetty desimaalilukujen tarkkuus 3 desimaalin tarkkuuteen kalpa-apissa.