### PR TITLE
Droth 3744 enable tram stops on pedestrian links

### DIFF
--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -194,6 +194,7 @@
 
     var open = function(asset) {
       currentAsset.id = asset.id;
+      currentAsset.linkId = asset.linkId;
       currentAsset.propertyMetadata = asset.propertyData;
       currentAsset.payload = _.merge({}, _.pick(asset, usedKeysFromFetchedAsset), transformPropertyData(asset.propertyData));
       currentAsset.validityPeriod = asset.validityPeriod;
@@ -247,19 +248,24 @@
     };
 
     var wrongStopTypeOnWalkingCyclingLink = function () {
-      var isCarTrafficRoad = getRoadLink().isCarTrafficRoad();
-      var isOnlyTramStop = _.some(currentAsset.payload.properties, function (property) {
-        if (property.publicId == massTransitStopTypePublicId) {
-          return _.some(property.values, function (propertyValue) {
-            return (propertyValue.propertyValue == 1 && property.values.length == 1);
-          });
-        }
+      var selectedRoadLink = getRoadLink();
+      if (_.isEmpty(selectedRoadLink)) {
         return false;
-      });
-      if(!isCarTrafficRoad) {
-        return !isOnlyTramStop;
       } else {
-        return false;
+        var isCarTrafficRoad = selectedRoadLink.isCarTrafficRoad();
+        var isOnlyTramStop = _.some(currentAsset.payload.properties, function (property) {
+          if (property.publicId == massTransitStopTypePublicId) {
+            return _.some(property.values, function (propertyValue) {
+              return (propertyValue.propertyValue == 1 && property.values.length == 1);
+            });
+          }
+          return false;
+        });
+        if (!isCarTrafficRoad) {
+          return !isOnlyTramStop;
+        } else {
+          return false;
+        }
       }
     };
 
@@ -478,7 +484,7 @@
 
     var get = function() {
       if (exists()) {
-          var nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(), currentAsset.payload.lon, currentAsset.payload.lat);
+          var nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForCarPedestrianCycling(), currentAsset.payload.lon, currentAsset.payload.lat);
           var linkId = nearestLine.linkId;
           if (!currentAsset.linkId)
               currentAsset.linkId = linkId;

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -246,6 +246,23 @@
       });
     };
 
