### PR TITLE
DROTH-3532 Drop columns from change_table

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_25__drop_columns_from_change_table.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_25__drop_columns_from_change_table.sql
@@ -1,0 +1,5 @@
+ALTER TABLE change_table DROP COLUMN asset_geometry;
+ALTER TABLE change_table DROP COLUMN link_geometry;
+ALTER TABLE change_table DROP COLUMN link_type;
+ALTER TABLE change_table DROP COLUMN link_length;
+ALTER TABLE change_table DROP COLUMN link_functional_class;


### PR DESCRIPTION
Pudotettu muutos-taulusta kenttiä:
- **asset_geometry** pudotettu, koska geometria voidaan laskea m-arvojen ja linkin geometrian perusteella.
- **link_geometry, link_type, link_length ja link_functional_class** pudotettu, koska linkin tiedot voidaan kysellä keskilinjavarasto:road_links_versions rajapinnasta.