### PR TITLE
DROTH-3513 fix bug and add admin class when applicable

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
@@ -120,9 +120,9 @@ object SpeedLimitFiller extends AssetFiller {
       remainders.map { segment =>
         val geometry = GeometryUtils.truncateGeometry3D(roadLink.geometry, segment._1, segment._2)
         PieceWiseLinearAsset(0, roadLink.linkId, SideCode.BothDirections, None, geometry, false,
-          segment._1, segment._1, geometry.toSet, None, None, None, None,
+          segment._1, segment._2, geometry.toSet, None, None, None, None,
           SpeedLimitAsset.typeId, roadLink.trafficDirection, 0, None,
-          roadLink.linkSource, Unknown, Map(), None, None, None)
+          roadLink.linkSource, roadLink.administrativeClass, Map(), None, None, None)
       }
     } else
       Seq()
@@ -359,6 +359,6 @@ object SpeedLimitFiller extends AssetFiller {
     (PieceWiseLinearAsset(id = assetId, linkId = newLinkId, sideCode = newSideCode, asset.value, geometry, false,
       newStart, newEnd, geometry.toSet, asset.modifiedBy, asset.modifiedDateTime, asset.createdBy, asset.createdDateTime,
       SpeedLimitAsset.typeId, newDirection, projection.timeStamp, None,
-      asset.linkSource, Unknown, Map(), None, None, None), changeSet)
+      asset.linkSource, to.administrativeClass, Map(), None, None, None), changeSet)
   }
 }

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFillerSpec.scala
@@ -239,6 +239,8 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     filledTopology.map(_.sideCode) should be(Seq(SideCode.BothDirections))
     filledTopology.map(_.value) should be(Seq(None))
     filledTopology.map(_.id) should be(Seq(0))
+    filledTopology.head.startMeasure should be(0.0)
+    filledTopology.head.endMeasure should be(100.0)
   }
 
   test("project speed limits to new geometry, case 1 - single speed, both directions") {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -119,7 +119,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
         PieceWiseLinearAsset(persisted.id, persisted.linkId, SideCode(persisted.sideCode), persisted.value, GeometryUtils.truncateGeometry3D(roadLinkFetched.geometry, persisted.startMeasure, persisted.endMeasure), persisted.expired,
           persisted.startMeasure, persisted.endMeasure, Set(Point(0.0, 0.0)), persisted.modifiedBy, persisted.modifiedDateTime, persisted.createdBy, persisted.createdDateTime,
           persisted.typeId, SideCode.toTrafficDirection(SideCode(persisted.sideCode)), persisted.timeStamp, persisted.geomModifiedDate,
-          roadLinkFetched.linkSource, Unknown, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource),
+          roadLinkFetched.linkSource, roadLinkFetched.administrativeClass, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource),
         roadLinkFetched)
     }
   }
@@ -313,7 +313,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
             PieceWiseLinearAsset(persisted.id, persisted.linkId, SideCode(persisted.sideCode), persisted.value, geometry, persisted.expired,
               persisted.startMeasure, persisted.endMeasure, geometry.toSet, persisted.modifiedBy, persisted.modifiedDateTime, persisted.createdBy, persisted.createdDateTime,
               persisted.typeId, roadLink.trafficDirection, persisted.timeStamp, persisted.geomModifiedDate,
-              persisted.linkSource, Unknown, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource)
+              persisted.linkSource, roadLink.administrativeClass, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource)
 
           }
           speedLimits.filter(asset => asset.id == idUpdated || asset.id == newId)
@@ -347,7 +347,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
     PieceWiseLinearAsset(persisted.id, persisted.linkId, SideCode(persisted.sideCode), persisted.value, geometry, persisted.expired,
       persisted.startMeasure, persisted.endMeasure, geometry.toSet, persisted.modifiedBy, persisted.modifiedDateTime, persisted.createdBy, persisted.createdDateTime,
       persisted.typeId, roadLink.trafficDirection, persisted.timeStamp, persisted.geomModifiedDate,
-      persisted.linkSource, Unknown, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource)
+      persisted.linkSource, roadLink.administrativeClass, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource)
 
   }
 


### PR DESCRIPTION
Korjaa bugin, joka aiheutti tuntemattoman nopeusrajoituksen päälle tallentamisessa ongelman. Tuntemattomien luonnissa oli typo, jonka vuoksi tuntemattoman start- ja endMeasure oli samat. Testiin lisätty pari riviä, jotka tarvittaessa nappaa vastaavan jatkossa.

Samalla muokattu assettien adminClasseja tielinkin mukaiseksi siellä, missä sen saa helposti linkistä (tällä ei taida olla väliä, kun SpeedLimitillä ei tätä tietoa ollut, mutta muutin nyt kuitenkin).