### PR TITLE
DROTH-3745 remove traffic direction condition from trams and fix bug

### DIFF
--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -327,7 +327,7 @@
       if(roadCollection){
         var roadLinkDirection = getRoadLinkDirection();
         var massTransitStopDirection = currentAsset.payload.validityDirection;
-        return isTerminalBusStop(currentAsset.payload.properties) || roadLinkDirection === 1 || roadLinkDirection === massTransitStopDirection;
+        return isTerminalBusStop(currentAsset.payload.properties) || isTram(currentAsset.payload.properties) || roadLinkDirection === 1 || roadLinkDirection === massTransitStopDirection;
       }
       return false;
     };
@@ -404,9 +404,9 @@
         backend.getMassTransitStopByNationalId(assetNationalId, function (asset, statusMessage, errorObject) {
           if (errorObject !== undefined) {
             console.log(errorObject);
-            
+
           }
-          
+
           eventbus.trigger('asset:fetched', asset);
         });
       }
@@ -423,7 +423,7 @@
           if (errorObject !== undefined) {
             console.log(errorObject);
           }
-          
+
           eventbus.trigger('asset:fetched', asset);
         });
       }
@@ -587,6 +587,14 @@
 
       return _.some(properties, function (property) {
         return property.publicId === 'liitetty_terminaaliin' && !_.isEmpty(property.values);
+      });
+    }
+
+    function isTram(properties) {
+      return _.some(properties, function (property) {
+        return property.publicId == 'pysakin_tyyppi' && _.some(property.values, function (value) {
+          return value.propertyValue == "1";
+        });
       });
     }
 

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -135,6 +135,9 @@
       }else{
         new GenericConfirmPopup('Pysäkin vaikutussuunta on yksisuuntaisen tielinkin ajosuunnan vastainen. Pysäkkiä ei tallennettu.',
           {type: 'alert'});
+        selectedMassTransitStopModel.cancel();
+        selectedMassTransitStopModel.close();
+        eventbus.trigger('layer:cleared');
       }
     }
 

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -925,6 +925,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     eventListener.listenTo(eventbus, 'map:moved', handleMapMoved);
     eventListener.listenTo(eventbus, 'map:clicked', handleMapClick);
     eventListener.listenTo(eventbus, 'layer:selected', closeAsset);
+    eventListener.listenTo(eventbus, 'layer:cleared', roadLayer.clearSelection());
     eventListener.listenTo(eventbus, 'massTransitStopDeleted', function(asset){
       closeAsset();
       destroyAsset(asset);

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
@@ -143,8 +143,9 @@ object MassTransitStopOperations {
   def isValidBusStopDirections(properties: Seq[SimplePointAssetProperty], roadLink: Option[RoadLinkLike]) = {
     val roadLinkDirection = roadLink.map(dir => dir.trafficDirection).getOrElse(throw new IllegalStateException("Road link no longer available"))
     val stopTypes = properties.filter(prop => prop.publicId == "pysakin_tyyppi").flatMap(_.values).map(_.asInstanceOf[PropertyValue].propertyValue)
-    // a stop including tram type is always valid, otherwise check that the validity direction and traffic direction match
-    if (stopTypes.contains("1")) {
+    val anyDirectionIsValidBecauseOfTram = stopTypes.contains("1")
+
+    if (anyDirectionIsValidBecauseOfTram) {
       true
     } else {
       properties.find(prop => prop.publicId == "vaikutussuunta").flatMap(_.values.headOption.map(_.asInstanceOf[PropertyValue].propertyValue)) match {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
@@ -142,11 +142,16 @@ object MassTransitStopOperations {
 
   def isValidBusStopDirections(properties: Seq[SimplePointAssetProperty], roadLink: Option[RoadLinkLike]) = {
     val roadLinkDirection = roadLink.map(dir => dir.trafficDirection).getOrElse(throw new IllegalStateException("Road link no longer available"))
-
-    properties.find(prop => prop.publicId == "vaikutussuunta").flatMap(_.values.headOption.map(_.asInstanceOf[PropertyValue].propertyValue)) match {
-      case Some(busDir) =>
-        !((roadLinkDirection != TrafficDirection.BothDirections) && (roadLinkDirection.toString != SideCode.apply(busDir.toInt).toString))
-      case None => false
+    val stopTypes = properties.filter(prop => prop.publicId == "pysakin_tyyppi").flatMap(_.values).map(_.asInstanceOf[PropertyValue].propertyValue)
+    // a stop including tram type is always valid, otherwise check that the validity direction and traffic direction match
+    if (stopTypes.contains("1")) {
+      true
+    } else {
+      properties.find(prop => prop.publicId == "vaikutussuunta").flatMap(_.values.headOption.map(_.asInstanceOf[PropertyValue].propertyValue)) match {
+        case Some(busDir) =>
+          !((roadLinkDirection != TrafficDirection.BothDirections) && (roadLinkDirection.toString != SideCode.apply(busDir.toInt).toString))
+        case None => false
+      }
     }
   }
 


### PR DESCRIPTION
Hyväksytään pysäkin tallennus liikennevirran suuntaa vastaan, jos pysäkki sisältää ratikan. Korjataan bugi, jossa ei-sallitun tallennusyrityksen jälkeen, lomake jää näkyviin, mutta sitä ei voi enää muokata. Nyt lomake suljetaan, jos tallennusta ei sallita.