### PR TITLE
DROTH-3547 Track parameter optional, move code to LaneService, change…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.lane.{LanePartitioner, PieceWiseLane}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}
 import fi.liikennevirasto.digiroad2.util.LaneUtils.pwLanesTwoDigitLaneCode
-import fi.liikennevirasto.digiroad2.util.RoadAddress.isCarTrafficRoadAddress
+import fi.liikennevirasto.digiroad2.util.RoadAddress.{isCarTrafficRoadAddress, roadPartNumberRange}
 import fi.liikennevirasto.digiroad2.util.{GeometryTransform, PolygonTools, RoadAddressRange, Track}
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.json.JacksonJsonSupport
@@ -24,7 +24,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
 
   lazy val geometryTransform = new GeometryTransform(roadAddressService)
   case class HomogenizedLane(laneCode: Long, laneTypeCode: Long, roadNumber: Long, roadPartNumber: Long, track: Long, startAddressM: Long, endAddressM: Long)
-  case class InvalidRoadNumberException(msg: String) extends Exception(msg)
+  case class InvalidRoadAddressRangeParamaterException(msg: String) extends Exception(msg)
 
   override protected def applicationDescription: String = "Lanes API"
   override protected implicit def jsonFormats: Formats = DefaultFormats
@@ -67,21 +67,23 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     contentType = formats("json") + "; charset=utf-8"
     ApiUtils.avoidRestrictions(apiId + "_range", request, params) { params =>
       val roadNumber = params.getOrElse("road_number", halt(BadRequest("Missing parameters")))
-      val track = params.getOrElse("track", halt(BadRequest("Missing parameters")))
+      val track = params.get("track")
       val startRoadPartNumber = params.getOrElse("start_part", halt(BadRequest("Missing parameters")))
       val startAddrM = params.getOrElse("start_addrm", halt(BadRequest("Missing parameters")))
       val endRoadPartNumber = params.getOrElse("end_part", halt(BadRequest("Missing parameters")))
       val endAddrM = params.getOrElse("end_addrm", halt(BadRequest("Missing parameters")))
 
       val parameters = try {
-        val params = RoadAddressRange(roadNumber.toLong, Track(track.toInt), startRoadPartNumber.toLong,
+        val trackParam = if(track.isDefined) Some(Track(track.get.toInt))
+        else None
+        val params = RoadAddressRange(roadNumber.toLong, trackParam, startRoadPartNumber.toLong,
           endRoadPartNumber.toLong, startAddrM.toLong, endAddrM.toLong)
 
         validateRangeParameters(params)
         params
       }
       catch {
-        case invalidRoadNumberException: InvalidRoadNumberException => halt(BadRequest(invalidRoadNumberException.getMessage))
+        case invalidRoadNumberException: InvalidRoadAddressRangeParamaterException => halt(BadRequest(invalidRoadNumberException.getMessage))
         case _: NumberFormatException => halt(BadRequest("Invalid parameters"))
       }
 
@@ -105,9 +107,14 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
       }
     }
   }
-//TODO add more validations
+
   def validateRangeParameters(parameters: RoadAddressRange): Unit = {
-    if (!isCarTrafficRoadAddress(parameters.roadNumber)) throw InvalidRoadNumberException("Invalid road number. Road number must be in range 1 to 62999")
+    if (!isCarTrafficRoadAddress(parameters.roadNumber)) throw InvalidRoadAddressRangeParamaterException("Invalid road number. Road number must be in range 1 to 62999")
+    if (parameters.track.contains(Track.Unknown)) throw InvalidRoadAddressRangeParamaterException("Invalid track number, allowed Track values are: 0, 1, 2")
+    if (parameters.startRoadPartNumber > parameters.endRoadPartNumber) throw InvalidRoadAddressRangeParamaterException("Start part number must be smaller than end part number")
+    if (!roadPartNumberRange.contains(parameters.startRoadPartNumber) ||
+      !roadPartNumberRange.contains(parameters.endRoadPartNumber)) throw InvalidRoadAddressRangeParamaterException("Road part numbers must be in range 1 - 1000")
+    if(parameters.startAddrMValue >= parameters.endAddrMValue) throw InvalidRoadAddressRangeParamaterException("StartAddrM value must be less than EndAddrM value")
   }
 
   def lanesInMunicipalityToApi(municipalityNumber: Int): Seq[Map[String, Any]] = {
@@ -125,29 +132,17 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     })
     val twoDigitLanes = pwLanesTwoDigitLaneCode(lanesWithRoadAddress)
     val homogenousLanes = homogenizeTwoDigitLanes(twoDigitLanes, roadLinksGrouped)
