### PR TITLE
DROTH-3686 Fix traffic sign save condition regex for number field

### DIFF
--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -1431,7 +1431,7 @@
             /* sppedLimits */
             { types: [1, 2, 3, 4, 170, 237, 238], validate: function (someValue) { return /^\d+$/.test(someValue) && _.includes(possibleSpeedLimitsValues, parseInt(someValue)); }},
             /* number (int) */
-            { types: [8, 30, 31, 32, 33, 34, 35, 174, 175, 176, 177, 290, 291, 292, 400], validate: function (someValue) { return /^\d*$/.test(someValue) ; }},
+            { types: [8, 30, 31, 32, 33, 34, 35, 174, 175, 176, 177, 290, 291, 292, 400], validate: function (someValue) { return /^-?\d+$/.test(someValue) ; }},
             /* decimal number */
             { types: [45, 46, 138, 139, 148, 149, 308, 347, 348, 376], validate: function (someValue) { return /^\d*(,\d+)?$/.test(someValue) ; }},
             /* Number and special marks */


### PR DESCRIPTION
Korjattu regex. Aikaisempi regex matchasi tyhjän "" kanssa. Mahdollisti tyhjän arvon tallentamisen, jos kumitti kentän tyhjäksi. Korjattu nyt hyväksymään vain numerot, ei tyhjää.