+    var wrongStopTypeOnWalkingCyclingLink = function () {
+      var isCarTrafficRoad = getRoadLink().isCarTrafficRoad();
+      var isOnlyTramStop = _.some(currentAsset.payload.properties, function (property) {
+        if (property.publicId == massTransitStopTypePublicId) {
+          return _.some(property.values, function (propertyValue) {
+            return (propertyValue.propertyValue == 1 && property.values.length == 1);
+          });
+        }
+        return false;
+      });
+      if(!isCarTrafficRoad) {
+        return !isOnlyTramStop;
+      } else {
+        return false;
+      }
+    };
+
     var requiredPropertiesMissing = function () {
       var isRequiredProperty = function (publicId) {
         var isTerminal = currentAsset.stopTypes && isTerminalType(_.head(currentAsset.stopTypes)) || currentAsset.payload && isTerminalBusStop(currentAsset.payload.properties);
@@ -642,6 +659,7 @@
       place: place,
       hasMixedVirtualAndRealStops:hasMixedVirtualAndRealStops,
       pikavuoroIsAlone: pikavuoroIsAlone,
+      wrongStopTypeOnWalkingCyclingLink: wrongStopTypeOnWalkingCyclingLink,
       copyDataFromOtherMasTransitStop: copyDataFromOtherMasTransitStop,
       getCurrentAsset: getCurrentAsset,
       deleteMassTransitStop: deleteMassTransitStop,

--- a/UI/src/view/navigationpanel/massTransitStopBox.js
+++ b/UI/src/view/navigationpanel/massTransitStopBox.js
@@ -113,6 +113,9 @@
         '<div class="check-box-container">' +
         '<input id="complementaryLinkCheckBox" type="checkbox" checked/> <lable>Näytä täydentävä geometria</lable>' +
         '</div>' +
+        '<div class="check-box-container">' +
+        '<input id="walkingCyclingCheckbox" type="checkbox" unchecked/> <lable>Salli pysäkin luonti kävelyn ja pyöräilyn väylälle (vain raitiovaunupysäkit)</lable>' +
+        '</div>' +
         '</div>'
       ].join('');
     };

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -169,7 +169,9 @@
     var updateStatus = function() {
       if(pointAssetToSave && !isValidServicePoint()){
         element.prop('disabled', true);
-      } else if (selectedMassTransitStopModel.isDirty() && !selectedMassTransitStopModel.requiredPropertiesMissing() && !selectedMassTransitStopModel.hasMixedVirtualAndRealStops() && !selectedMassTransitStopModel.pikavuoroIsAlone()){
+      } else if (selectedMassTransitStopModel.isDirty() && !selectedMassTransitStopModel.requiredPropertiesMissing()
+          && !selectedMassTransitStopModel.hasMixedVirtualAndRealStops() && !selectedMassTransitStopModel.pikavuoroIsAlone()
+          && !selectedMassTransitStopModel.wrongStopTypeOnWalkingCyclingLink()){
         element.prop('disabled', false);
       } else if(poistaSelected) {
         element.prop('disabled', false);

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -169,9 +169,9 @@
     var updateStatus = function() {
       if(pointAssetToSave && !isValidServicePoint()){
         element.prop('disabled', true);
-      } else if (selectedMassTransitStopModel.isDirty() && !selectedMassTransitStopModel.requiredPropertiesMissing()
-          && !selectedMassTransitStopModel.hasMixedVirtualAndRealStops() && !selectedMassTransitStopModel.pikavuoroIsAlone()
-          && !selectedMassTransitStopModel.wrongStopTypeOnWalkingCyclingLink()){
+      } else if (selectedMassTransitStopModel.isDirty() && !selectedMassTransitStopModel.requiredPropertiesMissing() &&
+          !selectedMassTransitStopModel.hasMixedVirtualAndRealStops() && !selectedMassTransitStopModel.pikavuoroIsAlone() &&
+          !selectedMassTransitStopModel.wrongStopTypeOnWalkingCyclingLink()){
         element.prop('disabled', false);
       } else if(poistaSelected) {
         element.prop('disabled', false);

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -3,6 +3,7 @@
   var poistaSelected = false;
   var authorizationPolicy;
   var pointAssetToSave = false;
+  var tramStopToSave = false;
 
   var rootElement = $("#feature-attributes");
 
@@ -124,6 +125,11 @@
             selectedMassTransitStopModel.deleteMassTransitStop(poistaSelected);
           }
         });
+      } else if(tramStopToSave) {
+        new GenericConfirmPopup('Oletko varma, että haluat luoda pysäkin kävelyn ja pyöräilyn väylälle?', {
+          successCallback: function () {
+            saveStop();
+          }});
       } else if (pointAssetToSave) {
         saveStop();
       } else {
@@ -1085,6 +1091,10 @@
           updateViranomaisdataaValue();
 
           pointAssetToSave = true;
+        }
+
+        if (property.publicId === "pysakin_tyyppi" && _.some(property.values, function (value) {return value.propertyValue === 1;})) {
+          tramStopToSave = true;
         }
 
       });

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -21,7 +21,29 @@
     return _.find(selectedMassTransitStopModel.getCurrentAsset().payload.properties, {'publicId' : public_id});
   }
 
