### PR TITLE
DROTH-3703 Use String KMTK ID

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -151,7 +151,6 @@ class VKMClient {
 
   // TODO VKM does not provide all road links when transforming road address range to roadLinks, only start and end links
   //  Support for this is coming to VKM in early 2023, change implementation to use the feature when it's available.
-  //  KmtkId not supported as of January 2023, use linkID for now
   def fetchStartAndEndLinkIdForAddrRange(roadAddressRange: RoadAddressRange): Set[(String, String)] = {
     val params = Map(
       VkmRoad -> Some(roadAddressRange.roadNumber),

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -138,8 +138,8 @@ class VKMClient {
 
   def fetchLinkIdsBetweenTwoRoadLinks(startLinkId: String, endLinkId: String, roadNumber: Long): Set[String] = {
     val params = Map(
-      VkmLinkId -> Some(startLinkId),
-      VkmLinkIdEnd -> Some(endLinkId),
+      VkmKmtkId -> Some(startLinkId),
+      VkmKmtkIdEnd -> Some(endLinkId),
       VkmRoad -> Some(roadNumber)
     )
 
@@ -167,8 +167,8 @@ class VKMClient {
 
     request(vkmBaseUrl + "muunna?valihaku=true&palautusarvot=6&" + urlParams(params)) match {
       case Left(featureCollection) =>
-        featureCollection.features.map(feature => (feature.properties(VkmLinkId).asInstanceOf[BigInt].toString(),
-          feature.properties(VkmLinkIdEnd).asInstanceOf[BigInt].toString())).toSet
+        featureCollection.features.map(feature => (feature.properties(VkmKmtkId).asInstanceOf[String],
+          feature.properties(VkmKmtkIdEnd).asInstanceOf[String])).toSet
       case Right(error) => throw new RoadAddressException(error.toString)
     }
   }


### PR DESCRIPTION
Käytetään nyt kmtk_id ja ktmtk_id_loppu kenttiä VKM:n vastauksesta linkId sijaan.