### PR TITLE
DROTH-3500 Modify kgv_roadlink constraints

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_28__edit_kgv_roadlink_constraints.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_28__edit_kgv_roadlink_constraints.sql
@@ -1,0 +1,4 @@
+ALTER TABLE kgv_roadlink DROP CONSTRAINT kgv_roadlink_linkid;
+ALTER TABLE kgv_roadlink ADD CONSTRAINT kgv_roadlink_linkid UNIQUE (linkid);
+
+ALTER TABLE kgv_roadlink DROP CONSTRAINT kgv_roadlink_mtkid;


### PR DESCRIPTION
- Pudotettu pois kgv_roadlink_mtkid constraint, sillä kgv siirtymän myötä sama mtkid voi esiintyä useammalla linkillä (esim. eri linkkien versioilla)
- Muutettu kgv_roadlink_linkid constraint kgv_roadlink_linkid UNIQUE (linkid) DEFERRABLE INITIALLY DEFERRED => ALTER TABLE kgv_roadlink ADD CONSTRAINT kgv_roadlink_linkid UNIQUE (linkid), jotta uusien linkkien lisäämisessä tauluun voidaan hyödyntää ON CONFLICT:ia