-  var ValidationErrorLabel = function() {
+  var walkingCyclingErrorLabel = function() {
+    var element = $('<span class="validation-error">Vain raitiovaunupysäkki voidaan tallentaa kävelyn ja pyöräilyn väylälle</span>');
+    var updateVisibility = function() {
+      if(selectedMassTransitStopModel.wrongStopTypeOnWalkingCyclingLink()) {
+        element.show();
+      }
+      else {
+        element.hide();
+      }
+    };
+
+    updateVisibility();
+
+    eventbus.on('asset:moved assetPropertyValue:changed', function() {
+      updateVisibility();
+    }, this);
+
+    return {
+      element: element
+    };
+  };
+
+  var missingInfoLabel = function() {
     var element = $('<span class="validation-error">Pakollisia tietoja puuttuu</span>');
 
     var updateVisibility = function() {
@@ -233,7 +255,9 @@
 
         var buttons = function (busStopTypeSelected) {
           return $('<div/>').addClass('mass-transit-stop').addClass('form-controls')
-              .append(new ValidationErrorLabel().element)
+              .append(new walkingCyclingErrorLabel().element)
+              .append($('<br>'))
+              .append(new missingInfoLabel().element)
               .append(new SaveButton(busStopTypeSelected).element)
               .append(new CancelButton().element);
         };

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -203,7 +203,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   var pointTool = new PointsCursorTool(eventListener, assetLayer, selectControl, roadCollection, {
     style : function(feature) {
       return massTransitStopLayerStyles.default.getStyle(feature, {zoomLevel: zoomlevels.isInRoadLinkZoomLevel(zoomlevels.getViewZoom(map))});
-    }
+    },
+    walkingCycling : false
   });
 
   roadLayer.setLayerSpecificStyleProvider('massTransitStop', function() {
@@ -938,6 +939,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     });
     eventListener.listenTo(eventbus, 'massTransitStop-complementaryLinks:show', showWithComplementary);
     eventListener.listenTo(eventbus, 'massTransitStop-complementaryLinks:hide', hideComplementary);
+    eventListener.listenTo(eventbus, 'massTransitStop-walkingCyclingLinks:show', toggleWalkingCyclingLinks);
+    eventListener.listenTo(eventbus, 'massTransitStop-walkingCyclingLinks:hide', toggleWalkingCyclingLinks);
     eventListener.listenTo(eventbus, 'road-type:selected', roadLayer.toggleRoadTypeWithSpecifiedStyle);
 
     eventListener.listenTo(eventbus, 'application:readOnly', toggleMode);
@@ -981,6 +984,10 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     roadAddressInfoPopup.start();
     hideClusterLayer();
     me.show(map);
+  };
+
+  var toggleWalkingCyclingLinks = function() {
+    pointTool.toggleWalkingCycling();
   };
 
   var showWithComplementary = function() {

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -474,7 +474,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   var createNewAsset = function(coordinate, placement, stopTypes) {
 
     var default_asset_direction = {BothDirections: 2, TowardsDigitizing: 2, AgainstDigitizing: 3};
-    var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadCollection.getRoadsForPointAssets()), coordinate.x, coordinate.y);
+    var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadCollection.getRoadsForCarPedestrianCycling()), coordinate.x, coordinate.y);
     var lon, lat;
 
     if(nearestLine.end && nearestLine.start){

--- a/UI/src/view/point_asset/pointsCursorTool.js
+++ b/UI/src/view/point_asset/pointsCursorTool.js
@@ -32,15 +32,28 @@
       });
     };
 
-    var updateByPosition = function(mousePoint) {
-      var nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(), mousePoint[0], mousePoint[1]);
-      var projectionOnNearestLine = geometrycalculator.nearestPointOnLine(nearestLine, { x: mousePoint[0], y:mousePoint[1] });
+    var toggleWalkingCycling = function () {
+      settings.walkingCycling = settings.walkingCycling !== true;
+    };
+
+    var updateByPosition = function (mousePoint) {
+      var nearestLine;
+      if (settings.walkingCycling === true) {
+        nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForCarPedestrianCycling(), mousePoint[0], mousePoint[1]);
+      } else {
+        nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(), mousePoint[0], mousePoint[1]);
+      }
+      var projectionOnNearestLine = geometrycalculator.nearestPointOnLine(nearestLine, {
+        x: mousePoint[0],
+        y: mousePoint[1]
+      });
       moveTo(projectionOnNearestLine.x, projectionOnNearestLine.y);
     };
 
     return {
       activate: activate,
-      deactivate: deactivate
+      deactivate: deactivate,
+      toggleWalkingCycling: toggleWalkingCycling
     };
   };
 })(this);

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -378,6 +378,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     val massTransitStop = massTransitStopReturned._1.map { stop =>
 
       Map("id" -> stop.id,
+        "linkId" -> stop.linkId,
         "nationalId" -> stop.nationalId,
         "stopTypes" -> stop.stopTypes,
         "lat" -> stop.lat,

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -260,7 +260,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
   test("update asset admin id by CSV import") {
     val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockService)
 
-    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil))).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
+    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil))).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
     val csv = massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1, "ylläpitäjän tunnus" -> "NewAdminId"))
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, Set())
 
@@ -271,7 +271,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
   test("Should not update asset LiVi id by CSV import") {
     val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockService)
 
