### PR TITLE
DROTH-3559 Remove redundant reorganizeLanes method call

### DIFF
--- a/UI/src/model/selectedLaneModelling.js
+++ b/UI/src/model/selectedLaneModelling.js
@@ -447,7 +447,6 @@
       });
       removePropertyByPublicId(newMainLane, "end_date");
       self.selection = lanesAfterPromotion;
-      reorganizeLanes(laneNumber);
       self.dirty = true;
       self.promotionDirty = true;
     };


### PR DESCRIPTION
Korjattu bugi pääkaistan paikan vaihdossa poistamalla turha metodi kutsu. Metodin kutsu on tainnut jäädä aikaisemmin vahingossa mukaan, jäänyt huomaamatta kun useimmissa tapauksissa metodi ei tee mitään, mutta tiketissä kuvatussa tilanteessa sekoitti formin.