### PR TITLE
DROTH-3508 correct replace info

### DIFF
--- a/digiroad2-oracle/src/test/resources/smallChangeSet.json
+++ b/digiroad2-oracle/src/test/resources/smallChangeSet.json
@@ -722,12 +722,12 @@
     ],
     "replaceInfo": [
       {
-        "oldLinkId": "b05075a5-45e1-447e-9813-752ba3e07fe5:1",
+        "oldLinkId": "9d23b85a-d7bf-4c6f-83ff-aa391ff4879f:1",
         "newLinkId": "fbea6a9c-6682-4a1b-9807-7fb11a67e227:1",
         "oldFromMValue": 0.0,
-        "oldToMValue": 42.5908355484,
-        "newFromMValue": 623.5620521019,
-        "newToMValue": 666.1528876503,
+        "oldToMValue": 580.2148170854,
+        "newFromMValue": 0.0,
+        "newToMValue": 580.2148170854,
         "digitizationChange": false
       }
     ]


### PR DESCRIPTION
Korjataan väärä replace info, joka ilmeisesti tullut, kun pilkoin mergen replaceiksi. 