### PR TITLE
DROTH-3743 Add event configuration to s3 bucket

### DIFF
--- a/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
+++ b/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
@@ -74,7 +74,9 @@ Resources:
             AbortIncompleteMultipartUpload:
               DaysAfterInitiation: 1
             Status: Enabled
-      # TODO: NotificationConfiguration: -- add notification configuration to new object notify uploads
+      NotificationConfiguration:
+        EventBridgeConfiguration:
+          EventBridgeEnabled: true
       Tags:
         - Key: Name
           Value: !Sub ${ApplicationName}-${Environment}-road-link-change-bucket
@@ -182,7 +184,6 @@ Resources:
 
 
   ### EVENTS ###
-
   StartLambdaEvent:
     Type: AWS::Events::Rule
     Properties:
@@ -194,8 +195,6 @@ Resources:
         - Arn: !GetAtt Lambda.Arn
           Id: !Sub "${Environment}-${ApplicationName}-road-link-change-event-target"
 
-
-  # TODO: Add event to handle s3 put events
 
   ### IAM ###
   LambdaRole:


### PR DESCRIPTION
Lisätty s3 bucketille toiminnallisuus lähettää muutostietoja EventBridgelle, joiden perusteella voidaan ajoittaa samuutuksen aloitus oikein. Vaatii muutoksia vielä batch lambdan konfiguraatioon sekä uusi käsittely samuutuksella (toteutetaan eri PR yhteydessä).