-    lanesToApi(homogenousLanes)
+    homogenizedLanesToApi(homogenousLanes)
   }
 
   def lanesInRoadAddressRangeToApi(roadAddressRange: RoadAddressRange): Seq[Map[String, Any]] = {
-    val linkIds = geometryTransform.getLinkIdsInRoadAddressRange(roadAddressRange)
-    val roadLinksInRange = roadLinkService.getRoadLinksByLinkIds(linkIds)
-    val roadLinksFiltered = roadLinksInRange.filter(_.functionalClass != WalkingAndCyclingPath.value)
-    val roadLinksGrouped = roadLinksFiltered.groupBy(_.linkId).mapValues(_.head)
-    val lanes = laneService.getLanesByRoadLinks(roadLinksFiltered, adjust = false)
-    val lanesWithRoadAddress = roadAddressService.laneWithRoadAddress(lanes).filter(roadLink => {
-      val roadNumber = roadLink.attributes.get("ROAD_NUMBER").asInstanceOf[Option[Long]]
-      roadNumber match {
-        case None => false
-        case Some(rn) => isCarTrafficRoadAddress(rn)
-      }
-    })
-
+    val (lanesWithRoadAddress, roadLinksGrouped) = laneService.getLanesInRoadAddressRange(roadAddressRange)
     val twoDigitLanes = pwLanesTwoDigitLaneCode(lanesWithRoadAddress)
     val homogenousLanes = homogenizeTwoDigitLanes(twoDigitLanes, roadLinksGrouped)
-    lanesToApi(homogenousLanes)
+    homogenizedLanesToApi(homogenousLanes)
   }
 
