### PR TITLE
DROTH-3547 LaneApiSpec mock geometryTransform, LaneApi use Digiroad2C…

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -319,6 +319,10 @@ object Digiroad2Context {
     new RoadAddressService(viiteClient)
   }
 
+  lazy val geometryTransform: GeometryTransform = {
+    new GeometryTransform(roadAddressService)
+  }
+
   lazy val assetService: AssetService = {
     new AssetService(eventbus)
   }

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -319,10 +319,6 @@ object Digiroad2Context {
     new RoadAddressService(viiteClient)
   }
 
-  lazy val geometryTransform: GeometryTransform = {
-    new GeometryTransform(roadAddressService)
-  }
-
   lazy val assetService: AssetService = {
     new AssetService(eventbus)
   }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -16,13 +16,12 @@ import org.scalatra.swagger.{Swagger, SwaggerSupport}
 import org.scalatra.{BadRequest, ScalatraServlet}
 
 
-class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val roadAddressService: RoadAddressService)
+class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val roadAddressService: RoadAddressService, val geometryTransform: GeometryTransform)
   extends ScalatraServlet with JacksonJsonSupport with SwaggerSupport {
   lazy val vkmClient = new VKMClient
   lazy val polygonTools = new PolygonTools
   val apiId = "lane-api"
 
-  val geometryTransform = new GeometryTransform(roadAddressService)
   case class HomogenizedLane(laneCode: Long, laneTypeCode: Long, roadNumber: Long, roadPartNumber: Long, track: Long, startAddressM: Long, endAddressM: Long)
   case class InvalidRoadNumberException(msg: String) extends Exception(msg)
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -16,12 +16,13 @@ import org.scalatra.swagger.{Swagger, SwaggerSupport}
 import org.scalatra.{BadRequest, ScalatraServlet}
 
 
-class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val roadAddressService: RoadAddressService, val geometryTransform: GeometryTransform)
+class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val roadAddressService: RoadAddressService)
   extends ScalatraServlet with JacksonJsonSupport with SwaggerSupport {
   lazy val vkmClient = new VKMClient
   lazy val polygonTools = new PolygonTools
   val apiId = "lane-api"
 
+  lazy val geometryTransform = new GeometryTransform(roadAddressService)
   case class HomogenizedLane(laneCode: Long, laneTypeCode: Long, roadNumber: Long, roadPartNumber: Long, track: Long, startAddressM: Long, endAddressM: Long)
   case class InvalidRoadNumberException(msg: String) extends Exception(msg)
 

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -17,7 +17,7 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
   val mockRoadAddressService = MockitoSugar.mock[RoadAddressService]
   val mockGeometryTransform = MockitoSugar.mock[GeometryTransform]
 
-  private val laneApi = new LaneApi(new OthSwagger, mockRoadLinkService, mockRoadAddressService)
+  private val laneApi = new LaneApi(new OthSwagger, mockRoadLinkService, mockRoadAddressService, mockGeometryTransform)
   addServlet(laneApi, "/*")
 
   val linkId1 = LinkIdGenerator.generateRandom()
@@ -162,6 +162,8 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
   }
 
   test("lanes in road address range Api requires valid parameters"){
+    when(mockGeometryTransform.getLinkIdsInRoadAddressRange(any[RoadAddressRange])).thenReturn(Set.empty[String])
+
     get("/lanes_in_range") {
       status should equal(400)
     }

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -17,7 +17,9 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
   val mockRoadAddressService = MockitoSugar.mock[RoadAddressService]
   val mockGeometryTransform = MockitoSugar.mock[GeometryTransform]
 
-  private val laneApi = new LaneApi(new OthSwagger, mockRoadLinkService, mockRoadAddressService, mockGeometryTransform)
+  private val laneApi = new LaneApi(new OthSwagger, mockRoadLinkService, mockRoadAddressService) {
+    override lazy val geometryTransform: GeometryTransform = mockGeometryTransform
+  }
   addServlet(laneApi, "/*")
 
   val linkId1 = LinkIdGenerator.generateRandom()

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -55,7 +55,7 @@ ScalatraBootstrap extends LifeCycle {
     context.mount(new ServiceRoadAPI( Digiroad2Context.maintenanceRoadService, 
                                       Digiroad2Context.roadLinkService, swagger),
                           s"/externalApi/livi/*")
-    context.mount(new LaneApi(swagger, Digiroad2Context.roadLinkService, Digiroad2Context.roadAddressService), 
+    context.mount(new LaneApi(swagger, Digiroad2Context.roadLinkService, Digiroad2Context.roadAddressService, Digiroad2Context.geometryTransform),
                           s"/externalApi/lanes/*")
   }
 }

--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -55,7 +55,7 @@ ScalatraBootstrap extends LifeCycle {
     context.mount(new ServiceRoadAPI( Digiroad2Context.maintenanceRoadService, 
                                       Digiroad2Context.roadLinkService, swagger),
                           s"/externalApi/livi/*")
-    context.mount(new LaneApi(swagger, Digiroad2Context.roadLinkService, Digiroad2Context.roadAddressService, Digiroad2Context.geometryTransform),
+    context.mount(new LaneApi(swagger, Digiroad2Context.roadLinkService, Digiroad2Context.roadAddressService),
                           s"/externalApi/lanes/*")
   }
 }


### PR DESCRIPTION
"lanes in road address range Api requires valid parameters" Unit test failaa pilviympäristössä (mahdollisesti mockaamattoman Viite kutsun takia), mockattu nyt GeometryTransform, jotta ei tarvitse hakea tielinkkejä, kaistoja tai niille osoitteita testin aikana, testin pitäisi palauttaa tyhjä 200 OK vastaus