### PR TITLE
DROTH-3532 change_table improvements

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_24__edit_change_table.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_24__edit_change_table.sql
@@ -1,0 +1,9 @@
+ALTER TABLE change_table ALTER COLUMN asset_type_id SET NOT NULL;
+
+ALTER TABLE change_table ALTER COLUMN value_type DROP NOT NULL;
+ALTER TABLE change_table ADD CONSTRAINT value_type_not_null_if_value CHECK (value is null or value_type is not null);
+
+ALTER TABLE change_table ALTER COLUMN change_type TYPE int4 USING change_type::integer;
+ALTER TABLE change_table ADD CONSTRAINT change_type_values CHECK (change_type in (1,2,3));
+
+ALTER TABLE change_table ADD CONSTRAINT unique_change_event unique (edit_date, edit_by, change_type, asset_type_id, asset_id);


### PR DESCRIPTION
Tehty muutos-tauluun seuraavat muutokset:

- **asset_type_id** ei voi olla null
- **value_type** voi olla null. Lisätty uusi constraint: Jos value kenttään on syötetty arvo niin value_type pitää olla myös määritetty.
- muutettu **change_type** int tyyppiseksi ja lisätty sopiva constraint
- lisätty uniikki constraint kentille: **edit_date, edit_by, change_type, asset_type_id, asset_id**, jotta vältyttäisiin duplikaatti riveiltä