### PR TITLE
 DROTH-3562 change how viite change client is configured

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -275,7 +275,7 @@ object Digiroad2Context {
   lazy val authenticationTestModeEnabled: Boolean = {
     Digiroad2Properties.authenticationTestMode
   }
-  private def clientBuilder(maxConnTotal: Int = 10000, maxConnPerRoute: Int = 10000) = {
+  private def clientBuilder(maxConnTotal: Int = 1000, maxConnPerRoute: Int = 1000) = {
     HttpClientBuilder.create().setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
       .setMaxConnTotal(maxConnTotal)
       .setMaxConnPerRoute(maxConnPerRoute)

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -275,6 +275,12 @@ object Digiroad2Context {
   lazy val authenticationTestModeEnabled: Boolean = {
     Digiroad2Properties.authenticationTestMode
   }
+  private def clientBuilder(maxConnTotal: Int = 10000, maxConnPerRoute: Int = 10000) = {
+    HttpClientBuilder.create().setDefaultRequestConfig(RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build())
+      .setMaxConnTotal(maxConnTotal)
+      .setMaxConnPerRoute(maxConnPerRoute)
+      .build()
+  }
 
   lazy val assetPropertyService: AssetPropertyService = {
     new AssetPropertyService(eventbus, userProvider, DefaultDatabaseTransaction)
@@ -305,12 +311,9 @@ object Digiroad2Context {
   }
 
   lazy val viiteClient: SearchViiteClient = {
-    new SearchViiteClient(Digiroad2Properties.viiteRestApiEndPoint,
-      HttpClientBuilder.create().setDefaultRequestConfig(
-        RequestConfig.custom().setCookieSpec(CookieSpecs.STANDARD).build()
-      ).build())
+    new SearchViiteClient(Digiroad2Properties.viiteRestApiEndPoint, clientBuilder())
   }
-
+  
   lazy val linearAssetDao: PostGISLinearAssetDao = {
     new PostGISLinearAssetDao()
   }

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/vallu/ValluSender.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/vallu/ValluSender.scala
@@ -21,8 +21,8 @@ object ValluSender extends AssetPropertiesReader {
     .build()
 
   val httpClient = HttpClients.custom().setDefaultRequestConfig(config)
-    .setMaxConnTotal(10000)
-    .setMaxConnPerRoute(10000)
+    .setMaxConnTotal(1000)
+    .setMaxConnPerRoute(1000)
     .build()
 
   def postToVallu(massTransitStop: EventBusMassTransitStop) {

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/vallu/ValluSender.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/vallu/ValluSender.scala
@@ -20,7 +20,10 @@ object ValluSender extends AssetPropertiesReader {
     .setConnectTimeout(60 * 1000)
     .build()
 
-  val httpClient = HttpClients.custom().setDefaultRequestConfig(config).build()
+  val httpClient = HttpClients.custom().setDefaultRequestConfig(config)
+    .setMaxConnTotal(10000)
+    .setMaxConnPerRoute(10000)
+    .build()
 
   def postToVallu(massTransitStop: EventBusMassTransitStop) {
     val payload = ValluStoreStopChangeMessage.create(massTransitStop)


### PR DESCRIPTION
Kasvatetaan connection pool asetuksia. 
Toiven vaihtoehto olisi kyl tehdä niin että jokainen kutsu loisi oman client.
Oman client luonti per kutsu tietty tarkoittaa että kyselyt ei voi hyödyntään connection pool hommia tai keskitettyä cache. 
Tää voisi olla ehkä nyt tähän hätään nopein ratkaisu kun tätä rajapintaa muutenkin kutsutaan tosi paljon.