### PR TITLE
DROTH-3566 fix asset measures

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -24,7 +24,7 @@ class AssetFiller {
   val AllowedTolerance = 2.0
   val MinAllowedLength = 2.0
   protected val MaxAllowedMValueError = 0.1
-  val roadLinkLongAssets = Seq(SpeedLimitAsset.typeId, WinterSpeedLimit.typeId, RoadWidth.typeId, EuropeanRoads.typeId,
+  val roadLinkLongAssets = Seq(SpeedLimitAsset.typeId, RoadWidth.typeId, EuropeanRoads.typeId,
     CyclingAndWalking.typeId, CareClass.typeId, TrafficVolume.typeId, ExitNumbers.typeId)
   
   /* Smallest mvalue difference we can tolerate to be "equal to zero". One micrometer.

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -1,11 +1,12 @@
 package fi.liikennevirasto.digiroad2.linearasset
 
-import com.sun.org.slf4j.internal.LoggerFactory
 import fi.liikennevirasto.digiroad2.asset.ConstructionType.{Planned, UnderConstruction}
+import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller._
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
 
 import scala.util.Try
 
@@ -21,9 +22,10 @@ case class RoadLinkForFillTopology(linkId: String, length:Double, trafficDirecti
 
 class AssetFiller {
   val AllowedTolerance = 2.0
-  val MaxAllowedError = 0.001
   val MinAllowedLength = 2.0
   protected val MaxAllowedMValueError = 0.1
+  val roadLinkLongAssets = Seq(SpeedLimitAsset.typeId, WinterSpeedLimit.typeId, RoadWidth.typeId, EuropeanRoads.typeId,
+    CyclingAndWalking.typeId, CareClass.typeId, TrafficVolume.typeId, ExitNumbers.typeId)
   
   /* Smallest mvalue difference we can tolerate to be "equal to zero". One micrometer.
      See https://en.wikipedia.org/wiki/Floating_point#Accuracy_problems */
@@ -48,9 +50,9 @@ class AssetFiller {
 
   protected def adjustAsset(asset: PieceWiseLinearAsset, roadLink: RoadLinkForFillTopology): (PieceWiseLinearAsset, Seq[MValueAdjustment]) = {
     val roadLinkLength = GeometryUtils.geometryLength(roadLink.geometry)
-    val adjustedStartMeasure = if (asset.startMeasure < AllowedTolerance && asset.startMeasure >= MaxAllowedError) Some(0.0) else None
+    val adjustedStartMeasure = if (asset.startMeasure != 0.0 && asset.startMeasure < AllowedTolerance) Some(0.0) else None
     val endMeasureDifference: Double = roadLinkLength - asset.endMeasure
-    val adjustedEndMeasure = if (endMeasureDifference < AllowedTolerance && endMeasureDifference >= MaxAllowedError) Some(roadLinkLength) else None
+    val adjustedEndMeasure = if (endMeasureDifference != 0.0 && endMeasureDifference < AllowedTolerance) Some(roadLinkLength) else None
     val mValueAdjustments = (adjustedStartMeasure, adjustedEndMeasure) match {
       case (None, None) => Nil
       case (s, e)       => Seq(MValueAdjustment(asset.id, asset.linkId, s.getOrElse(asset.startMeasure), e.getOrElse(asset.endMeasure)))
@@ -531,6 +533,148 @@ class AssetFiller {
       (linearAssets, changeSet.copy(adjustedMValues = redundantFiltered))
     }
   }
+
+  def adjustRoadLinkLongAsset(asset: PieceWiseLinearAsset, roadLink: RoadLinkForFillTopology): (PieceWiseLinearAsset, Seq[MValueAdjustment]) = {
+    val roadLinkLength = GeometryUtils.geometryLength(roadLink.geometry)
+    val mAdjustment =
+      if (asset.startMeasure > 0 || asset.endMeasure < roadLinkLength)
+        Seq(MValueAdjustment(asset.id, asset.linkId, 0, roadLinkLength))
+      else
+        Nil
+    val modifiedSegment = asset.copy(geometry = GeometryUtils.truncateGeometry3D(roadLink.geometry, 0, roadLinkLength), startMeasure = 0, endMeasure = roadLinkLength)
+    (modifiedSegment, mAdjustment)
+  }
+
+  def adjustRoadLinkLongAssetHead(asset: PieceWiseLinearAsset, roadLink: RoadLinkForFillTopology): (Option[PieceWiseLinearAsset], Seq[MValueAdjustment]) = {
+    if (asset.startMeasure > 0) {
+      val mAdjustment= Seq(MValueAdjustment(asset.id, asset.linkId, 0, asset.endMeasure))
+      val modifiedSegment = asset.copy(geometry = GeometryUtils.truncateGeometry3D(roadLink.geometry, 0, asset.endMeasure), startMeasure = 0, endMeasure = asset.endMeasure)
+      (Some(modifiedSegment), mAdjustment)
+    }else {
+      (Some(asset), Nil)
+    }
+  }
+
+  def adjustRoadLinkLongAssetTail(asset: PieceWiseLinearAsset, roadLink: RoadLinkForFillTopology): (Option[PieceWiseLinearAsset], Seq[MValueAdjustment]) = {
+    val roadLinkLength = GeometryUtils.geometryLength(roadLink.geometry)
+    if (asset.endMeasure < roadLinkLength) {
+      val mAdjustment= Seq(MValueAdjustment(asset.id, asset.linkId, asset.startMeasure, roadLinkLength))
+      val modifiedSegment = asset.copy(geometry = GeometryUtils.truncateGeometry3D(roadLink.geometry, asset.startMeasure, roadLinkLength), startMeasure = asset.startMeasure, endMeasure = roadLinkLength)
+      (Some(modifiedSegment), mAdjustment)
+    } else {
+      (Some(asset), Nil)
+    }
+  }
+
+  private def adjustTwoWaySegments(roadLink: RoadLinkForFillTopology,
+                                   assets: Seq[PieceWiseLinearAsset]):
+  (Seq[PieceWiseLinearAsset], Seq[MValueAdjustment]) = {
+    val twoWaySegments = assets.filter(_.sideCode == SideCode.BothDirections).sortBy(_.startMeasure)
+    if (twoWaySegments.isEmpty) {
+      (Nil, Nil)
+    }
+    else if (twoWaySegments.length == 1  && assets.forall(_.sideCode == SideCode.BothDirections)) {
+      val segment = assets.last
+      val (adjustedSegment, mValueAdjustments) = adjustRoadLinkLongAsset(segment, roadLink)
+      (Seq(adjustedSegment), mValueAdjustments)
+    } else {
+      val head = twoWaySegments.head
+      val last = twoWaySegments.last
+      val (adjustedHead, mValueAdjustmentsHead) = if (head.startMeasure <= assets.sortBy(_.startMeasure).head.startMeasure) adjustRoadLinkLongAssetHead(head, roadLink) else (None, Nil)
+      val (adjustedLast, mValueAdjustmentsLast) = if (last.endMeasure >= assets.sortBy(_.endMeasure).last.endMeasure) adjustRoadLinkLongAssetTail(last, roadLink) else (None, Nil)
+      (adjustedHead, adjustedLast) match {
+        case (Some(aH), Some(aL)) =>
+          val rest = twoWaySegments.filterNot(a => a.id == aH.id || a.id == aL.id)
+          (Seq(aH, aL) ++ rest, mValueAdjustmentsHead ++ mValueAdjustmentsLast)
+        case (Some(aH), None) =>
+          val rest = twoWaySegments.filterNot(a => a.id == aH.id)
+          (Seq(aH) ++ rest, mValueAdjustmentsHead)
+        case (None, Some(aL)) =>
+          val rest = twoWaySegments.filterNot(a => a.id == aL.id)
+          (Seq(aL) ++ rest, mValueAdjustmentsLast)
+        case (None, None) =>
+          (twoWaySegments, Nil)
+      }
+    }
+  }
+
+  private def adjustOneWaySegments(roadLink: RoadLinkForFillTopology,
+                                   assets: Seq[PieceWiseLinearAsset],
+                                   runningDirection: SideCode):
+  (Seq[PieceWiseLinearAsset], Seq[MValueAdjustment]) = {
+    val segmentsTowardsRunningDirection = assets.filter(_.sideCode == runningDirection).sortBy(_.startMeasure)
+    if (segmentsTowardsRunningDirection.isEmpty) {
+      (Nil, Nil)
+    } else if (segmentsTowardsRunningDirection.length == 1 && !assets.exists(_.sideCode == SideCode.BothDirections)) {
+      val segment = segmentsTowardsRunningDirection.last
+      val (adjustedSegment, mValueAdjustments) = adjustRoadLinkLongAsset(segment, roadLink)
+      (Seq(adjustedSegment), mValueAdjustments)
+    } else {
+      val head = segmentsTowardsRunningDirection.head
+      val firstTwo = assets.sortBy(_.startMeasure).slice(0, 2)
+      val (adjustedHead, mValueAdjustmentsHead) = {
+        val othersThanHead = firstTwo.filterNot(a => a.id == head.id)
+        // the first asset with inspected side code is not among the two first
+        if (othersThanHead.size == 2) {
+          (None, Nil)
+        // the first asset with inspected side code is the first of all
+        } else if (head.id == firstTwo.head.id) {
+          adjustRoadLinkLongAssetHead(head, roadLink)
+        // the first asset with inspected side code is opposite to the first asset of all
+        } else if (head.sideCode != othersThanHead.head.sideCode && othersThanHead.head.sideCode != BothDirections) {
+          adjustRoadLinkLongAssetHead(head, roadLink)
+        } else {
+          (None, Nil)
+        }
+      }
+
+      val last = segmentsTowardsRunningDirection.last
+      val lastTwo = assets.sortBy(_.endMeasure).slice(assets.length - 2, assets.length)
+      val (adjustedLast, mValueAdjustmentsLast) = {
+        val othersThanLast = lastTwo.filterNot(a => a.id == last.id)
+        // the last asset with inspected side code is not among the two last
+        if (othersThanLast.size == 2) {
+          (None, Nil)
+        // the last asset with inspected side code is the last of all
+        } else if (last.id == lastTwo.last.id) {
+          adjustRoadLinkLongAssetTail(last, roadLink)
+        // the last asset with inspected side code is opposite to the last asset of all
+        } else if (head.sideCode != othersThanLast.head.sideCode && othersThanLast.head.sideCode != BothDirections) {
+          adjustRoadLinkLongAssetTail(last, roadLink)
+        } else {
+          (None, Nil)
+        }
+      }
+      (adjustedHead, adjustedLast) match {
+        case (Some(aH), Some(aL)) =>
+          val rest = segmentsTowardsRunningDirection.filterNot(a => a.id == aH.id || a.id == aL.id)
+          (Seq(aH, aL) ++ rest, mValueAdjustmentsHead ++ mValueAdjustmentsLast)
+        case (Some(aH), None) =>
+          val rest = segmentsTowardsRunningDirection.filterNot(a => a.id == aH.id)
+          (Seq(aH) ++ rest, mValueAdjustmentsHead)
+        case (None, Some(aL)) =>
+          val rest = segmentsTowardsRunningDirection.filterNot(a => a.id == aL.id)
+          (Seq(aL) ++ rest, mValueAdjustmentsLast)
+        case (None, None) =>
+          (segmentsTowardsRunningDirection, Nil)
+      }
+    }
+  }
+
+  def adjustRoadLinkLongAssets(roadLink: RoadLinkForFillTopology, assets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet): (Seq[PieceWiseLinearAsset], ChangeSet) = {
+    val (towardsGeometrySegments, towardsGeometryAdjustments) = adjustOneWaySegments(roadLink, assets, SideCode.TowardsDigitizing)
+    val (againstGeometrySegments, againstGeometryAdjustments) = adjustOneWaySegments(roadLink, assets, SideCode.AgainstDigitizing)
+    val (twoWayGeometrySegments, twoWayGeometryAdjustments) = adjustTwoWaySegments(roadLink, assets)
+    val mValueAdjustments = towardsGeometryAdjustments ++ againstGeometryAdjustments ++ twoWayGeometryAdjustments
+    val (asset,changeSetCopy)=(towardsGeometrySegments ++ againstGeometrySegments ++ twoWayGeometrySegments,
+      changeSet.copy(adjustedMValues = changeSet.adjustedMValues ++ mValueAdjustments))
+    adjustLopsidedLimit(roadLink,asset,changeSetCopy)
+  }
+
+
+  protected def adjustLopsidedLimit(roadLink: RoadLinkForFillTopology, assets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet):
+  (Seq[PieceWiseLinearAsset], ChangeSet) = (assets, changeSet)
+
   /**
     * Finally adjust asset length by snapping to links start and endpoint. <br> <pre> 
     * RoadLink -------
@@ -546,10 +690,20 @@ class AssetFiller {
     * @return assets and changeSet
     */
   def adjustAssets(roadLink: RoadLinkForFillTopology, linearAssets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet): (Seq[PieceWiseLinearAsset], ChangeSet) = {
-    linearAssets.foldLeft((Seq[PieceWiseLinearAsset](), changeSet)){
-      case ((resultAssets, change),linearAsset) =>
-        val (asset, adjustmentsMValues) = adjustAsset(linearAsset, roadLink)
-        (resultAssets ++ Seq(asset), change.copy(adjustedMValues = change.adjustedMValues ++ adjustmentsMValues))
+    if (linearAssets.nonEmpty && roadLinkLongAssets.contains(linearAssets.head.typeId)) {
+      val (towardsGeometrySegments, towardsGeometryAdjustments) = adjustOneWaySegments(roadLink, linearAssets, SideCode.TowardsDigitizing)
+      val (againstGeometrySegments, againstGeometryAdjustments) = adjustOneWaySegments(roadLink, linearAssets, SideCode.AgainstDigitizing)
+      val (twoWayGeometrySegments, twoWayGeometryAdjustments) = adjustTwoWaySegments(roadLink, linearAssets)
+      val mValueAdjustments = towardsGeometryAdjustments ++ againstGeometryAdjustments ++ twoWayGeometryAdjustments
+      val (asset,changeSetCopy)=(towardsGeometrySegments ++ againstGeometrySegments ++ twoWayGeometrySegments,
+        changeSet.copy(adjustedMValues = changeSet.adjustedMValues ++ mValueAdjustments))
+      adjustLopsidedLimit(roadLink,asset,changeSetCopy)
+    } else {
+      linearAssets.foldLeft((Seq[PieceWiseLinearAsset](), changeSet)) {
+        case ((resultAssets, change), linearAsset) =>
+          val (asset, adjustmentsMValues) = adjustAsset(linearAsset, roadLink)
+          (resultAssets ++ Seq(asset), change.copy(adjustedMValues = change.adjustedMValues ++ adjustmentsMValues))
+      }
     }
   }
 

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -56,10 +56,10 @@ class AssetFillerSpec extends FunSuite with Matchers {
       createdDateTime = Some(DateTime.now().plusDays(addDay)), typeId = 140, trafficDirection = TrafficDirection.BothDirections, timeStamp = 0L,
       geomModifiedDate = None, linkSource = NormalLinkInterface, administrativeClass = State, attributes = Map(), verifiedBy = None, verifiedDate = None, informationSource = None)
   }
-  def createAsset(id: Long, linkId1: String, measure: Measure, sideCode: SideCode, value: Option[Value],trafficDirection:TrafficDirection = TrafficDirection.BothDirections) = {
+  def createAsset(id: Long, linkId1: String, measure: Measure, sideCode: SideCode, value: Option[Value],trafficDirection:TrafficDirection = TrafficDirection.BothDirections, typeId: Int = NumberOfLanes.typeId) = {
     PieceWiseLinearAsset(id = id, linkId = linkId1, sideCode = sideCode, value = value, geometry = Nil, expired = false, startMeasure = measure.startMeasure, endMeasure = measure.endMeasure,
       endpoints = Set(Point(measure.endMeasure,0.0)), modifiedBy = None, modifiedDateTime = None, createdBy = Some("guy"),
-      createdDateTime = Some(DateTime.now()), typeId = 140, trafficDirection = trafficDirection, timeStamp = 0L,
+      createdDateTime = Some(DateTime.now()), typeId = typeId, trafficDirection = trafficDirection, timeStamp = 0L,
       geomModifiedDate = None, linkSource = NormalLinkInterface, administrativeClass = State, attributes = Map(), verifiedBy = None, verifiedDate = None, informationSource = None)
   }
   def createRoadLink(id: String, length: Double) = {
@@ -529,6 +529,252 @@ class AssetFillerSpec extends FunSuite with Matchers {
       filledTopology.head.startMeasure should be(0)
       filledTopology.head.endMeasure should be(11)
     })
+  }
+
+  test("Adjust road link long asset length when link difference is bigger than 2m from both ends") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(15.0, 0.0)), 15.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+
+    val assets = Seq(createAsset(1, linkId1, Measure(3, 11), SideCode.BothDirections, None, TrafficDirection.BothDirections, ExitNumbers.typeId))
+
+    val (methodTest, combineTestChangeSet) = assetFiller.adjustAssets(roadLinks.map(assetFiller.toRoadLinkForFillTopology).head, assets, initChangeSet)
+    val (testWholeProcess, changeSet) = assetFiller.fillTopology(roadLinks.map(assetFiller.toRoadLinkForFillTopology), Map(linkId1 -> assets), 140)
+
+    Seq((methodTest, combineTestChangeSet), (testWholeProcess, changeSet)).foreach(item => {
+      val filledTopology = item._1
+      val changeSet = item._2
+      changeSet.adjustedMValues.size should be(1)
+      filledTopology.head.startMeasure should be(0)
+      filledTopology.head.endMeasure should be(15)
+    })
+  }
+
+  test("Adjust road link long asset length when link difference is bigger than 2m from the beginning") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(15.0, 0.0)), 15.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+
+    val assets = Seq(createAsset(1, linkId1, Measure(3, 15), SideCode.BothDirections, None, TrafficDirection.BothDirections, CyclingAndWalking.typeId))
+
+    val (methodTest, combineTestChangeSet) = assetFiller.adjustAssets(roadLinks.map(assetFiller.toRoadLinkForFillTopology).head, assets, initChangeSet)
+    val (testWholeProcess, changeSet) = assetFiller.fillTopology(roadLinks.map(assetFiller.toRoadLinkForFillTopology), Map(linkId1 -> assets), 140)
+
+    Seq((methodTest, combineTestChangeSet), (testWholeProcess, changeSet)).foreach(item => {
+      val filledTopology = item._1
+      val changeSet = item._2
+      changeSet.adjustedMValues.size should be(1)
+      filledTopology.head.startMeasure should be(0)
+      filledTopology.head.endMeasure should be(15)
+    })
+  }
+
+  test("Adjust road link long asset length when link difference is bigger than 2m from the end") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(15.0, 0.0)), 15.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+
+    val assets = Seq(createAsset(1, linkId1, Measure(0, 11), SideCode.BothDirections, None, TrafficDirection.BothDirections, CareClass.typeId))
+
+    val (methodTest, combineTestChangeSet) = assetFiller.adjustAssets(roadLinks.map(assetFiller.toRoadLinkForFillTopology).head, assets, initChangeSet)
+    val (testWholeProcess, changeSet) = assetFiller.fillTopology(roadLinks.map(assetFiller.toRoadLinkForFillTopology), Map(linkId1 -> assets), 140)
+
+    Seq((methodTest, combineTestChangeSet), (testWholeProcess, changeSet)).foreach(item => {
+      val filledTopology = item._1
+      val changeSet = item._2
+      changeSet.adjustedMValues.size should be(1)
+      filledTopology.head.startMeasure should be(0)
+      filledTopology.head.endMeasure should be(15)
+    })
+  }
+
+  test("adjust two-sided winter speed limits from both ends leaving the middle limit intact") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+    val speedLimit1 = PieceWiseLinearAsset(1, linkId1, SideCode.BothDirections, Some(NumericValue(80)), Seq(Point(0.2, 0.0), Point(2.0, 0.0)),
+      false, 0.2, 2.0, Set(Point(0.2, 0.0), Point(2.0, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit2 = PieceWiseLinearAsset(2, linkId1, SideCode.BothDirections, Some(NumericValue(60)), Seq(Point(2.0, 0.0), Point(4.9, 0.0)),
+      false, 2.0, 4.9, Set(Point(2.0, 0.0), Point(4.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit3 = PieceWiseLinearAsset(3, linkId1, SideCode.BothDirections, Some(NumericValue(100)), Seq(Point(4.9, 0.0), Point(9.8, 0.0)),
+      false, 4.9, 9.8, Set(Point(4.9, 0.0), Point(9.8, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimits = Map(linkId1 -> Seq(speedLimit1, speedLimit2, speedLimit3))
+    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(roadLinks.map(SpeedLimitFiller.toRoadLinkForFillTopology), speedLimits, SpeedLimitAsset.typeId)
+    val sortedFilledTopology = filledTopology.sortBy(_.startMeasure)
+    sortedFilledTopology.length should be(3)
+    sortedFilledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(2.0, 0.0)))
+    sortedFilledTopology.head.startMeasure should be(0.0)
+    sortedFilledTopology.head.endMeasure should be(2.0)
+    sortedFilledTopology(1).geometry should be(Seq(Point(2.0, 0.0), Point(4.9, 0.0)))
+    sortedFilledTopology(1).startMeasure should be(2.0)
+    sortedFilledTopology(1).endMeasure should be(4.9)
+    sortedFilledTopology.last.geometry should be(Seq(Point(4.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology.last.startMeasure should be(4.9)
+    sortedFilledTopology.last.endMeasure should be(10.0)
+    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)), Nil, Nil, Set.empty, Nil))
+  }
+
+
+  test("adjust one-sided winter limits when there is one on one side and two on the other") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+    val speedLimit1 = PieceWiseLinearAsset(1, linkId1, SideCode.TowardsDigitizing, Some(NumericValue(80)), Seq(Point(0.2, 0.0), Point(2.9, 0.0)),
+      false, 0.2, 2.9, Set(Point(0.2, 0.0), Point(2.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit2 = PieceWiseLinearAsset(2, linkId1, SideCode.TowardsDigitizing, Some(NumericValue(60)), Seq(Point(2.9, 0.0), Point(8.9, 0.0)),
+      false, 2.9, 8.9, Set(Point(2.9, 0.0), Point(8.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit3 = PieceWiseLinearAsset(3, linkId1, SideCode.AgainstDigitizing, Some(NumericValue(100)), Seq(Point(0.9, 0.0), Point(9.8, 0.0)),
+      false, 0.9, 9.8, Set(Point(0.9, 0.0), Point(9.8, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimits = Map(linkId1 -> Seq(speedLimit1, speedLimit2, speedLimit3))
+    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(roadLinks.map(SpeedLimitFiller.toRoadLinkForFillTopology), speedLimits, SpeedLimitAsset.typeId)
+    val sortedFilledTopology = filledTopology.sortBy(_.id)
+    sortedFilledTopology.length should be(3)
+    sortedFilledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(2.9, 0.0)))
+    sortedFilledTopology.head.startMeasure should be(0.0)
+    sortedFilledTopology.head.endMeasure should be(2.9)
+    sortedFilledTopology(1).geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology(1).startMeasure should be(2.9)
+    sortedFilledTopology(1).endMeasure should be(10.0)
+    sortedFilledTopology.last.geometry should be(Seq(Point(0.0, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology.last.startMeasure should be(0.0)
+    sortedFilledTopology.last.endMeasure should be(10.0)
+    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0),
+      MValueAdjustment(3, linkId1, 0.0, 10.0)), Nil, Nil, Set.empty, Nil))
+  }
+
+  test("two opposite side directions with smallest start measure are adjusted") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+    val speedLimit1 = PieceWiseLinearAsset(1, linkId1, SideCode.TowardsDigitizing, Some(NumericValue(80)), Seq(Point(0.2, 0.0), Point(2.9, 0.0)),
+      false, 0.2, 2.9, Set(Point(0.2, 0.0), Point(2.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit2 = PieceWiseLinearAsset(2, linkId1, SideCode.AgainstDigitizing, Some(NumericValue(60)), Seq(Point(0.7, 0.0), Point(2.9, 0.0)),
+      false, 0.7, 2.9, Set(Point(0.7, 0.0), Point(2.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit3 = PieceWiseLinearAsset(3, linkId1, SideCode.BothDirections, Some(NumericValue(100)), Seq(Point(2.9, 0.0), Point(10.0, 0.0)),
+      false, 2.9, 10.0, Set(Point(2.9, 0.0), Point(10.0, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimits = Map(linkId1 -> Seq(speedLimit1, speedLimit2, speedLimit3))
+    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(roadLinks.map(SpeedLimitFiller.toRoadLinkForFillTopology), speedLimits, SpeedLimitAsset.typeId)
+    val sortedFilledTopology = filledTopology.sortBy(_.id)
+    sortedFilledTopology.length should be(3)
+    sortedFilledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(2.9, 0.0)))
+    sortedFilledTopology.head.startMeasure should be(0.0)
+    sortedFilledTopology.head.endMeasure should be(2.9)
+    sortedFilledTopology(1).geometry should be(Seq(Point(0.0, 0.0), Point(2.9, 0.0)))
+    sortedFilledTopology(1).startMeasure should be(0.0)
+    sortedFilledTopology(1).endMeasure should be(2.9)
+    sortedFilledTopology.last.geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology.last.startMeasure should be(2.9)
+    sortedFilledTopology.last.endMeasure should be(10.0)
+    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 0.0, 2.9)),
+      Nil, Nil, Set.empty, Nil))
+  }
+
+  test("only the one-sided limit with the smallest start measure is adjusted when the two smallest are on the same side") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+    val speedLimit1 = PieceWiseLinearAsset(1, linkId1, SideCode.TowardsDigitizing, Some(NumericValue(80)), Seq(Point(0.2, 0.0), Point(2.9, 0.0)),
+      false, 0.2, 2.9, Set(Point(0.2, 0.0), Point(2.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit2 = PieceWiseLinearAsset(2, linkId1, SideCode.TowardsDigitizing, Some(NumericValue(60)), Seq(Point(2.9, 0.0), Point(5.9, 0.0)),
+      false, 2.9, 5.9, Set(Point(2.9, 0.0), Point(5.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit3 = PieceWiseLinearAsset(3, linkId1, SideCode.BothDirections, Some(NumericValue(100)), Seq(Point(5.9, 0.0), Point(10.0, 0.0)),
+      false, 5.9, 10.0, Set(Point(5.9, 0.0), Point(10.0, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimits = Map(linkId1 -> Seq(speedLimit1, speedLimit2, speedLimit3))
+    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(roadLinks.map(SpeedLimitFiller.toRoadLinkForFillTopology), speedLimits, SpeedLimitAsset.typeId)
+    val (generated, adjusted) = filledTopology.partition(_.id == 0)
+    val sortedFilledTopology = adjusted.sortBy(_.id)
+    sortedFilledTopology.length should be(3)
+    sortedFilledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(2.9, 0.0)))
+    sortedFilledTopology.head.startMeasure should be(0.0)
+    sortedFilledTopology.head.endMeasure should be(2.9)
+    sortedFilledTopology(1).geometry should be(Seq(Point(2.9, 0.0), Point(5.9, 0.0)))
+    sortedFilledTopology(1).startMeasure should be(2.9)
+    sortedFilledTopology(1).endMeasure should be(5.9)
+    sortedFilledTopology.last.geometry should be(Seq(Point(5.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology.last.startMeasure should be(5.9)
+    sortedFilledTopology.last.endMeasure should be(10.0)
+    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Nil, Set.empty, Nil))
+  }
+
+  test("two opposite side directions with largest end measure and the two-sided limit in the beginning are adjusted") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+    val speedLimit1 = PieceWiseLinearAsset(1, linkId1, SideCode.BothDirections, Some(NumericValue(80)), Seq(Point(0.2, 0.0), Point(2.9, 0.0)),
+      false, 0.2, 2.9, Set(Point(0.2, 0.0), Point(2.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit2 = PieceWiseLinearAsset(2, linkId1, SideCode.AgainstDigitizing, Some(NumericValue(60)), Seq(Point(2.9, 0.0), Point(9.9, 0.0)),
+      false, 2.9, 9.9, Set(Point(2.9, 0.0), Point(9.9, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit3 = PieceWiseLinearAsset(3, linkId1, SideCode.TowardsDigitizing, Some(NumericValue(100)), Seq(Point(2.9, 0.0), Point(8.0, 0.0)),
+      false, 2.9, 8.0, Set(Point(2.9, 0.0), Point(8.0, 0.0)), None, None, None, None, WinterSpeedLimit.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimits = Map(linkId1 -> Seq(speedLimit1, speedLimit2, speedLimit3))
+    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(roadLinks.map(SpeedLimitFiller.toRoadLinkForFillTopology), speedLimits, SpeedLimitAsset.typeId)
+    val sortedFilledTopology = filledTopology.sortBy(_.id)
+    sortedFilledTopology.length should be(3)
+    sortedFilledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(2.9, 0.0)))
+    sortedFilledTopology.head.startMeasure should be(0.0)
+    sortedFilledTopology.head.endMeasure should be(2.9)
+    sortedFilledTopology(1).geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology(1).startMeasure should be(2.9)
+    sortedFilledTopology(1).endMeasure should be(10.0)
+    sortedFilledTopology.last.geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology.last.startMeasure should be(2.9)
+    sortedFilledTopology.last.endMeasure should be(10.0)
+    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(3, linkId1, 2.9, 10.0), MValueAdjustment(2, linkId1, 2.9, 10.0),
+      MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Nil, Set.empty, Nil))
+  }
+
+  test("only the one-sided limit with the largest end measure is adjusted when the two largest are on the same side") {
+    val roadLinks = Seq(
+      RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, AdministrativeClass.apply(1), UnknownFunctionalClass.value,
+        TrafficDirection.BothDirections, LinkType.apply(3), None, None, Map())
+    )
+    val speedLimit1 = PieceWiseLinearAsset(1, linkId1, SideCode.BothDirections, Some(SpeedLimitValue(80)), Seq(Point(0.2, 0.0), Point(2.9, 0.0)),
+      false, 0.2, 2.9, Set(Point(0.2, 0.0), Point(2.9, 0.0)), None, None, None, None, SpeedLimitAsset.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit2 = PieceWiseLinearAsset(2, linkId1, SideCode.TowardsDigitizing, Some(SpeedLimitValue(60)), Seq(Point(2.9, 0.0), Point(5.9, 0.0)),
+      false, 2.9, 5.9, Set(Point(2.9, 0.0), Point(5.9, 0.0)), None, None, None, None, SpeedLimitAsset.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimit3 = PieceWiseLinearAsset(3, linkId1, SideCode.TowardsDigitizing, Some(SpeedLimitValue(100)), Seq(Point(5.9, 0.0), Point(9.5, 0.0)),
+      false, 5.9, 9.5, Set(Point(5.9, 0.0), Point(9.5, 0.0)), None, None, None, None, SpeedLimitAsset.typeId, TrafficDirection.BothDirections,
+      0, None, NormalLinkInterface, Unknown, Map(), None, None, None)
+    val speedLimits = Map(linkId1 -> Seq(speedLimit1, speedLimit2, speedLimit3))
+    val (filledTopology, changeSet) = SpeedLimitFiller.fillTopology(roadLinks.map(SpeedLimitFiller.toRoadLinkForFillTopology), speedLimits, SpeedLimitAsset.typeId)
+    val (generated, adjusted) = filledTopology.partition(_.id == 0)
+    val sortedFilledTopology = adjusted.sortBy(_.id)
+    sortedFilledTopology.length should be(3)
+    sortedFilledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(2.9, 0.0)))
+    sortedFilledTopology.head.startMeasure should be(0.0)
+    sortedFilledTopology.head.endMeasure should be(2.9)
+    sortedFilledTopology(1).geometry should be(Seq(Point(2.9, 0.0), Point(5.9, 0.0)))
+    sortedFilledTopology(1).startMeasure should be(2.9)
+    sortedFilledTopology(1).endMeasure should be(5.9)
+    sortedFilledTopology.last.geometry should be(Seq(Point(5.9, 0.0), Point(10.0, 0.0)))
+    sortedFilledTopology.last.startMeasure should be(5.9)
+    sortedFilledTopology.last.endMeasure should be(10.0)
+    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(3, linkId1, 5.9, 10.0), MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Nil, Set.empty, Nil))
   }
 
   test("Adjust start and end m-value when difference is 0.001") {

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
@@ -63,8 +63,8 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
     (points.toList, GeometryUtils.geometryLength(points))
   }
 
-  def createAsset(measures: Measures, value: Value, link: RoadLink, sideCode:SideCode = SideCode.BothDirections ): Long = {
-    service.createWithoutTransaction(TrafficVolume.typeId, link.linkId, value, sideCode.value,
+  def createAsset(measures: Measures, value: Value, link: RoadLink, sideCode:SideCode = SideCode.BothDirections, typeId: Int = TrafficVolume.typeId): Long = {
+    service.createWithoutTransaction(typeId, link.linkId, value, sideCode.value,
       measures, "testuser", 0L, Some(link), false, None, None)
   }
 
@@ -693,15 +693,15 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
       val oldRoadLink = roadLinkService.getExpiredRoadLinkByLinkId(linksid1).get
       val oldMaxLength = 11.715
 
-      val id1 = createAsset(Measures(0, 5), NumericValue(3), oldRoadLink)
-      val id2 = createAsset(Measures(5, oldMaxLength), NumericValue(4), oldRoadLink)
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1, id2), false)
+      val id1 = createAsset(Measures(0, 5), NumericValue(3), oldRoadLink, SideCode.BothDirections, HeightLimit.typeId)
+      val id2 = createAsset(Measures(5, oldMaxLength), NumericValue(4), oldRoadLink, SideCode.BothDirections, HeightLimit.typeId)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1, id2), false)
       
       assetsBefore.size should be(2)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(TrafficVolume.typeId, change)
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq("619d3fb8-056c-4745-8988-d143c29af659:1"), false)
+      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(HeightLimit.typeId, change)
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq("619d3fb8-056c-4745-8988-d143c29af659:1"), false)
       val sorted = assetsAfter.sortBy(_.endMeasure)
 
       sorted.size should be(2)
@@ -1192,16 +1192,16 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
     runWithRollback {
       when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(linkId, false)).thenReturn(Some(oldRoadLink))
       when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1", false)).thenReturn(Some(newLink))
-      val id1 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.AgainstDigitizing.value, Measures(0, 2), "testuser", 0L, Some(oldRoadLink), false, None, None)
-      val id2 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(2, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
-      
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.AgainstDigitizing.value, Measures(0, 2), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id2 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(2, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
+
    
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1, id2), false)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1, id2), false)
       assetsBefore.size should be(2)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdater.updateByRoadLinks(TrafficVolume.typeId, Seq(change))
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1"), false)
+      TestLinearAssetUpdater.updateByRoadLinks(HeightLimit.typeId, Seq(change))
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1"), false)
       assetsAfter.size should be(1)
 
       val sorted = assetsAfter.sortBy(_.endMeasure)
@@ -1232,16 +1232,16 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
     runWithRollback {
       when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(linkId, false)).thenReturn(Some(oldRoadLink))
       when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1", false)).thenReturn(Some(newLink))
-      val id1 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.AgainstDigitizing.value, Measures(0, 2), "testuser", 0L, Some(oldRoadLink), false, None, None)
-      val id2 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(2, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.AgainstDigitizing.value, Measures(0, 2), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id2 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(2, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
 
 
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1, id2), false)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1, id2), false)
       assetsBefore.size should be(2)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdater.updateByRoadLinks(TrafficVolume.typeId, Seq(change))
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1"), false)
+      TestLinearAssetUpdater.updateByRoadLinks(HeightLimit.typeId, Seq(change))
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1"), false)
       assetsAfter.size should be(1)
 
       val sorted = assetsAfter.sortBy(_.endMeasure)
@@ -1272,16 +1272,16 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
     runWithRollback {
       when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(linkId, false)).thenReturn(Some(oldRoadLink))
       when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1", false)).thenReturn(Some(newLink))
-      val id1 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.AgainstDigitizing.value, Measures(0, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
-      val id2 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 2), "testuser", 0L, Some(oldRoadLink), false, None, None)
-      val id3 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(4), SideCode.AgainstDigitizing.value, Measures(2, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.AgainstDigitizing.value, Measures(0, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id2 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 2), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id3 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(4), SideCode.AgainstDigitizing.value, Measures(2, 4), "testuser", 0L, Some(oldRoadLink), false, None, None)
 
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1, id2,id3), false)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1, id2,id3), false)
       assetsBefore.size should be(3)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdater.updateByRoadLinks(TrafficVolume.typeId, Seq(change))
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1"), false)
+      TestLinearAssetUpdater.updateByRoadLinks(HeightLimit.typeId, Seq(change))
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq("c83d66e9-89fe-4b19-8f5b-f9f2121e3db7:1"), false)
       assetsAfter.size should be(1)
 
       val sorted = assetsAfter.sortBy(_.endMeasure)
@@ -1294,16 +1294,6 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
       SideCode.apply(assetsAfter.head.sideCode) should be(SideCode.TowardsDigitizing)
     }
   }
