### PR TITLE
Droth 3674 use history events with no event number

### DIFF
--- a/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
@@ -128,6 +128,10 @@
       {
         "name": "cacheTTL",
         "value": "72000"
+      },
+      {
+        "name": "roadLinkChangeS3BucketName",
+        "value": "dev-vaylapilvi-digiroad2-road-link-change-bucket"
       }
     ],
     "logConfiguration": {

--- a/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
@@ -128,6 +128,10 @@
       {
         "name": "cacheTTL",
         "value": "72000"
+      },
+      {
+        "name": "roadLinkChangeS3BucketName",
+        "value": "prod-vaylapilvi-digiroad2-road-link-change-bucket"
       }
     ],
     "logConfiguration": {

--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -128,6 +128,10 @@
       {
         "name": "cacheTTL",
         "value": "72000"
+      },
+      {
+        "name": "roadLinkChangeS3BucketName",
+        "value": "qa-vaylapilvi-digiroad2-road-link-change-bucket"
       }
     ],
     "logConfiguration": {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -358,7 +358,7 @@ class VKMClient {
   }
 
   private def validateAndConvertToInt(fieldName: String, map: Map[String, Any]) = {
-    def value = map.get(fieldName).asInstanceOf[Option[String]]
+    def value = map.get(fieldName).asInstanceOf[Option[BigInt]]
     if (value.isEmpty) {
       throw new RoadAddressException(
         "Missing mandatory field in response: %s".format(

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneHistoryDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneHistoryDao.scala
@@ -251,8 +251,7 @@ class LaneHistoryDao() {
 
     val withAutoAdjustFilter = if (withAdjust) "" else "and (l.modified_by is null OR l.modified_by != 'generated_in_update')"
 
-    val filter = s"""WHERE ((l.HISTORY_CREATED_DATE > $querySinceDate and l.HISTORY_CREATED_DATE <= $queryUntilDate) and l.event_order_number is not null
-                      $withAutoAdjustFilter)"""
+    val filter = s"""WHERE ((l.HISTORY_CREATED_DATE > $querySinceDate and l.HISTORY_CREATED_DATE <= $queryUntilDate) $withAutoAdjustFilter)"""
 
     getHistoryLanesFilterQuery(withFilter(filter))
   }


### PR DESCRIPTION
Käyttäjät halusivat myös aikaisemmat muutokset, joilla ei ollut history_event_order_number tietoa kannassa rajapinnan vastaukseen, mahdollistettu tämä, korjattu samalla bugi end_date asettamisessa päättämisen yhteydessä. Parannettu LaneChange järjestämistä.