### PR TITLE
DROTH-3700 round link lengths to 3 decimals

### DIFF
--- a/lambda/road-link-change-handler/src/client/kgv-client.ts
+++ b/lambda/road-link-change-handler/src/client/kgv-client.ts
@@ -101,6 +101,7 @@ export class KgvLink {
                 surfaceType?: number, lifeCycleStatus?: number, surfaceRelation?: number, xyAccuracy?: number,
                 zAccuracy?: number, geomFlip?: boolean, fromLeft?: number, toLeft?: number, fromRight?: number,
                 toRight?: number, startTime?: string, versionStartTime?: string) {
+        const roundedLength     = length?.toFixed(3);
         this.id                 = id;
         this.sourceId           = this.extractNumberOrNull(sourceId);
         this.adminClass         = this.extractNumberOrNull(adminClass);
@@ -119,7 +120,7 @@ export class KgvLink {
         this.surfaceRelation    = this.extractNumberOrNull(surfaceRelation);
         this.xyAccuracy         = this.extractNumberOrNull(xyAccuracy);
         this.zAccuracy          = this.extractNumberOrNull(zAccuracy);
-        this.length             = this.extractNumberOrNull(length);
+        this.length             = roundedLength == undefined ? null : parseFloat(roundedLength);
         this.geometryFlip       = geomFlip == undefined ? null : JSON.parse(geomFlip.toString().toLowerCase()) ? 1 : 0;
         this.fromLeft           = this.extractNumberOrNull(fromLeft);
         this.toLeft             = this.extractNumberOrNull(toLeft);

--- a/lambda/road-link-change-handler/src/client/kgv-client.ts
+++ b/lambda/road-link-change-handler/src/client/kgv-client.ts
@@ -53,7 +53,7 @@ export class KgvClient extends ClientBase {
             const props = feature.properties;
             const geometry = this.extractLinkGeometry(feature.geometry);
             return new KgvLink(props.id, geometry, props.sourceid, props.adminclass, props.municipalitycode,
-                props.roadclass, props.horizontallength, props.directiontype, props.roadnamefin, props.roadnameswe,
+                props.horizontallength, props.directiontype, props.roadclass, props.roadnamefin, props.roadnameswe,
                 props.roadnamesme, props.roadnamesmn, props.roadnamesms, props.roadnumber, props.roadpartnumber,
                 props.surfacetype, props.lifecyclestatus, props.surfacerelation, props.xyaccuracy, props.zaccuracy,
                 props.geometryflip, props.addressfromleft, props.addresstoleft, props.addressfromright,

--- a/lambda/road-link-change-handler/test/service/change-set_test.js
+++ b/lambda/road-link-change-handler/test/service/change-set_test.js
@@ -22,7 +22,7 @@ describe('Change Set', function () {
             "new": [
                 {
                     "linkId": newLinkId,
-                    "linkLength": 16.93706266,
+                    "linkLength": 16.937,
                     "geometry": testLinkGeom1,
                     "roadClass": 12141,
                     "adminClass": 3,
@@ -54,7 +54,7 @@ describe('Change Set', function () {
             "changeType": "remove",
             "old": {
                 "linkId": linkId,
-                "linkLength": 16.93706266,
+                "linkLength": 16.937,
                 "geometry": testLinkGeom1,
                 "roadClass": 12141,
                 "adminClass": 3,
@@ -81,14 +81,14 @@ describe('Change Set', function () {
         const oldLinkId = "link:1";
         const newLinkId = "link:2";
         const oldLink = new KgvLink(oldLinkId, testLinkGeom1, 123, 3, 149, 16.93706266, 0, undefined);
-        const newLink = new KgvLink(newLinkId, testLinkGeom1, 124, 3, 149, 16.93706266, 0, 12141);
+        const newLink = new KgvLink(newLinkId, testLinkGeom1, 124, 3, 149, 16.93786266, 0, 12141);
         const change = new ReplaceInfo(oldLinkId, newLinkId, 0, 16.937, 0, 16.937);
         const changeSet = new ChangeSet([oldLink], [newLink], [change]);
         const expected = [{
             "changeType": "replace",
             "old": {
                 "linkId": oldLinkId,
-                "linkLength": 16.93706266,
+                "linkLength": 16.937,
                 "geometry": testLinkGeom1,
                 "roadClass": null,
                 "adminClass": 3,
@@ -98,7 +98,7 @@ describe('Change Set', function () {
             "new": [
                 {
                     "linkId": newLinkId,
-                    "linkLength": 16.93706266,
+                    "linkLength": 16.938,
                     "geometry": testLinkGeom1,
                     "roadClass": 12141,
                     "adminClass": 3,


### PR DESCRIPTION
Lisätty linkkien pituuden pyöristäminen kolmen desimaalin tarkkuuteen. Muutos vaikuttaa niin kantaan tallennettaviin tietoihin kuin muodostettuun muutossanomaan.

Korjattu lisäksi KgvLink parametrien järjestys oikeaksi.