### PR TITLE
 DROTH-3788 update timetamp

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinks.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinks.scala
@@ -43,6 +43,7 @@ trait ResolvingFrozenRoadLinks {
   lazy val username: String = "batch_process_temp_road_address"
 
   //Timestamp for the instant when Viite road links were frozen
+  // 20.05.2023 16:29:59
   lazy val viiteTimestamp: Long = 1684589399000L
   
   val logger: Logger = LoggerFactory.getLogger(getClass)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinks.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ResolveFrozenRoadLinks.scala
@@ -43,8 +43,8 @@ trait ResolvingFrozenRoadLinks {
   lazy val username: String = "batch_process_temp_road_address"
 
   //Timestamp for the instant when Viite road links were frozen
-  lazy val viiteTimestamp: Long = 1667925243000L
-
+  lazy val viiteTimestamp: Long = 1684589399000L
+  
   val logger: Logger = LoggerFactory.getLogger(getClass)
 
   def calculateSideCodeUsingEndPointAddrs(addrMAtStart: Int, addrMAtEnd: Int): SideCode = {


### PR DESCRIPTION
Päivitetään timestamp viimeisimpään viite tielinkki verkkoon.

Paremetrisoidaan jos tulee tarvetta muuttaa useammin tai eri ympäristöissä eri viite tieverkko.