### PR TITLE
DROTH-3671 Fix VKM response value type cast

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -358,7 +358,7 @@ class VKMClient {
   }
 
   private def validateAndConvertToInt(fieldName: String, map: Map[String, Any]) = {
-    def value = map.get(fieldName).asInstanceOf[Option[String]]
+    def value = map.get(fieldName).asInstanceOf[Option[BigInt]]
     if (value.isEmpty) {
       throw new RoadAddressException(
         "Missing mandatory field in response: %s".format(


### PR DESCRIPTION
Pysäkki form ei auennut, koska VKM vastauksessa tuli vastauksen kenttien käsittelyssä tyyppi castaus virhe. Hieman omituinen tapaus, käytettiin .asInstanceOf[Option[String]] mutta silti debuggerissa tyypiksi näkyi Some(BigInt). Ennen tätä metodia arvon tyyppiä ei ole määritelty vaan on ollut [Any]. Lähti nyt toimimaan tällä muutoksella.