-    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
+    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
     val csv = massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1, "liVi-tunnus" -> "Livi987654"))
 
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, Set()) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
@@ -282,7 +282,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
   test("update asset stop code by CSV import") {
     val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockService)
 
-    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
+    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
     val csv = massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1, "matkustajatunnus" -> "H156"))
 
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
@@ -293,7 +293,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
   test("update additional information by CSV import", Tag("db")) {
     val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockService)
 
-    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
+    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
 
     val csv = massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1, "lisätiedot" -> "Updated additional info"))
 
@@ -338,7 +338,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
   test("update asset's properties in a generic manner", Tag("db")) {
     val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockService)
 
-    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
+    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
     val csv =  massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1) ++ massTransitStopImporterUpdate.mappings.mapValues(exampleValues(_)._2))
 
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, Set()) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
@@ -367,7 +367,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
     val mockService = MockitoSugar.mock[MassTransitStopService]
     val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockService)
 
-    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
+    when(mockService.getMassTransitStopByNationalId(ArgumentMatchers.eq(1l), anyObject(), anyBoolean())).thenReturn(Some(MassTransitStopWithProperties(1, "", 1, Nil, 0.0, 0.0, None, None, None, false, Nil)))
     val assetFields = massTransitStopImporterUpdate.defaultValues(Map("valtakunnallinen id" -> 1))
     val csv = massTransitStopImporterUpdate.csvRead(assetFields).map(fields => fields.filterNot(field => field._1 == "pysäkin nimi"))
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -24,7 +24,7 @@ case class MassTransitStop(id: Long, nationalId: Long, lon: Double, lat: Double,
                            validityDirection: Int, municipalityNumber: Int,
                            validityPeriod: String, floating: Boolean, stopTypes: Seq[Int]) extends FloatingAsset
 
-case class MassTransitStopWithProperties(id: Long, nationalId: Long, stopTypes: Seq[Int], lon: Double, lat: Double,
+case class MassTransitStopWithProperties(id: Long, linkId: String = "", nationalId: Long, stopTypes: Seq[Int], lon: Double, lat: Double,
                                          validityDirection: Option[Int], bearing: Option[Int],
                                          validityPeriod: Option[String], floating: Boolean,
                                          propertyData: Seq[Property], municipalityName: Option[String] = None) extends FloatingAsset
@@ -570,7 +570,7 @@ trait MassTransitStopService extends PointAssetOperations {
   private def persistedStopToMassTransitStopWithProperties(roadLinkByLinkId: String => Option[RoadLinkLike], getMunicipalityName: Int => Option[String] = _ => None)
                                                           (persistedStop: PersistedMassTransitStop): (MassTransitStopWithProperties, Option[FloatingReason]) = {
     val (floating, floatingReason) = isFloating(persistedStop, roadLinkByLinkId(persistedStop.linkId))
-    (MassTransitStopWithProperties(id = persistedStop.id, nationalId = persistedStop.nationalId, stopTypes = persistedStop.stopTypes,
+    (MassTransitStopWithProperties(id = persistedStop.id, linkId = persistedStop.linkId, nationalId = persistedStop.nationalId, stopTypes = persistedStop.stopTypes,
       lon = persistedStop.lon, lat = persistedStop.lat, validityDirection = persistedStop.validityDirection,
       bearing = persistedStop.bearing, validityPeriod = persistedStop.validityPeriod, floating = floating,
       propertyData = persistedStop.propertyData, municipalityName = getMunicipalityName(persistedStop.municipalityCode)), floatingReason)


### PR DESCRIPTION
- Lisätty checkBox "Salli pysäkin luonti kävelyn ja pyöräilyn väylälle (vain raitiovaunupysäkit)", jonka ollessa enabled sallitaan lisäystyökalun kursorin liikkuminen käpy-väylilllä
- lisätty uusi virhe label jos yritetään lisätä käpy-väylälle väärän tyyppistä pysäkkiä
- Lisätty tarkastus pysäkin tallennukseen(jos käpy-linkki, pysäkin tyyppi voi olla vain ratikka)
- backEnd palauttaa linkId:n pysäkille kun haetaan asset (tarvitaan UI:lla muokattavan pysäkin linkin löytämiseksi)
- Lisätty PopUp "Oletko varma, että haluat luoda pysäkin kävelyn ja pyöräilyn väylälle?" kun tallennetaan käpy-väylälle ratikkapysäkkiä