### PR TITLE
DROTH-3691 speedlimit editing rights bug fix

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1395,7 +1395,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             "startAddrMValue" -> extractLongValue(link.attributes, "START_ADDR"),
             "endAddrMValue" ->  extractLongValue(link.attributes, "END_ADDR"),
             "administrativeClass" -> link.attributes.get("ROAD_ADMIN_CLASS"),
-            "municipalityCode" -> extractIntValue(link.attributes, "municipalityCode"),
+            "municipalityCode" -> extractIntValue(link.attributes, "municipality"),
             "constructionType" -> extractIntValue(link.attributes, "constructionType")
           )
         }


### PR DESCRIPTION
Digiroad api on hakenut tielinkin kuntakoodin nopeusrajoituksen attribuuteista eri keylla kuin muissa asseteissa. Nyt kun nopeusrajoitukset haetaan samalla tavalla kuin muutkin lineaariset, kuntakoodia ei enää löydy. Vaihdettu key samaan kuin muillakin.

Kuntakäyttäjän oikeudet katsotaan kuntakoodin perusteella UI:ssa, joten tämä ainakin lokaalin testailun perusteella korjaa kuntakäyttäjien muokkausoikeusongelman.