### PR TITLE
DROTH-3681 Fix Traffic sign form pedestrian cycling link default sign

### DIFF
--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -1383,7 +1383,7 @@
         allowComplementaryLinks: true,
         newAsset: { validityDirection: 2, propertyData: [
           {'name': 'Liikenteenvastainen', 'propertyType': 'single_choice', 'publicId': "opposite_side_sign", values: [] },
-          {'name': 'Tyyppi', 'propertyType': 'single_choice', 'publicId': "trafficSigns_type", values: [ {propertyValue: 36} ] },
+          {'name': 'Tyyppi', 'propertyType': 'single_choice', 'publicId': "trafficSigns_type", values: [] },
           {'name': 'Päämerkin teksti', 'propertyType': 'text', 'publicId': 'main_sign_text', values: []},
           {'name': "Arvo", 'propertyType': 'text', 'publicId': "trafficSigns_value", values: []},
           {'name': "Lisatieto", 'propertyType': 'text', 'publicId': "trafficSigns_info", values: []},

--- a/UI/src/view/point_asset/trafficSignForm.js
+++ b/UI/src/view/point_asset/trafficSignForm.js
@@ -290,18 +290,22 @@
     }
 
     var singleChoiceTrafficSignTypeHandler = function (property, collection) {
+      if((_.isUndefined(property) || property.values.length === 0) ){
+        property.values = (isPedestrianOrCyclingRoadLink() ? [ {propertyValue: "85"} ] : [ {propertyValue: "36"} ]);
+      }
+
       var propertyValue = me.extractPropertyValue(property);
       var signTypes = getValuesFromEnumeratedProperty(property.publicId);
       var auxProperty = property;
       var groups =  collection.getGroup(signTypes);
       var groupKeys = Object.keys(groups);
-      var mainTypeDefaultValue = _.indexOf(_.map(groups, function (group) {return _.some(group, function(val) {return val.propertyValue == propertyValue;});}), true);
+      var mainTypeDefaultValueIndex = _.indexOf(_.map(groups, function (group) {return _.some(group, function(val) {return val.propertyValue == propertyValue;});}), true);
 
       if (isPedestrianOrCyclingRoadLink()) {
         var mandatorySignsDefaultValue = "70";
         var allAllowedSigns = collection.signTypesAllowedInPedestrianCyclingLinks;
         /* get the correct index for group to be used in subSingleChoice */
-        mainTypeDefaultValue = _.indexOf(_.map(groups, function (group) {return _.some(group, function(val) {return val.propertyValue == propertyValue;});}), true);
+        mainTypeDefaultValueIndex = _.indexOf(_.map(groups, function (group) {return _.some(group, function(val) {return val.propertyValue == propertyValue;});}), true);
 
         /* Only after get the correct index of the group (mainTypeDefaultValue) I can reset the values for the */
         /* correct one to be used in the 'main singleChoice field' */
@@ -313,7 +317,7 @@
       var counter = 0;
       var mainTypesTrafficSigns = _.map(groupKeys, function (label) {
         return $('<option>',
-          { selected: counter === mainTypeDefaultValue,
+          { selected: counter === mainTypeDefaultValueIndex,
             value: counter++,
             text: label}
         )[0].outerHTML; }).join('');
@@ -321,12 +325,12 @@
       return '' +
         '    <div class="form-group editable form-point-asset">' +
         '      <label class="control-label">' + property.localizedName + '</label>' +
-        '      <p class="form-control-static">' + (groupKeys[mainTypeDefaultValue] || '-') + '</p>' +
+        '      <p class="form-control-static">' + (groupKeys[mainTypeDefaultValueIndex] || '-') + '</p>' +
         '      <select class="form-control" id=main-' + property.publicId +'>' +
         mainTypesTrafficSigns +
         '      </select>' +
         '    </div>' +
-        singleChoiceSubType( collection, mainTypeDefaultValue, auxProperty );
+        singleChoiceSubType( collection, mainTypeDefaultValueIndex, auxProperty );
     };
 
     var sortPanelKeys = function(properties) {


### PR DESCRIPTION
Korjattu bugitiketissä kuvattu pyöräily- ja jalankulku linkkien traffic sign formin default liikennemerkin toiminta formia avatessa. Ennen korjausta loi A1.1-liikennemerkin (DR-arvo 36), vaikka formilla näkyi A11-liikennemerkki (DR-arvo 85), jos merkkiä ei vaihtanut pudotusvalikosta ollenkaan.