-  def lanesToApi(lanes: Seq[HomogenizedLane]): Seq[Map[String, Any]] = {
+  def homogenizedLanesToApi(lanes: Seq[HomogenizedLane]): Seq[Map[String, Any]] = {
     lanes.sortBy(lane => (lane.roadNumber, lane.roadPartNumber, lane.track)).map(lane => {
       Map(
         "roadNumber" -> lane.roadNumber,
@@ -168,7 +163,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     val groupedAndConnectedLanes = lanesGroupedByAttributes.map(laneGroup => {
       val lanesWithContinuingLanes = laneGroup.map(lane => {
         val identifier = LanePartitioner.getLaneRoadIdentifierByUsingViiteRoadNumber(lane, roadLinks(lane.linkId))
-        val continuingLanes = LanePartitioner.getContinuingWithIdentifier(lane, identifier, laneGroup, roadLinks)
+        val continuingLanes = LanePartitioner.getContinuingWithIdentifier(lane, identifier, laneGroup, roadLinks, sideCodesCorrected = true)
         LaneWithContinuingLanes(lane, continuingLanes)
       })
       LanePartitioner.getConnectedGroups(lanesWithContinuingLanes)

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -40,7 +40,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     (apiOperation[Long]("getLanesInRoadAddressRange")
       .parameters(
         queryParam[Int]("road_number").description("Road Number for the range"),
-        queryParam[Int]("track").description("Track code for search"),
+        queryParam[Int]("track").description("Track code for search").optional,
         queryParam[Int]("start_part").description("Starting road part number for search"),
         queryParam[Int]("start_addrm").description("Starting distance on starting roadPart for search"),
         queryParam[Int]("end_part").description("Ending road part number for search"),

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/MunicipalityApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/MunicipalityApi.scala
@@ -144,12 +144,12 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
     }
   }
 
-  private def validatePoint(properties: Map[String, String]): List[FeatureStatus] = {
+  private def validatePoint(properties: Map[String, Any]): List[FeatureStatus] = {
     val assetType = properties("type")
 
     val status = assetType match {
       case "obstacle" =>
-        properties.get("class") match {
+        properties.get("class").asInstanceOf[Option[String]] match {
           case Some(value) if Set(1, 2).contains(value.toInt) => FeatureStatus.Inserted
           case _ => FeatureStatus.WrongMandatoryValue
         }
@@ -157,10 +157,10 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
     List(status)
   }
 
-  private def validateLinearAssets(properties: Map[String, String]): List[FeatureStatus] = {
-    val speedLimit = properties.get("speedLimit")
-    val pavementClass = properties.get("pavementClass")
-    val sideCode = properties.get("sideCode")
+  private def validateLinearAssets(properties: Map[String, Any]): List[FeatureStatus] = {
+    val speedLimit = properties.get("speedLimit").asInstanceOf[Option[String]]
+    val pavementClass = properties.get("pavementClass").asInstanceOf[Option[String]]
+    val sideCode = properties.get("sideCode").asInstanceOf[Option[String]]
 
     val speedlimitStatus = speedLimit match {
       case Some(value) if !Set("20", "30", "40", "50", "60", "70", "80", "90", "100", "120").contains(value) => FeatureStatus.WrongMandatoryValue
@@ -180,18 +180,18 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
     List(speedlimitStatus, pavementClassStatus, sideCodeStatus)
   }
 
-  private def updatePoint(properties: Map[String, String], link: RoadLink, assetType: String, assetCoordinates: List[Double]): Unit = {
+  private def updatePoint(properties: Map[String, Any], link: RoadLink, assetType: String, assetCoordinates: List[Double]): Unit = {
     assetType match {
       case "obstacle" =>
-        val obstacleType = Set(SimplePointAssetProperty(obstacleService.typePublicId, Seq(PropertyValue(properties("class")))))
+        val obstacleType = Set(SimplePointAssetProperty(obstacleService.typePublicId, Seq(PropertyValue(properties("class").asInstanceOf[String]))))
         val newObstacle = IncomingObstacle(assetCoordinates.head, assetCoordinates(1), link.linkId, obstacleType)
         obstacleService.createFromCoordinates(newObstacle, link, AwsUser, false)
     }
   }
 
-  private def updateLinearAssets(properties: Map[String, String], links: Seq[RoadLink]) = {
-    val speedLimit = properties.get("speedLimit")
-    val pavementClass = properties.get("pavementClass")
+  private def updateLinearAssets(properties: Map[String, Any], links: Seq[RoadLink]) = {
+    val speedLimit = properties.get("speedLimit").asInstanceOf[Option[String]]
+    val pavementClass = properties.get("pavementClass").asInstanceOf[Option[String]]
     val timeStamp = LinearAssetUtils.createTimeStamp()
 
     links.foreach { link =>
@@ -201,11 +201,11 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
           val speedLimitsOnRoadLink = speedLimitService.getExistingAssetByRoadLink(link, false)
 
           if (speedLimitsOnRoadLink.isEmpty) {
-            val newSpeedLimitAsset = NewLinearAsset(link.linkId, 0, link.length, speedLimitValue, properties("sideCode").toInt, timeStamp, None)
+            val newSpeedLimitAsset = NewLinearAsset(link.linkId, 0, link.length, speedLimitValue, properties("sideCode").asInstanceOf[String].toInt, timeStamp, None)
             speedLimitService.createMultiple(Seq(newSpeedLimitAsset), AwsUser, timeStamp, (_, _) => Unit)
           } else
             speedLimitsOnRoadLink.foreach { sl =>
-              val newSpeedLimitAsset = NewLinearAsset(link.linkId, sl.startMeasure, sl.endMeasure, speedLimitValue, properties("sideCode").toInt,timeStamp, None)
+              val newSpeedLimitAsset = NewLinearAsset(link.linkId, sl.startMeasure, sl.endMeasure, speedLimitValue, properties("sideCode").asInstanceOf[String].toInt,timeStamp, None)
               speedLimitService.update(sl.id, Seq(newSpeedLimitAsset), AwsUser, false)
             }
         case None =>
@@ -217,7 +217,7 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
 
           val duplicate = pavedRoadService.getPersistedAssetsByLinkIds(PavedRoad.typeId, Seq(link.linkId), false)
           if(duplicate.isEmpty) {
-            val newPavementClassAsset = NewLinearAsset(link.linkId, 0, link.length, pavementClassValue, properties("sideCode").toInt, timeStamp, None)
+            val newPavementClassAsset = NewLinearAsset(link.linkId, 0, link.length, pavementClassValue, properties("sideCode").asInstanceOf[String].toInt, timeStamp, None)
             pavedRoadService.createWithoutTransaction(PavedRoad.typeId, newPavementClassAsset.linkId, newPavementClassAsset.value, newPavementClassAsset.sideCode, Measures(newPavementClassAsset.startMeasure, newPavementClassAsset.endMeasure), AwsUser, timeStamp, None, informationSource = Some(MunicipalityMaintenainer.value))
           } else {
             pavedRoadService.updateWithoutTransaction(Seq(duplicate.head.id), pavementClassValue, AwsUser)
@@ -258,7 +258,7 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
             }
             val featureStatus = linkIdValidationStatus :: propertiesStatus
 
-            insertFeatureAndUpdateDataset(dataset.datasetId, featureId, featureStatus)
+            insertFeatureAndUpdateDataset(dataset.datasetId, featureId.asInstanceOf[String], featureStatus)
             None
 
           case None => awsDao.updateDatasetStatus(dataset.datasetId, DatasetStatus.ErrorsFeatures.value)
@@ -287,7 +287,7 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
         properties.get("id") match {
           case Some(id) =>
             val featureId = id
-            val status = awsDao.getFeatureStatus(featureId, dataset.datasetId)
+            val status = awsDao.getFeatureStatus(featureId.asInstanceOf[String], dataset.datasetId)
             if (status == FeatureStatus.Inserted.value.toString) {
 
               val assetTypeGeometry = feature.geometry.`type`
@@ -300,13 +300,13 @@ class MunicipalityApi(val roadLinkClient: RoadLinkClient,
 
                     updateLinearAssets(properties, links)
                 }
-                  awsDao.updateFeatureStatus(featureId, FeatureStatus.Processed.value)
+                  awsDao.updateFeatureStatus(featureId.asInstanceOf[String], FeatureStatus.Processed.value)
 
                 case "Point" =>
                   val assetCoordinates = feature.geometry.coordinates.head
                   val link = vvhRoadLinksIds.find(road => road.linkId == featureRoadlinks.head).get
-                  updatePoint(properties, link, assetType, assetCoordinates)
-                  awsDao.updateFeatureStatus(featureId, FeatureStatus.Processed.value)
+                  updatePoint(properties, link, assetType.asInstanceOf[String], assetCoordinates)
+                  awsDao.updateFeatureStatus(featureId.asInstanceOf[String], FeatureStatus.Processed.value)
               }
             }
           case None =>

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeoJson.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeoJson.scala
@@ -1,5 +1,5 @@
 package fi.liikennevirasto.digiroad2
 
   case class FeatureCollection(`type`: String, features: List[Feature], crs: Option[Map[String, Any]] = None)
-  case class Feature(`type`: String, geometry: Geometry, properties: Map[String, String])
+  case class Feature(`type`: String, geometry: Geometry, properties: Map[String, Any])
   case class Geometry(`type`: String, coordinates: List[List[Double]])

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/LanePartitioner.scala
@@ -23,7 +23,7 @@ object LanePartitioner {
   //Returns lanes continuing from from given lane
   def getContinuingWithIdentifier(lane: PieceWiseLane, laneRoadIdentifier: String,
                                   lanes: Seq[PieceWiseLane], roadLinks: Map[String, RoadLink],
-                                  SideCodesCorrected: Boolean = false): Seq[PieceWiseLane] = {
+                                  sideCodesCorrected: Boolean = false): Seq[PieceWiseLane] = {
     val continuingLanes = lanes.filter(potentialLane => {
       val potentialLaneLink = roadLinks(potentialLane.linkId)
       val potentialLaneRoadIdentifier = getLaneRoadIdentifierByUsingViiteRoadNumber(potentialLane, potentialLaneLink)
@@ -33,7 +33,7 @@ object LanePartitioner {
       potentialLane.id != lane.id && laneRoadIdentifier == potentialLaneRoadIdentifier && continuingEndPoints && sameLaneCode
     })
 
-    if (SideCodesCorrected) continuingLanes
+    if (sideCodesCorrected) continuingLanes
     else continuingLanes.filter(_.sideCode == lane.sideCode)
   }
 


### PR DESCRIPTION
- Ajorata parametri vaihdettu vapaaehtoiseksi parametriksi, ilman ajorata parametria palauttaa kaikkien ajoratojen kaistatiedot tieosoiteväliltä. 

- Korjattu bugeja:

1. Annettaessa ajorata-parametrin palauttaa kaistat oikein, vaikka samalla tiellä olisi välissä pätkä toista ajorataa
2. Kaistojen homogenisoinnissa kaistat yhdistyvät oikein, vaikka sideCode muuttuisi vierekkäisillä kaistoilla.

- Muutettu Feature luokan properties tyyppi Map[String, Any], tyypitetty properties arvot VKMClient ja MunicipalityApi
- Lisätty validointeja /lanes_in_range rajapinnan parametreille

- Siirretty koodia LaneApista -> LaneService