-
-/*  "old": {
-    "linkId": "c19bd6b4-9923-4ce9-a9cb-09779708913e:1",
-    "linkLength": 121.673,
-    "roadClass": 12131,
-    "adminClass": 1,
-    "municipality": 49,
-    "trafficDirection": 1
-  }
-  ,*/
 
   test("case 10.7 links under asset is split, different values each side first part change to one direction") {
     val linkId = "609d430a-de96-4cb7-987c-3caa9c72c08d:1"
@@ -1379,14 +1369,14 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
 
     runWithRollback {
       val oldRoadLink = roadLinkService.getExpiredRoadLinkByLinkId(linkId).get
-      val id1 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.BothDirections.value, Measures(0, 221.892), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.BothDirections.value, Measures(0, 221.892), "testuser", 0L, Some(oldRoadLink), false, None, None)
  
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1), false)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1), false)
       assetsBefore.size should be(1)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(TrafficVolume.typeId, change)
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq(linkIdNew), false)
+      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(HeightLimit.typeId, change)
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq(linkIdNew), false)
 
       val sorted = assetsAfter.sortBy(_.endMeasure)
 
@@ -1406,15 +1396,15 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
 
     runWithRollback {
       val oldRoadLink = roadLinkService.getExpiredRoadLinkByLinkId(linkId).get
-      val id1 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 221.892), "testuser", 0L, Some(oldRoadLink), false, None, None)
-      val id2 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(4), SideCode.AgainstDigitizing.value, Measures(0, 221.892), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 221.892), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id2 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(4), SideCode.AgainstDigitizing.value, Measures(0, 221.892), "testuser", 0L, Some(oldRoadLink), false, None, None)
 
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1, id2), false)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1, id2), false)
       assetsBefore.size should be(2)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(TrafficVolume.typeId, change)
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq(linkIdNew), false)
+      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(HeightLimit.typeId, change)
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq(linkIdNew), false)
 
       val sorted = assetsAfter.sortBy(_.sideCode)
 
