### PR TITLE
DROTH-3752 Process road link change sets individually

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
@@ -970,18 +970,18 @@ case object NumberOfLanes extends AssetTypeInfo { val typeId = 140; def geometry
 case object MassTransitLane extends AssetTypeInfo { val typeId = 160; def geometryType = "linear"; val label = "MassTransitLane"; val layerName = "massTransitLanes"; val nameFI = "Joukkoliikennekaistat"  }
 case object TrafficVolume extends AssetTypeInfo { val typeId = 170; def geometryType = "linear"; val label = "TrafficVolume"; val layerName = "trafficVolume"; val nameFI = "Liikennemäärä" }
 case object WinterSpeedLimit extends AssetTypeInfo { val typeId = 180; def geometryType = "linear"; val label = "WinterSpeedLimit"; val layerName = "winterSpeedLimits"; val nameFI = "Talvinopeusrajoitukset"  }
-case object Prohibition extends AssetTypeInfo { val typeId = 190; def geometryType = "linear"; val label = ""; val layerName = "prohibition"; val nameFI = "Ajokielto" }
+case object Prohibition extends AssetTypeInfo { val typeId = 190; def geometryType = "linear"; val label = "Prohibition"; val layerName = "prohibition"; val nameFI = "Ajokielto" }
 case object PedestrianCrossings extends AssetTypeInfo { val typeId = 200; def geometryType = "point"; val label = "PedestrianCrossings"; val layerName = "pedestrianCrossings"; val nameFI = "Suojatie" }
 case object HazmatTransportProhibition extends AssetTypeInfo { val typeId = 210; def geometryType = "linear"; val label = "HazmatTransportProhibition"; val layerName = "hazardousMaterialTransportProhibition"; val nameFI = "VAK-rajoitus" }
-case object Obstacles extends AssetTypeInfo { val typeId = 220; def geometryType = "point"; val label = ""; val layerName = "obstacles"; val nameFI = "Esterakennelma" }
-case object RailwayCrossings extends AssetTypeInfo { val typeId = 230; def geometryType = "point"; val label = ""; val layerName = "railwayCrossings"; val nameFI = "Rautatien tasoristeys" }
-case object DirectionalTrafficSigns extends AssetTypeInfo { val typeId = 240; def geometryType = "point"; val label = ""; val layerName = "directionalTrafficSigns"; val nameFI = "Opastustaulu ja sen informaatio" }
-case object ServicePoints extends AssetTypeInfo { val typeId = 250; def geometryType = "point"; val label = ""; val layerName = "servicePoints"; val nameFI = "Palvelupiste" }
-case object EuropeanRoads extends AssetTypeInfo { val typeId = 260; def geometryType = "linear"; val label = ""; val layerName = "europeanRoads"; val nameFI = "Eurooppatienumero" }
-case object ExitNumbers extends AssetTypeInfo { val typeId = 270; def geometryType = "linear"; val label = ""; val layerName = "exitNumbers"; val nameFI = "Liittymänumero" }
-case object TrafficLights extends AssetTypeInfo { val typeId = 280; def geometryType = "point"; val label =  ""; val layerName = "trafficLights"; val nameFI = "Liikennevalo"}
-case object MaintenanceRoadAsset extends AssetTypeInfo { val typeId = 290; def geometryType = "linear"; val label = ""; val layerName = "maintenanceRoads"; val nameFI = "Huoltotie" }
-case object TrafficSigns extends AssetTypeInfo { val typeId = 300; def geometryType = "point"; val label = ""; val layerName = "trafficSigns"; val nameFI = "Liikennemerkki"}
+case object Obstacles extends AssetTypeInfo { val typeId = 220; def geometryType = "point"; val label = "Obstacles"; val layerName = "obstacles"; val nameFI = "Esterakennelma" }
+case object RailwayCrossings extends AssetTypeInfo { val typeId = 230; def geometryType = "point"; val label = "RailwayCrossings"; val layerName = "railwayCrossings"; val nameFI = "Rautatien tasoristeys" }
+case object DirectionalTrafficSigns extends AssetTypeInfo { val typeId = 240; def geometryType = "point"; val label = "DirectionalTrafficSigns"; val layerName = "directionalTrafficSigns"; val nameFI = "Opastustaulu ja sen informaatio" }
+case object ServicePoints extends AssetTypeInfo { val typeId = 250; def geometryType = "point"; val label = "ServicePoints"; val layerName = "servicePoints"; val nameFI = "Palvelupiste" }
+case object EuropeanRoads extends AssetTypeInfo { val typeId = 260; def geometryType = "linear"; val label = "EuropeanRoads"; val layerName = "europeanRoads"; val nameFI = "Eurooppatienumero" }
+case object ExitNumbers extends AssetTypeInfo { val typeId = 270; def geometryType = "linear"; val label = "ExitNumbers"; val layerName = "exitNumbers"; val nameFI = "Liittymänumero" }
+case object TrafficLights extends AssetTypeInfo { val typeId = 280; def geometryType = "point"; val label = "TrafficLights"; val layerName = "trafficLights"; val nameFI = "Liikennevalo"}
+case object MaintenanceRoadAsset extends AssetTypeInfo { val typeId = 290; def geometryType = "linear"; val label = "MaintenanceRoads"; val layerName = "maintenanceRoads"; val nameFI = "Huoltotie" }
+case object TrafficSigns extends AssetTypeInfo { val typeId = 300; def geometryType = "point"; val label = "TrafficSigns"; val layerName = "trafficSigns"; val nameFI = "Liikennemerkki"}
 case object StateSpeedLimit extends AssetTypeInfo { val typeId = 310; def geometryType = "linear"; val label = "StateSpeedLimit"; val layerName = "totalWeightLimit"; val nameFI = "Tierekisteri Nopeusrajoitukset" }
 case object UnknownAssetTypeId extends  AssetTypeInfo {val typeId = 99; def geometryType = ""; val label = ""; val layerName = ""; val nameFI = ""}
 case object TrWeightLimit extends  AssetTypeInfo {val typeId = 320; def geometryType = "point"; val label = "TrWeightLimit"; val layerName = "trWeightLimits"; val nameFI = "Tierekisteri Suurin sallittu massa"}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/queries.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/queries.scala
@@ -449,8 +449,8 @@ object Queries {
   def getLatestSuccessfulSamuutus(typeid: Int):DateTime = {
     sql"""select last_succesfull_samuutus from samuutus_success where asset_type_id = $typeid """.as[DateTime].list.head
   }
-  def updateLatestSuccessfulSamuutus(typeid: Int): Unit = {
-    sqlu"""UPDATE samuutus_success SET last_succesfull_samuutus = current_timestamp WHERE asset_type_id = $typeid""".execute
+  def updateLatestSuccessfulSamuutus(typeid: Int, latestSuccess: DateTime): Unit = {
+    sqlu"""UPDATE samuutus_success SET last_succesfull_samuutus = to_timestamp($latestSuccess, 'YYYY-MM-DD"T"HH24:MI:SS.FF') WHERE asset_type_id = $typeid""".execute
   }
  
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
@@ -5,12 +5,15 @@ import software.amazon.awssdk.core.exception.SdkClientException
 import software.amazon.awssdk.core.sync.RequestBody
 import software.amazon.awssdk.core.waiters.WaiterOverrideConfiguration
 import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, ListObjectsV2Request, PutObjectRequest}
+import software.amazon.awssdk.services.s3.model.{GetObjectRequest, HeadObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Object}
 import software.amazon.awssdk.services.s3.presigner.S3Presigner
 import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
 
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.io.Source.fromInputStream
 
 class AwsService {
   val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -75,14 +78,29 @@ class AwsService {
       }
     }
 
-    def getObjectFromS3(s3bucket: String, key: String) = {
+    def getObjectFromS3(s3bucket: String, key: String): String = {
       val getObjectRequest = GetObjectRequest.builder().bucket(s3bucket).key(key).build()
-      s3.getObject(getObjectRequest)
+      val s3Object = s3.getObject(getObjectRequest)
+      fromInputStream(s3Object).mkString
     }
 
-    def listObjects(s3bucket: String) = {
-      val listObjectsRequest = ListObjectsV2Request.builder().bucket(s3bucket).build()
-      s3.listObjectsV2(listObjectsRequest).contents()
+    def listObjects(s3bucket: String): List[S3Object] = {
+      listBucketObjects(s3bucket).toList
+    }
+
+    @tailrec
+    def listBucketObjects(s3Bucket: String, results: Seq[S3Object] = Seq(), continuationToken: Option[String] = None): Seq[S3Object] = {
+      val listObjectsRequest = ListObjectsV2Request.builder().bucket(s3Bucket)
+      if (continuationToken.isDefined) listObjectsRequest.continuationToken(continuationToken.get)
+
+      val result = s3.listObjectsV2(listObjectsRequest.build())
+      val objects = results ++ result.contents().asScala
+
+      if (result.isTruncated) {
+        listBucketObjects(s3Bucket, objects, Some(result.nextContinuationToken()))
+      } else {
+        objects
+      }
     }
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
@@ -380,10 +380,11 @@ object ChangeReporter {
   // Used for testing CSV report. Saves file locally to directory 'samuutus-reports-local-test' created in project root directory
   def saveReportToLocalFile(assetName: String, changesProcessedUntil: DateTime, body: String, contentRowCount: Int,
                             hasGeometry: Boolean = false): Unit = {
+    val date = DateTime.now().toString("YYYY-MM-dd")
     val untilDate = changesProcessedUntil.toString("YYYY-MM-dd")
     val withGeometry = if (hasGeometry) "_withGeometry" else ""
-    Files.createDirectories(Paths.get(localReportDirectoryName))
-    val path = s"$localReportDirectoryName/${assetName}_${untilDate}_${contentRowCount}content_rows$withGeometry.csv"
+    Files.createDirectories(Paths.get(localReportDirectoryName, date))
+    val path = s"$localReportDirectoryName/$date/${assetName}_${untilDate}_${contentRowCount}content_rows$withGeometry.csv"
 
     new PrintWriter(path) {
       write(body)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LaneUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LaneUpdater.scala
@@ -217,17 +217,17 @@ object LaneUpdater {
         val changeSet = handleChanges(roadLinkChanges, workListChanges)
         val changedLanes = updateSamuutusChangeSet(changeSet, allRoadLinkChanges)
         val changeReport = ChangeReport(Lanes.typeId, changedLanes)
-        generateAndSaveReport(changeReport)
+        generateAndSaveReport(changeReport, roadLinkChangeSet.targetDate)
         Queries.updateLatestSuccessfulSamuutus(Lanes.typeId, roadLinkChangeSet.targetDate)
       }
     })
   }
 
-  def generateAndSaveReport(changeReport: ChangeReport): Unit = {
+  def generateAndSaveReport(changeReport: ChangeReport, processedTo: DateTime): Unit = {
     val (reportBody, contentRowCount) = ChangeReporter.generateCSV(changeReport)
-    ChangeReporter.saveReportToS3(Lanes.label, reportBody, contentRowCount)
+    ChangeReporter.saveReportToS3(Lanes.label, processedTo, reportBody, contentRowCount)
     val (reportBodyWithGeom, _) = ChangeReporter.generateCSV(changeReport, withGeometry = true)
-    ChangeReporter.saveReportToS3(Lanes.label, reportBodyWithGeom, contentRowCount, hasGeometry = true)
+    ChangeReporter.saveReportToS3(Lanes.label, processedTo, reportBodyWithGeom, contentRowCount, hasGeometry = true)
   }
 
   def updateTrafficDirectionChangesLaneWorkList(roadLinkChanges: Seq[RoadLinkChange]): Unit = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -15,7 +15,7 @@ import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.{LinearAssetOperations, LinearAssetTypes, Measures}
 import fi.liikennevirasto.digiroad2.util.{Digiroad2Properties, LinearAssetUtils}
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.annotation.tailrec
 
@@ -41,18 +41,22 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   def assetFiller: AssetFiller = service.assetFiller
   def dao: PostGISLinearAssetDao = new PostGISLinearAssetDao()
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
-  val logger = LoggerFactory.getLogger(getClass)
+  val logger: Logger = LoggerFactory.getLogger(getClass)
   val roadLinkChangeClient = new RoadLinkChangeClient
   
   protected val removePart: Int = -1 
 
   def updateLinearAssets(typeId: Int): Unit = {
-    withDynTransaction {
-      val latestSuccessful = Queries.getLatestSuccessfulSamuutus(typeId)
-      val changes = roadLinkChangeClient.getRoadLinkChanges(latestSuccessful)
-      updateByRoadLinks(typeId, changes)
-      Queries.updateLatestSuccessfulSamuutus(typeId)
-    }
+    val latestSuccess = PostGISDatabase.withDynSession( Queries.getLatestSuccessfulSamuutus(typeId) )
+    val changeSets = roadLinkChangeClient.getRoadLinkChanges(latestSuccess)
+
+    changeSets.foreach( changeSet => {
+      logger.info(s"Started processing change set ${changeSet.key}")
+      withDynTransaction {
+        updateByRoadLinks(typeId, changeSet.changes)
+        Queries.updateLatestSuccessfulSamuutus(typeId, changeSet.targetDate)
+      }
+    })
   }
 
   protected val isDeleted: RoadLinkChange => Boolean = (change: RoadLinkChange) => {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -287,7 +287,7 @@ class RoadLinkPropertyUpdater {
         val deletedProperties = removePropertiesFromOldLinks(removeChanges ++ otherChanges)
         val changeReport = ChangeReport(RoadLinkProperties.typeId, transferredProperties ++ createdProperties ++ deletedProperties)
         val (reportBody, contentRowCount) = ChangeReporter.generateCSV(changeReport)
-        ChangeReporter.saveReportToS3("roadLinkProperties", reportBody, contentRowCount)
+        ChangeReporter.saveReportToS3("roadLinkProperties", changeSet.targetDate, reportBody, contentRowCount)
         Queries.updateLatestSuccessfulSamuutus(RoadLinkProperties.typeId, changeSet.targetDate)
       }
     })

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -15,6 +15,7 @@ import fi.liikennevirasto.digiroad2.util.assetUpdater.ChangeTypeReport.{Creation
 import fi.liikennevirasto.digiroad2.util.{Digiroad2Properties, KgvUtil, LinearAssetUtils}
 import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
 import org.joda.time.DateTime
+import org.slf4j.{Logger, LoggerFactory}
 
 import scala.collection.mutable.ListBuffer
 
@@ -22,6 +23,7 @@ class RoadLinkPropertyUpdater {
 
   lazy val roadLinkService: RoadLinkService = new RoadLinkService(new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint), new DummyEventBus, new DummySerializer)
   lazy val roadLinkChangeClient: RoadLinkChangeClient = new RoadLinkChangeClient
+  val logger: Logger = LoggerFactory.getLogger(getClass)
 
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
@@ -269,20 +271,25 @@ class RoadLinkPropertyUpdater {
     transferredProperties
   }
 
-  def updateProperties() = {
-    withDynTransaction {
-      val latestSuccess = Queries.getLatestSuccessfulSamuutus(RoadLinkProperties.typeId)
-      val changes = roadLinkChangeClient.getRoadLinkChanges(latestSuccess)
-      val (addChanges, remaining) = changes.partition(_.changeType == Add)
-      val (removeChanges, otherChanges) = remaining.partition(_.changeType == Remove)
+  def updateProperties(): Unit = {
+    val latestSuccess = PostGISDatabase.withDynSession( Queries.getLatestSuccessfulSamuutus(RoadLinkProperties.typeId) )
+    val changeSets = roadLinkChangeClient.getRoadLinkChanges(latestSuccess)
 
-      val transferredProperties = transferOverriddenPropertiesAndPrivateRoadInfo(otherChanges)
-      val createdProperties = transferOrGenerateFunctionalClassesAndLinkTypes(addChanges ++ otherChanges)
-      val deletedProperties = removePropertiesFromOldLinks(removeChanges ++ otherChanges)
-      val changeReport = ChangeReport(RoadLinkProperties.typeId, transferredProperties ++ createdProperties ++ deletedProperties)
-      val (reportBody, contentRowCount) = ChangeReporter.generateCSV(changeReport)
-      ChangeReporter.saveReportToS3("roadLinkProperties", reportBody, contentRowCount)
-      Queries.updateLatestSuccessfulSamuutus(RoadLinkProperties.typeId)
-    }
+    changeSets.foreach(changeSet => {
+      withDynTransaction {
+        logger.info(s"Started processing change set ${changeSet.key}")
+        val changes = changeSet.changes
+        val (addChanges, remaining) = changes.partition(_.changeType == Add)
+        val (removeChanges, otherChanges) = remaining.partition(_.changeType == Remove)
+
+        val transferredProperties = transferOverriddenPropertiesAndPrivateRoadInfo(otherChanges)
+        val createdProperties = transferOrGenerateFunctionalClassesAndLinkTypes(addChanges ++ otherChanges)
+        val deletedProperties = removePropertiesFromOldLinks(removeChanges ++ otherChanges)
+        val changeReport = ChangeReport(RoadLinkProperties.typeId, transferredProperties ++ createdProperties ++ deletedProperties)
+        val (reportBody, contentRowCount) = ChangeReporter.generateCSV(changeReport)
+        ChangeReporter.saveReportToS3("roadLinkProperties", reportBody, contentRowCount)
+        Queries.updateLatestSuccessfulSamuutus(RoadLinkProperties.typeId, changeSet.targetDate)
+      }
+    })
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
@@ -10,49 +10,57 @@ import fi.liikennevirasto.digiroad2._
 import org.joda.time.DateTime
 import org.json4s.JsonDSL._
 import org.json4s.jackson.compactJson
+import org.slf4j.{Logger, LoggerFactory}
 
 class PointAssetUpdater(service: PointAssetOperations) {
   val roadLinkChangeClient = new RoadLinkChangeClient
+  val logger: Logger = LoggerFactory.getLogger(getClass)
+
   val MaxDistanceDiffAllowed = 3.0 // Meters
 
   def adjustValidityDirection(assetDirection: Option[Int], digitizationChange: Boolean): Option[Int] = None
   def calculateBearing(point: Point, geometry: Seq[Point]): Option[Int] = None
 
-  def getRoadLinkChanges(typeId: Int): Seq[RoadLinkChange] = {
-    val latestSuccess = Queries.getLatestSuccessfulSamuutus(typeId)
-    roadLinkChangeClient.getRoadLinkChanges(latestSuccess)
+  def updatePointAssets(typeId: Int): Unit = {
+    val latestSuccess = PostGISDatabase.withDynSession ( Queries.getLatestSuccessfulSamuutus(typeId) )
+    val changeSets = roadLinkChangeClient.getRoadLinkChanges(latestSuccess)
+
+    changeSets.foreach(changeSet => {
+      logger.info(s"Started processing change set ${changeSet.key}")
+      PostGISDatabase.withDynTransaction {
+        updateByRoadLinks(typeId, changeSet.changes)
+        Queries.updateLatestSuccessfulSamuutus(typeId, changeSet.targetDate)
+      }
+    })
   }
 
-  def updatePointAssets(typeId: Int): Unit = {
-    PostGISDatabase.withDynTransaction {
-      val linkChanges = getRoadLinkChanges(typeId).filterNot(_.changeType == RoadLinkChangeType.Add)
-      val changedLinkIds = linkChanges.flatMap(change => change.oldLink).map(_.linkId).toSet
+  protected def updateByRoadLinks(typeId: Int, changes: Seq[RoadLinkChange]): Unit = {
+    val linkChanges = changes.filterNot(_.changeType == RoadLinkChangeType.Add)
+    val changedLinkIds = linkChanges.flatMap(change => change.oldLink).map(_.linkId).toSet
 
-      val changedAssets = service.getPersistedAssetsByLinkIdsWithoutTransaction(changedLinkIds).toSet
-      val reportedChanges = changedAssets.map(asset => {
-        val linkChange = linkChanges.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == asset.linkId).get
-        correctPersistedAsset(asset, linkChange) match {
-          case adjustment if adjustment.floating =>
-            service.floatingUpdate(asset.id, adjustment.floating, adjustment.floatingReason)
-            val newAsset = service.createOperation(asset, adjustment)
-            Some(reportChange(asset, newAsset, Floating, linkChange, adjustment))
-          case adjustment =>
-            val link = linkChange.newLinks.find(_.linkId == adjustment.linkId)
-            val assetId = service.adjustmentOperation(asset, adjustment, link.get)
-            val newAsset = service.createOperation(asset, adjustment.copy(assetId = assetId))
-            Some(reportChange(asset, newAsset, Move, linkChange, adjustment))
-        }
-      })
-      val (reportBody, contentRowCount) = ChangeReporter.generateCSV(ChangeReport(typeId, reportedChanges.toSeq.flatten))
-      ChangeReporter.saveReportToS3(AssetTypeInfo(typeId).label, reportBody, contentRowCount)
-      val (reportBodyWithGeom, _) = ChangeReporter.generateCSV(ChangeReport(typeId, reportedChanges.toSeq.flatten), true)
-      ChangeReporter.saveReportToS3(AssetTypeInfo(typeId).label, reportBodyWithGeom, contentRowCount, true)
-      Queries.updateLatestSuccessfulSamuutus(typeId)
-    }
+    val changedAssets = service.getPersistedAssetsByLinkIdsWithoutTransaction(changedLinkIds).toSet
+    val reportedChanges = changedAssets.map(asset => {
+      val linkChange = linkChanges.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == asset.linkId).get
+      correctPersistedAsset(asset, linkChange) match {
+        case adjustment if adjustment.floating =>
+          service.floatingUpdate(asset.id, adjustment.floating, adjustment.floatingReason)
+          val newAsset = service.createOperation(asset, adjustment)
+          Some(reportChange(asset, newAsset, Floating, linkChange, adjustment))
+        case adjustment =>
+          val link = linkChange.newLinks.find(_.linkId == adjustment.linkId)
+          val assetId = service.adjustmentOperation(asset, adjustment, link.get)
+          val newAsset = service.createOperation(asset, adjustment.copy(assetId = assetId))
+          Some(reportChange(asset, newAsset, Move, linkChange, adjustment))
+      }
+    })
+    val (reportBody, contentRowCount) = ChangeReporter.generateCSV(ChangeReport(typeId, reportedChanges.toSeq.flatten))
+    ChangeReporter.saveReportToS3(AssetTypeInfo(typeId).label, reportBody, contentRowCount)
+    val (reportBodyWithGeom, _) = ChangeReporter.generateCSV(ChangeReport(typeId, reportedChanges.toSeq.flatten), true)
+    ChangeReporter.saveReportToS3(AssetTypeInfo(typeId).label, reportBodyWithGeom, contentRowCount, true)
   }
 
   def reportChange(oldPersistedAsset: PersistedPointAsset, newPersistedAsset: PersistedPointAsset,
-                   changeType: ChangeType, roadLinkChange: RoadLinkChange, assetUpdate: AssetUpdate) = {
+                   changeType: ChangeType, roadLinkChange: RoadLinkChange, assetUpdate: AssetUpdate): ChangedAsset = {
     val oldLinearReference = LinearReference(oldPersistedAsset.linkId,oldPersistedAsset.mValue, None, None, oldPersistedAsset.getValidityDirection, 0.0)
     val oldValues = compactJson(oldPersistedAsset.propertyData.map(_.toJson))
     val oldAsset = Asset(oldPersistedAsset.id, oldValues, Some(oldPersistedAsset.municipalityCode),

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/RoadLinkChangeClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/RoadLinkChangeClientSpec.scala
@@ -170,6 +170,7 @@ class RoadLinkChangeClientSpec extends FunSuite with Matchers {
   ignore("fetch changes from S3 and convert to RoadLinkChange") {
     val roadlinkChanges_all = roadLinkChangeClient.getRoadLinkChanges()
     roadlinkChanges_all.size should not be(0)
-    roadlinkChanges_all.foreach(change => change.changeType.isInstanceOf[RoadLinkChangeType] should be(true))
+    roadlinkChanges_all.foreach(
+      _.changes.foreach(change => change.changeType.isInstanceOf[RoadLinkChangeType] should be(true)))
   }
 }


### PR DESCRIPTION
- Muokattu muutossettien käsittely niin, että muutossetit käsitellään erikseen vanhimmasta uusimpaan, mikäli useampi muutossetti on tietolajilla käsittelemättä. Jokainen muutossetti käsitellään omassa transaktiossa
- Lisätty puuttuvat labelit AssetTypeInfoille
- Muokattu kantaan tallennettava viimeisin onnistunut samuutuspäivämäärä vastaamaan käsitellyn muutossetin kohdepäivämäärää
- Muokattu samuutuksen raportin nimi muodostumaan muutossetin kohdepäivämäärästä, jotta jos yhtenä päivänä muodostuu useampi raportti, ei uudempi ylikirjoita vanhaa.