### PR TITLE
DROTH-3547 Fix Unit test mock, Remove unused geometryTransform from L…

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -1,15 +1,15 @@
 package fi.liikennevirasto.digiroad2
 
-import fi.liikennevirasto.digiroad2.Digiroad2Context.laneService
 import fi.liikennevirasto.digiroad2.asset.WalkingAndCyclingPath
 import fi.liikennevirasto.digiroad2.client.VKMClient
 import fi.liikennevirasto.digiroad2.lane.LanePartitioner.LaneWithContinuingLanes
 import fi.liikennevirasto.digiroad2.lane.{LanePartitioner, PieceWiseLane}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import fi.liikennevirasto.digiroad2.service.lane.LaneService
 import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}
 import fi.liikennevirasto.digiroad2.util.LaneUtils.pwLanesTwoDigitLaneCode
 import fi.liikennevirasto.digiroad2.util.RoadAddress.{isCarTrafficRoadAddress, roadPartNumberRange}
-import fi.liikennevirasto.digiroad2.util.{GeometryTransform, PolygonTools, RoadAddressRange, Track}
+import fi.liikennevirasto.digiroad2.util.{PolygonTools, RoadAddressRange, Track}
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.swagger.{Swagger, SwaggerSupport}
@@ -20,9 +20,9 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
   extends ScalatraServlet with JacksonJsonSupport with SwaggerSupport {
   lazy val vkmClient = new VKMClient
   lazy val polygonTools = new PolygonTools
+  lazy val laneService = new LaneService(roadLinkService, new DummyEventBus, roadAddressService)
   val apiId = "lane-api"
 
-  lazy val geometryTransform = new GeometryTransform(roadAddressService)
   case class HomogenizedLane(laneCode: Long, laneTypeCode: Long, roadNumber: Long, roadPartNumber: Long, track: Long, startAddressM: Long, endAddressM: Long)
   case class InvalidRoadAddressRangeParamaterException(msg: String) extends Exception(msg)
 

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -4,6 +4,7 @@ import fi.liikennevirasto.digiroad2.asset.{ConstructionType, LinkGeomSource, Mot
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
 import fi.liikennevirasto.digiroad2.lane.{LaneProperty, LanePropertyValue, PieceWiseLane}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import fi.liikennevirasto.digiroad2.service.lane.LaneService
 import fi.liikennevirasto.digiroad2.service.{RoadAddressForLink, RoadAddressService, RoadLinkService}
 import fi.liikennevirasto.digiroad2.util.{GeometryTransform, LinkIdGenerator, RoadAddressRange, Track}
 import org.mockito.ArgumentMatchers.any
@@ -17,8 +18,11 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
   val mockRoadAddressService = MockitoSugar.mock[RoadAddressService]
   val mockGeometryTransform = MockitoSugar.mock[GeometryTransform]
 
-  private val laneApi = new LaneApi(new OthSwagger, mockRoadLinkService, mockRoadAddressService) {
+  private val laneServiceMock = new LaneService(mockRoadLinkService, new DummyEventBus, mockRoadAddressService){
     override lazy val geometryTransform: GeometryTransform = mockGeometryTransform
+  }
+  private val laneApi = new LaneApi(new OthSwagger, mockRoadLinkService, mockRoadAddressService) {
+    override lazy val laneService = laneServiceMock
   }
   addServlet(laneApi, "/*")
 


### PR DESCRIPTION
Build failasi, kun geometryTransform mock oli mennyt rikki, kun koodia siiretty LaneApista -> LaneService. Poistettu turha geometryTransform LaneApista, korjattu mockaus Unit test nyt. 