### PR TITLE
DROTH-3755 directional point asset samuutus to use overridden link direction

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/DirectionalPointAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/DirectionalPointAssetUpdater.scala
@@ -4,14 +4,15 @@ import fi.liikennevirasto.digiroad2.{FloatingReason, PersistedPointAsset, Point,
 import fi.liikennevirasto.digiroad2.asset.{SideCode, TrafficDirection}
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection.toSideCode
 import fi.liikennevirasto.digiroad2.client.{ReplaceInfo, RoadLinkInfo}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 
 class DirectionalPointAssetUpdater(service: PointAssetOperations) extends PointAssetUpdater(service: PointAssetOperations) {
-  override def shouldFloat(asset: PersistedPointAsset, replaceInfo: ReplaceInfo,
-                           newLink: Option[RoadLinkInfo]): (Boolean, Option[FloatingReason]) = {
+  override def shouldFloat(asset: PersistedPointAsset, replaceInfo: ReplaceInfo, newLinkInfo: Option[RoadLinkInfo],
+                           newLink: Option[RoadLink]): (Boolean, Option[FloatingReason]) = {
     newLink match {
       case Some(link) if !directionMatches(asset.getValidityDirection, link.trafficDirection, replaceInfo.digitizationChange) =>
         (true, Some(FloatingReason.TrafficDirectionNotMatch))
-      case _ => super.shouldFloat(asset, replaceInfo, newLink)
+      case _ => super.shouldFloat(asset, replaceInfo, newLinkInfo, newLink)
     }
   }
 
@@ -35,5 +36,11 @@ class DirectionalPointAssetUpdater(service: PointAssetOperations) extends PointA
 
   override def calculateBearing(point: Point, geometry: Seq[Point]): Option[Int] = {
     Some(PointAssetOperations.calculateBearing(point, geometry))
+  }
+
+  override def getRoadLink(link: Option[RoadLinkInfo]): Option[RoadLink] = {
+    if (link.isDefined)
+      roadLinkService.getRoadLinkAndComplementaryByLinkId(link.get.linkId, false)
+    else None
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdateProcess.scala
@@ -1,11 +1,16 @@
 package fi.liikennevirasto.digiroad2.util.assetUpdater.pointasset
 
-import fi.liikennevirasto.digiroad2.asset.{DirectionalTrafficSigns, Obstacles, PedestrianCrossings, RailwayCrossings, TrafficLights, TrafficSigns}
+import fi.liikennevirasto.digiroad2.asset.{DirectionalTrafficSigns, MassTransitStopAsset, Obstacles, PedestrianCrossings, RailwayCrossings, TrafficLights, TrafficSigns}
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
-import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
+import fi.liikennevirasto.digiroad2.dao.{MassTransitStopDao, MunicipalityDao}
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.service.{RoadAddressService, RoadLinkService}
+import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.MassTransitStopService
 import fi.liikennevirasto.digiroad2.service.pointasset.{DirectionalTrafficSignService, ObstacleService, PedestrianCrossingService, RailwayCrossingService, TrafficLightService, TrafficSignService}
 import fi.liikennevirasto.digiroad2.util._
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, DummyEventBus, DummySerializer, PointAssetOperations}
+import org.apache.http.impl.client.HttpClientBuilder
 
 import scala.sys.exit
 
@@ -14,9 +19,24 @@ object PointAssetUpdateProcess {
   lazy val roadLinkClient: RoadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
   lazy val roadLinkService: RoadLinkService = new RoadLinkService(roadLinkClient, eventBus, new DummySerializer)
 
+  lazy val viiteClient: SearchViiteClient = new SearchViiteClient(Digiroad2Properties.viiteRestApiEndPoint, HttpClientBuilder.create().build())
+  lazy val roadAddressService: RoadAddressService = new RoadAddressService(viiteClient)
+  lazy val massTransitStopService: MassTransitStopService = {
+    class MassTransitStopServiceWithDynTransaction(val eventbus: DigiroadEventBus, val roadLinkService: RoadLinkService, val roadAddressService: RoadAddressService) extends MassTransitStopService {
+      override def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
+      override def withDynSession[T](f: => T): T = PostGISDatabase.withDynSession(f)
+      override val massTransitStopDao: MassTransitStopDao = new MassTransitStopDao
+      override val municipalityDao: MunicipalityDao = new MunicipalityDao
+      override val geometryTransform: GeometryTransform = new GeometryTransform(roadAddressService)
+    }
+    new MassTransitStopServiceWithDynTransaction(eventBus, roadLinkService, roadAddressService)
+  }
+
   private def getAssetUpdater(typeId: Int): PointAssetUpdater = {
     val directionalPointAssets = List(DirectionalTrafficSigns.typeId, TrafficSigns.typeId, TrafficLights.typeId)
     typeId match {
+      case id if id == MassTransitStopAsset.typeId =>
+        new MassTransitStopUpdater(massTransitStopService)
       case id if directionalPointAssets.contains(id) =>
         new DirectionalPointAssetUpdater(getPointAssetService(typeId))
       case _ =>
@@ -60,6 +80,7 @@ object PointAssetUpdateProcess {
         case "directional_traffic_sign" => runUpdateProcess(DirectionalTrafficSigns.typeId)
         case "traffic_sign" => runUpdateProcess(TrafficSigns.typeId)
         case "traffic_light" => runUpdateProcess(TrafficLights.typeId)
+        case "mass_transit_stop" => runUpdateProcess(MassTransitStopAsset.typeId)
         case _ => throw new IllegalArgumentException("Invalid asset name")
       }
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
@@ -7,6 +7,9 @@ import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.util.assetUpdater.ChangeTypeReport.{Floating, Move}
 import fi.liikennevirasto.digiroad2.util.assetUpdater._
 import fi.liikennevirasto.digiroad2._
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.util.Digiroad2Properties
 import org.joda.time.DateTime
 import org.json4s.JsonDSL._
 import org.json4s.jackson.compactJson
@@ -16,10 +19,15 @@ class PointAssetUpdater(service: PointAssetOperations) {
   val roadLinkChangeClient = new RoadLinkChangeClient
   val logger: Logger = LoggerFactory.getLogger(getClass)
 
+  lazy val eventBus: DigiroadEventBus = new DummyEventBus
+  lazy val roadLinkClient: RoadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
+  lazy val roadLinkService = new RoadLinkService(roadLinkClient, eventBus, new DummySerializer)
+
   val MaxDistanceDiffAllowed = 3.0 // Meters
 
   def adjustValidityDirection(assetDirection: Option[Int], digitizationChange: Boolean): Option[Int] = None
   def calculateBearing(point: Point, geometry: Seq[Point]): Option[Int] = None
+  def getRoadLink(newLink: Option[RoadLinkInfo]): Option[RoadLink] = None
 
   def updatePointAssets(typeId: Int): Unit = {
     val latestSuccess = PostGISDatabase.withDynSession ( Queries.getLatestSuccessfulSamuutus(typeId) )
@@ -88,7 +96,7 @@ class PointAssetUpdater(service: PointAssetOperations) {
       case (_, Some(replace)) =>
         (roadLinkChange.oldLink, roadLinkChange.newLinks.find(_.linkId == replace.newLinkId)) match {
           case (Some(oldLink), Some(newLink)) =>
-            val (floating, floatingReason) = shouldFloat(asset, replace, Some(newLink))
+            val (floating, floatingReason) = shouldFloat(asset, replace, Some(newLink), getRoadLink(Some(newLink)))
             if (floating)   setAssetAsFloating(asset, floatingReason)
             else            snapAssetToNewLink(asset, newLink, oldLink, replace.digitizationChange)
           case _ => setAssetAsFloating(asset, Some(FloatingReason.NoRoadLinkFound))
@@ -97,9 +105,9 @@ class PointAssetUpdater(service: PointAssetOperations) {
     }
   }
 
-  protected def shouldFloat(asset: PersistedPointAsset, replaceInfo: ReplaceInfo,
-                            newLink: Option[RoadLinkInfo]): (Boolean, Option[FloatingReason]) = {
-    newLink match {
+  protected def shouldFloat(asset: PersistedPointAsset, replaceInfo: ReplaceInfo, newLinkInfo: Option[RoadLinkInfo],
+                            newLink: Option[RoadLink]): (Boolean, Option[FloatingReason]) = {
+    newLinkInfo match {
       case Some(link) if link.municipality != asset.municipalityCode =>
         (true, Some(FloatingReason.DifferentMunicipalityCode))
       case None =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
@@ -90,7 +90,8 @@ class PointAssetUpdater(service: PointAssetOperations) {
 
   def correctPersistedAsset(asset: PersistedPointAsset, roadLinkChange: RoadLinkChange): AssetUpdate = {
     val nearestReplace = roadLinkChange.replaceInfo.find(change =>
-      change.oldFromMValue <= asset.mValue && asset.mValue <= change.oldToMValue)
+      (change.oldFromMValue <= asset.mValue && asset.mValue <= change.oldToMValue) ||
+        (change.oldFromMValue >= asset.mValue && asset.mValue >= change.oldToMValue))
     (roadLinkChange.changeType, nearestReplace) match {
       case (RoadLinkChangeType.Remove, _) => setAssetAsFloating(asset, Some(FloatingReason.NoRoadLinkFound))
       case (_, Some(replace)) =>

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/MassTransitStopUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/MassTransitStopUpdaterSpec.scala
@@ -2,10 +2,8 @@ package fi.liikennevirasto.digiroad2.util.assetUpdater.pointasset
 
 import fi.liikennevirasto.digiroad2.FloatingReason.{NoRoadLinkFound, RoadOwnerChanged, TerminalChildless}
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
-import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.client.RoadLinkChangeType.Replace
-import fi.liikennevirasto.digiroad2.client.{ReplaceInfo, RoadLinkChange, RoadLinkChangeClient, RoadLinkInfo}
+import fi.liikennevirasto.digiroad2.client.{RoadLinkChange, RoadLinkChangeClient}
 import fi.liikennevirasto.digiroad2.dao.{MassTransitStopDao, MunicipalityDao}
 import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
@@ -18,6 +16,7 @@ import slick.jdbc.StaticQuery.interpolation
 import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import fi.liikennevirasto.digiroad2.util.assetUpdater.ChangeTypeReport.{Floating, Move}
+import org.mockito.Mockito.when
 
 class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
 
@@ -41,7 +40,7 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
 
   val testMassTransitStopDao = new MassTransitStopDao
 
-  val massTransitStopService = new MassTransitStopService {
+  val massTransitStopService: MassTransitStopService = new MassTransitStopService {
     val massTransitStopDao: MassTransitStopDao = testMassTransitStopDao
     val municipalityDao: MunicipalityDao = mockMunicipalityDao
     val roadLinkService: RoadLinkService = mockRoadLinkService
@@ -57,7 +56,9 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
     }
   }
 
-  val updater = new MassTransitStopUpdater(massTransitStopService)
+  val updater: MassTransitStopUpdater = new MassTransitStopUpdater(massTransitStopService) {
+    override lazy val roadLinkService: RoadLinkService = mockRoadLinkService
+  }
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback()(test)
 
@@ -66,8 +67,17 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
       val oldLinkId = "99ade73f-979b-480b-976a-197ad365440a:1"
       val newLinkId1 = "1cb02550-5ce4-4c0a-8bee-c7f5e1f314d1:1"
       val newLinkId2 = "7c6fc2d3-f79f-4e03-a349-80103714a442:1"
-
       val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
+
+      val newLinkInfo1 = change.newLinks.find(_.linkId == newLinkId1).get
+      val newLinkInfo2 = change.newLinks.find(_.linkId == newLinkId2).get
+      val newLink1 = RoadLink(newLinkId1, newLinkInfo1.geometry, newLinkInfo1.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+      val newLink2 = RoadLink(newLinkId1, newLinkInfo2.geometry, newLinkInfo2.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+      when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId1, false)).thenReturn(Some(newLink1))
+      when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId2, false)).thenReturn(Some(newLink2))
+
       val oldLinkInfo = change.oldLink.get
       val oldLink = RoadLink(oldLinkId, oldLinkInfo.geometry, oldLinkInfo.linkLength, oldLinkInfo.adminClass, oldLinkInfo.municipality,
         oldLinkInfo.trafficDirection, SingleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)))
@@ -112,16 +122,19 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
   test("Administrative class has changed, bus stop is marked floating") {
     val oldLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:1"
     val newLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:2"
-    val geometry = List(Point(367880.004,6673884.307,21.732),
-      Point(367877.133,6673892.641,22.435), Point(367868.672,6673919.942,24.138), Point(367858.777,6673950.125,24.72),
-      Point(367851.607,6673967.978,24.331), Point(367843.6280000001,6673981.799,23.742), Point(367834.833,6673991.432,23.121),
-      Point(367824.646,6674001.441,22.455))
-    val change = RoadLinkChange(Replace,Some(RoadLinkInfo(oldLinkId,131.68340638,geometry,12131,Municipality,49,BothDirections)),
-      List(RoadLinkInfo(newLinkId,131.68340638, geometry,12131,State,49,BothDirections)),
-      List(ReplaceInfo(oldLinkId,newLinkId,0.0,131.683,0.0,131.683,false)))
+    val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
+
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newAdminClass = State
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, newAdminClass, 1, TrafficDirection.BothDirections,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(1), "SURFACETYPE" -> BigInt(2)),
+      ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
     val administrativeClassProperty = Property(1, MassTransitStopOperations.MassTransitStopAdminClassPublicId, "text", false, Seq(PropertyValue("2")))
     val asset = testBusStop(1, 11, oldLinkId, Seq(), 49, 367830.31375169184, 6673995.872282351,
       123.74459961959604, Some(SideCode.TowardsDigitizing.value), None, None, false, 0L,  Seq(administrativeClassProperty), NormalLinkInterface)
+
     val corrected = updater.correctPersistedAsset(asset, change)
     corrected.floating should be(true)
     corrected.floatingReason.get should be(RoadOwnerChanged)
@@ -132,16 +145,17 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
   test("With normal version change (no admin class change), bus stop is transferred to new link") {
     val oldLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:1"
     val newLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:2"
-    val geometry = List(Point(367880.004,6673884.307,21.732),
-      Point(367877.133,6673892.641,22.435), Point(367868.672,6673919.942,24.138), Point(367858.777,6673950.125,24.72),
-      Point(367851.607,6673967.978,24.331), Point(367843.6280000001,6673981.799,23.742), Point(367834.833,6673991.432,23.121),
-      Point(367824.646,6674001.441,22.455))
-    val change = RoadLinkChange(Replace,Some(RoadLinkInfo(oldLinkId,131.68340638,geometry,12131,Municipality,49,BothDirections)),
-      List(RoadLinkInfo(newLinkId,131.68340638, geometry,12131,Municipality,49,BothDirections)),
-      List(ReplaceInfo(oldLinkId,newLinkId,0.0,131.683,0.0,131.683,false)))
+    val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
+
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
     val administrativeClassProperty = Property(1, MassTransitStopOperations.MassTransitStopAdminClassPublicId, "text", false, Seq(PropertyValue("2")))
     val asset = testBusStop(1, 11, oldLinkId, Seq(), 49, 367830.31375169184, 6673995.872282351,
       123.74459961959604, Some(SideCode.TowardsDigitizing.value), None, None, false, 0L,  Seq(administrativeClassProperty), NormalLinkInterface)
+
     val corrected = updater.correctPersistedAsset(asset, change)
     corrected.floating should be(false)
     corrected.floatingReason should be(None)
@@ -153,18 +167,19 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
     runWithRollback {
       val oldLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:1"
       val newLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:2"
-      val geometry = List(Point(367880.004, 6673884.307, 21.732),
-        Point(367877.133, 6673892.641, 22.435), Point(367868.672, 6673919.942, 24.138), Point(367858.777, 6673950.125, 24.72),
-        Point(367851.607, 6673967.978, 24.331), Point(367843.6280000001, 6673981.799, 23.742), Point(367834.833, 6673991.432, 23.121),
-        Point(367824.646, 6674001.441, 22.455))
-      val change = RoadLinkChange(Replace, Some(RoadLinkInfo(oldLinkId, 131.68340638, geometry, 12131, Municipality, 49, BothDirections)),
-        List(RoadLinkInfo(newLinkId, 131.68340638, geometry, 12131, Municipality, 49, BothDirections)),
-        List(ReplaceInfo(oldLinkId, newLinkId, 0.0, 131.683, 0.0, 131.683, false)))
+      val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
+
+      val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+      val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+      when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
       val terminalStopProperty = Property(200, MassTransitStopOperations.MassTransitStopTypePublicId, "multiple_choice", false, Seq(PropertyValue(BusStopType.Terminal.value.toString)))
       val terminalStop = testBusStop(1, 11, oldLinkId, Seq(), 49, 367830.31375169184, 6673995.872282351,
         123.74459961959604, Some(SideCode.TowardsDigitizing.value), None, None, false, 0L, Seq(terminalStopProperty), NormalLinkInterface)
       val ordinaryStop = testBusStop(1, 11, oldLinkId, Seq(), 49, 367830.31375169184, 6673995.872282351,
         123.74459961959604, Some(SideCode.TowardsDigitizing.value), None, None, false, 0L, Seq(), NormalLinkInterface)
+
       val corrected1 = updater.correctPersistedAsset(terminalStop, change)
       corrected1.floating should be(true)
       corrected1.floatingReason.get should be(TerminalChildless)
@@ -194,6 +209,11 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
       val oldLink2 = RoadLink(oldLinkId2, oldLinkInfo2.geometry, oldLinkInfo2.linkLength, oldLinkInfo2.adminClass, oldLinkInfo2.municipality,
         oldLinkInfo2.trafficDirection, SingleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(91)))
 
+      val newLinkInfo = change1.newLinks.find(_.linkId == newLinkId).get
+      val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(91)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+      when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
       val terminalStopId = massTransitStopService.create(NewMassTransitStop(391922.1567866767, 6672845.986092816, oldLinkId1, 341,
         Seq(SimplePointAssetProperty("vaikutussuunta", Seq(PropertyValue("3"))), SimplePointAssetProperty(MassTransitStopOperations.MassTransitStopTypePublicId,
           Seq(PropertyValue(BusStopType.Terminal.value.toString))))), "test", oldLink1, false)
@@ -216,6 +236,11 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
       val newLinkId = "eca24369-a77b-4e6f-875e-57dc85176003:1"
       val change1 = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId1).get
       val change2 = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId2).get
+
+      val newLinkInfo = change1.newLinks.find(_.linkId == newLinkId).get
+      val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.AgainstDigitizing,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(1)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+      when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
 
       val oldLinkInfo1 = change1.oldLink.get
       val oldLink1 = RoadLink(oldLinkId1, oldLinkInfo1.geometry, oldLinkInfo1.linkLength, oldLinkInfo1.adminClass, oldLinkInfo1.municipality,
@@ -271,8 +296,13 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
     val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
     val asset = testBusStop(1, 11, oldLinkId, Seq(), 91, 391936.8899081593, 6672840.334351871,
       4.773532861864595, Some(SideCode.AgainstDigitizing.value), None, None, false, 0L, Seq(), NormalLinkInterface)
-    val corrected = updater.correctPersistedAsset(asset, change)
 
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.AgainstDigitizing,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(91)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
+    val corrected = updater.correctPersistedAsset(asset, change)
     corrected.floating should be(true)
     corrected.floatingReason should be(Some(FloatingReason.TrafficDirectionNotMatch))
     corrected.lon should be(asset.lon)
@@ -287,8 +317,13 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
     val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
     val asset = testBusStop(1, 11, oldLinkId, Seq(), 49, 370243.9245965985, 6670363.935476765,
       35.833489781349485, Some(SideCode.TowardsDigitizing.value), Some(289), None, true, 0L, Seq(), NormalLinkInterface)
-    val corrected = updater.correctPersistedAsset(asset, change)
 
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
+    val corrected = updater.correctPersistedAsset(asset, change)
     val distanceToOldLocation = Point(corrected.lon, corrected.lat).distance2DTo(Point(asset.lon, asset.lat))
     corrected.floating should be(false)
     corrected.linkId should be(newLinkId)
@@ -297,23 +332,35 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
 
   test("New link is shorter than old one: asset is too far from new link so it is marked as floating") {
     val oldLinkId = "875766ca-83b1-450b-baf1-db76d59176be:1"
+    val newLinkId = "6eec9a4a-bcac-4afb-afc8-f4e6d40ec571:1"
     val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
     val asset = testBusStop(1, 11, oldLinkId, Seq(), 49, 370235.4591063613, 6670366.945428849,
       44.83222354244527, Some(SideCode.TowardsDigitizing.value), Some(289), None, false, 0L, Seq(), NormalLinkInterface)
-    val corrected = updater.correctPersistedAsset(asset, change)
 
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(49)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
+    val corrected = updater.correctPersistedAsset(asset, change)
     corrected.floating should be(true)
     corrected.floatingReason should be(Some(FloatingReason.DistanceToRoad))
   }
 
   test("New link has different municipality than asset: asset is marked as floating") {
     val oldLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:1"
+    val newLinkId = "1438d48d-dde6-43db-8aba-febf3d2220c0:2"
     val assetMunicipality = 235 // New link is at municipality 49
     val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
     val asset = testBusStop(1, 11, oldLinkId, Seq(), assetMunicipality, 367830.31375169184, 6673995.872282351,
       123.74459961959604, Some(SideCode.TowardsDigitizing.value), Some(317), None, false, 0L, Seq(), NormalLinkInterface)
-    val corrected = updater.correctPersistedAsset(asset, change)
 
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.BothDirections,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(assetMunicipality)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
+    val corrected = updater.correctPersistedAsset(asset, change)
     corrected.floating should be(true)
     corrected.floatingReason should be(Some(FloatingReason.DifferentMunicipalityCode))
     corrected.linkId should be(oldLinkId)
@@ -376,6 +423,7 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
   test("Validity direction is changed in the report") {
     runWithRollback {
       val oldLinkId = "291f7e18-a48a-4afc-a84b-8485164288b2:1"
+      val newLinkId = "eca24369-a77b-4e6f-875e-57dc85176003:1"
       val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
 
       val oldLinkInfo = change.oldLink.get
@@ -385,6 +433,11 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
       val stopId = massTransitStopService.create(NewMassTransitStop(391942.45320008986, 6672844.827758611, oldLinkId, 23,
         Seq(SimplePointAssetProperty("vaikutussuunta", Seq(PropertyValue("2"))))), "test", oldLink, false)
       val createdStop = massTransitStopService.getPersistedAssetsByIds(Set(stopId)).head
+
+      val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+      val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.AgainstDigitizing,
+        Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(91)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+      when(mockRoadLinkService.getRoadLinkAndComplementaryByLinkId(newLinkId, false)).thenReturn(Some(newLink))
 
       val corrected = updater.correctPersistedAsset(createdStop, change)
 


### PR DESCRIPTION
- Muutettu bussipysäkkien ja muiden suunnallisten pistemäisten tietolajien samuutus käyttämään tielinkkien ylikirjoitettuja arvoja (hallinnollinen luokka sekä liikennevirran suunta) ja päivitetty testit
- Korjattu lähimmän korvaustiedon etsiminen lisäämällä puuttuva tarkastus
- Lisätty puuttuvat pysäkeiden samuutuksen käynnistämis konfiguraatiot