@@ -1440,14 +1430,14 @@ class LinearAssetUpdaterSpec extends FunSuite with Matchers {
 
     runWithRollback {
       val oldRoadLink = roadLinkService.getExpiredRoadLinkByLinkId(linkId).get
-      val id1 = service.createWithoutTransaction(TrafficVolume.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 18.081), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 18.081), "testuser", 0L, Some(oldRoadLink), false, None, None)
 
-      val assetsBefore = service.getPersistedAssetsByIds(TrafficVolume.typeId, Set(id1), false)
+      val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1), false)
       assetsBefore.size should be(1)
       assetsBefore.head.expired should be(false)
 
-      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(TrafficVolume.typeId, change)
-      val assetsAfter = service.getPersistedAssetsByLinkIds(TrafficVolume.typeId, Seq(linkIdNew), false)
+      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(HeightLimit.typeId, change)
+      val assetsAfter = service.getPersistedAssetsByLinkIds(HeightLimit.typeId, Seq(linkIdNew), false)
       
       val sorted = assetsAfter.sortBy(_.endMeasure)
       


### PR DESCRIPTION
1. Jos tielinkillä on 1-n kpl nopeusrajoituksia, ja niistä pienin alkuarvo on nollaa suurempi, niin se korjataan nollaksi.  Pienin alkuarvo voi olla myös kahdella assetilla, joilla on sidecode 2 ja 3. Tällöin korjaus nollaksimolemmille asseteille. Jos kahdella assetilla, joilla on sidecode 2 ja 3 pienin alkuarvo ei ole täsmälleen sama, riittää, että se on pienempi kuin kolmannella tielinkin assetilla. Jos kolmatta assettia ei ole, niin korjaus aina nollaan.
2. Nopeusrajoituksen loppu m-arvolle vastaava tarkastelu: suurin loppuarvo korjataan tielinkin mittaiseksi. Muu logiikka vastaava kuin kohdassa 1.
3. Talvinopeusrajoitus, leveys, eurooppatienumero, käpy-tietolaji, hoitoluokka, liikennemäärä ja liittymänumero -tietolajeille tehty samanlainen käsittely kuin nopeusrajoitukselle. Käytännössä kyseiset metodit siirretty asset-filleriin, ja ajetaan kyseisille adjustLopsidedLimitiä lukuunottamatta.
4. Muut assetit korjataan nollaan/tielinkin pituuteen, jos ero alle 2m. Erolle ei ole enää kynnysarvoa, että se on riittävän suuri (0.001) vaan riittää, että ero ei ole nolla.
5. Tämä tallentaa tällä hetkellä kantaan myös selauksen yhteydessä. Tämä ei ilmeisesti ole täysin välttämätöntä, mutta myös aiemmissa metodeissa kantaan tallentamista tapahtui. Varmaan kirjoittamalla erilliset metodit selaukselle tämä voidaan ottaa pois, mutta en tiedä onko tarpeellista.
6. Koitettu miettiä kaikki mahdolliset tilanteet testaukseen, kun on melko monimutkainen ja virhealtis logiikka.
7. Muokattu linearAssetUpdaterSpecia niin, että tietyt testit ajetaan assetilla, jota ei automaattisesti venytetä, koska kaatuu muuten. 