### PR TITLE
Droth 3726 ely admined bus stops retain national id when moved over 50m

### DIFF
--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -661,7 +661,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     if (distance > movementLimit && !movementPermissionConfirmed)
     {
       requestingMovePermission = true;
-      if (ownedByELY() || ownedByHSL()){
+      if (ownedByHSL()){
         popupMessageToShow = 'Pysäkkiä siirretty yli 50 metriä. Siirron yhteydessä vanha pysäkki lakkautetaan ja luodaan uusi pysäkki.';
       } else {
         popupMessageToShow = 'Pysäkkiä siirretty yli 50 metriä. Haluatko siirtää pysäkin uuteen sijaintiin?';

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
@@ -133,23 +133,12 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
       map(property => SimplePointAssetProperty(property.publicId, property.values)) ++ properties).
       filterNot(property => commonAssetProperties.exists(_._1 == property.publicId))
 
-    //If it all ready has liviId
+    //If asset already has liviId
     if (was(asset)) {
       val liviId = getLiviIdValue(asset.propertyData).orElse(getLiviIdValue(properties.toSeq)).getOrElse(throw new NoSuchElementException)
-      if (calculateMovedDistance(asset, optionalPosition) > MaxMovementDistanceMeters) {
-        //Expires the current asset and creates a new one in OTH with new liviId
-        val position = optionalPosition.get
-        massTransitStopDao.expireMassTransitStop(username, asset.id)
-        super.publishExpiringEvent(PublishInfo(Option(asset)))
-        create(NewMassTransitStop(position.lon, position.lat, roadLink.linkId, position.bearing.getOrElse(asset.bearing.get),
-          mergedProperties), username, Point(position.lon, position.lat), roadLink)
-
-      }else{
-        //Updates the asset in OTH
-        update(asset, optionalPosition, verifiedProperties.toSeq, roadLink, liviId,
+      update(asset, optionalPosition, verifiedProperties.toSeq, roadLink, liviId,
           username)
-      }
-    }else{
+    } else {
       //Updates the asset in OTH with new liviId
       update(asset, optionalPosition, verifiedProperties.toSeq, roadLink, toLiviId.format(asset.nationalId),
         username)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
@@ -460,7 +460,9 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers with BeforeAndAf
     }
   }
 
-  test("When moving over 50 meter and expiring in OthBusStopLifeCycle strategy send vallu message "){
+  test("Given a ELY administrated Motorway bus stop; " +
+                  "When the bus stop is moved over 50 meters; " +
+                  "Then the bus stop's nationalId should not change and the bus stop should not be expired"){
     runWithRollback {
       val linkId = randomLinkId1
       val municipalityCode = 91
@@ -479,12 +481,13 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers with BeforeAndAf
       when(mockGeometryTransform.resolveAddressAndLocation(any[Point], any[Int], any[Double], any[String], any[Int], any[Option[Int]], any[Option[Int]])).thenReturn(
         (RoadAddress(Some(municipalityCode.toString), 1, 1, Track.Combined, 0), RoadSide.Left)
       )
-      val roadLink = RoadLink(linkId, geometry, 120, Municipality, 1, TrafficDirection.BothDirections,
+      val roadLink = RoadLink(linkId, geometry, 120, State, 1, TrafficDirection.BothDirections,
         Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
       val oldAssetId = service.create(NewMassTransitStop(0, 0, linkId, 0, properties), "test", roadLink)
+      val oldAsset = service.getMassTransitStopById(oldAssetId)._1.get
       val position = Some(Position(60.0, 0.0, randomLinkId1, None))
       val updatedAsset =service.updateExistingById(oldAssetId, position, Set.empty, "user", (_,_) => Unit)
-      // check if new asset has same properties as old one
+
       updatedAsset.propertyData.find(p=>p.publicId =="nimi_suomeksi" ).get.values
         .head.asInstanceOf[PropertyValue].propertyValue should be("value is copied")
 
@@ -497,7 +500,11 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers with BeforeAndAf
       updatedAsset.propertyData.find(p=>p.publicId =="vaikutussuunta" ).get.values
         .head.asInstanceOf[PropertyValue].propertyValue should be("2")
 
-      verify(eventbus).publish(org.mockito.ArgumentMatchers.eq("asset:expired"), any[EventBusMassTransitStop]())
+      updatedAsset.nationalId should be(oldAsset.nationalId)
+
+      //check that no expiration message was sent
+      verify(eventbus, never()).publish(org.mockito.ArgumentMatchers.eq("asset:expired"), any[EventBusMassTransitStop]())
+
     }
   }
 
@@ -698,9 +705,6 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers with BeforeAndAf
 
       val newAsset = sql"""select id, municipality_code, valid_from, valid_to from asset where id = $updatedAssetId""".as[(Long, Int, String, String)].firstOption
       newAsset should be (Some(updatedAssetId, municipalityCode, null, null))
-
-      val expired = sql"""select case when a.valid_to <= current_timestamp then 1 else 0 end as expired from asset a where id = $oldAssetId""".as[(Boolean)].firstOption
-      expired should be(Some(true))
     }
   }
   

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/MassTransitStopServiceSpec.scala
@@ -502,6 +502,8 @@ class MassTransitStopServiceSpec extends FunSuite with Matchers with BeforeAndAf
 
       updatedAsset.nationalId should be(oldAsset.nationalId)
 
+      verify(eventbus, times(2)).publish(org.mockito.ArgumentMatchers.eq("asset:saved"), any[EventBusMassTransitStop]())
+
       //check that no expiration message was sent
       verify(eventbus, never()).publish(org.mockito.ArgumentMatchers.eq("asset:expired"), any[EventBusMassTransitStop]())
 


### PR DESCRIPTION
- Poistettu back endiltä poikkeuslogiikka, joka koski ELYn hallinnoimia pysäkkejä joita siirretään yli 50m:
  - Siirto ei enää expiroi alkuperäistä pysäkkiä ja luo uutta uudella kansallisella tunnuksella.
- Käyttöliittymä antaa nyt saman ilmoituksen kuin katuverkon pysäkkejä siirrettäessä.