### PR TITLE
DROTH-3505 move case classes outside the client

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/RoadLinkChangeClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/RoadLinkChangeClient.scala
@@ -33,6 +33,10 @@ object RoadLinkChangeType {
   case object Unknown extends RoadLinkChangeType { def value = "unknown" }
 }
 
+case class RoadLinkInfo(linkId: String, linkLength: Double, geometry: List[Point], roadClass: Int, adminClass: AdministrativeClass, municipality: Int, trafficDirection: TrafficDirection)
+case class ReplaceInfo(oldLinkId: String, newLinkId: String, oldFromMValue: Double, oldToMValue: Double, newFromMValue: Double, newToMValue: Double, digitizationChange: Boolean)
+case class RoadLinkChange(changeType: RoadLinkChangeType, oldLink: Option[RoadLinkInfo], newLinks: Seq[RoadLinkInfo], replaceInfo: Seq[ReplaceInfo])
+
 class RoadLinkChangeClient {
   lazy val awsService = new AwsService
   lazy val s3Service: awsService.S3.type = awsService.S3
@@ -110,10 +114,6 @@ class RoadLinkChangeClient {
 
   implicit val formats = DefaultFormats + changeItemSerializer + RoadLinkChangeTypeSerializer + GeometrySerializer +
     AdminClassSerializer + TrafficDirectionSerializer
-
-  case class RoadLinkInfo(linkId: String, linkLength: Double, geometry: List[Point], roadClass: Int, adminClass: AdministrativeClass, municipality: Int, trafficDirection: TrafficDirection)
-  case class ReplaceInfo(oldLinkId: String, newLinkId: String, oldFromMValue: Double, oldToMValue: Double, newFromMValue: Double, newToMValue: Double, digitizationChange: Boolean)
-  case class RoadLinkChange(changeType: RoadLinkChangeType, oldLink: Option[RoadLinkInfo], newLinks: Seq[RoadLinkInfo], replaceInfo: Seq[ReplaceInfo])
 
   def fetchLatestSuccessfulUpdateDate(): DateTime = {
     // placeholder value as long as fetching this date from db is possible


### PR DESCRIPTION
Ajattelin siirtää muutoksiin liittyvät case classit clientin ulkopuolelle. Helpompi kehittää näitä käyttäviä juttuja jatkossa, kun voi importata suoraan.