### PR TITLE
Droth 3744 enable tram stops on pedestrian links

### DIFF
--- a/UI/src/controller/roadCollection.js
+++ b/UI/src/controller/roadCollection.js
@@ -39,6 +39,11 @@
         linkTypes.PedestrianZone.value, linkTypes.CableFerry.value, linkTypes.Unknown.value], data.linkType);
     };
 
+    var isPedestrianCyclingRoad = function () {
+      return !_.isUndefined(data.linkType) && _.includes([linkTypes.CycleOrPedestrianPath.value,
+        linkTypes.PedestrianZone.value], data.linkType);
+    };
+
     var isCarPedestrianCyclingRoad = function() {
       return !_.isUndefined(data.linkType) && !_.includes([linkTypes.CableFerry.value, linkTypes.Unknown.value], data.linkType);
     };
@@ -61,6 +66,7 @@
       setLinkProperty: setLinkProperty,
       isSelected: isSelected,
       isCarTrafficRoad: isCarTrafficRoad,
+      isPedestrianCyclingRoad: isPedestrianCyclingRoad,
       isCarPedestrianCyclingRoad: isCarPedestrianCyclingRoad,
       select: select,
       unselect: unselect,

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -148,6 +148,7 @@
       currentAsset.payload.lat = position.lat;
       currentAsset.payload.roadLinkId = position.roadLinkId;
       currentAsset.payload.linkId = position.linkId;
+      currentAsset.linkId = position.linkId;
       currentAsset.payload.validityDirection = position.validityDirection;
       assetHasBeenModified = true;
       changedProps = _.union(changedProps, ['bearing', 'lon', 'lat', 'roadLinkId']);

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -247,12 +247,20 @@
       });
     };
 
+    var isWalkingCyclingLink = function () {
+      var selectedRoadLink = getRoadLink();
+      if (_.isEmpty(selectedRoadLink)) {
+        return false;
+      } else {
+        return selectedRoadLink.isPedestrianCyclingRoad();
+      }
+    };
+
     var wrongStopTypeOnWalkingCyclingLink = function () {
       var selectedRoadLink = getRoadLink();
       if (_.isEmpty(selectedRoadLink)) {
         return false;
       } else {
-        var isCarTrafficRoad = selectedRoadLink.isCarTrafficRoad();
         var isOnlyTramStop = _.some(currentAsset.payload.properties, function (property) {
           if (property.publicId == massTransitStopTypePublicId) {
             return _.some(property.values, function (propertyValue) {
@@ -261,7 +269,7 @@
           }
           return false;
         });
-        if (!isCarTrafficRoad) {
+        if (isWalkingCyclingLink()) {
           return !isOnlyTramStop;
         } else {
           return false;
@@ -666,6 +674,7 @@
       hasMixedVirtualAndRealStops:hasMixedVirtualAndRealStops,
       pikavuoroIsAlone: pikavuoroIsAlone,
       wrongStopTypeOnWalkingCyclingLink: wrongStopTypeOnWalkingCyclingLink,
+      isWalkingCyclingLink: isWalkingCyclingLink,
       copyDataFromOtherMasTransitStop: copyDataFromOtherMasTransitStop,
       getCurrentAsset: getCurrentAsset,
       deleteMassTransitStop: deleteMassTransitStop,

--- a/UI/src/view/navigationpanel/massTransitStopBox.js
+++ b/UI/src/view/navigationpanel/massTransitStopBox.js
@@ -114,7 +114,7 @@
         '<input id="complementaryLinkCheckBox" type="checkbox" checked/> <lable>Näytä täydentävä geometria</lable>' +
         '</div>' +
         '<div class="check-box-container">' +
-        '<input id="walkingCyclingCheckbox" type="checkbox" unchecked/> <lable>Salli pysäkin luonti kävelyn ja pyöräilyn väylälle (vain raitiovaunupysäkit)</lable>' +
+        '<input id="walkingCyclingCheckbox" type="checkbox" unchecked/> <lable>Salli raitiovaunupysäkin luonti kävelyn ja pyöräilyn väylälle</lable>' +
         '</div>' +
         '</div>'
       ].join('');

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -3,7 +3,6 @@
   var poistaSelected = false;
   var authorizationPolicy;
   var pointAssetToSave = false;
-  var tramStopToSave = false;
 
   var rootElement = $("#feature-attributes");
 
@@ -110,6 +109,15 @@
   }
 
   var SaveButton = function(busStopTypeSelected) {
+    function saveWithPossibleWalkingCyclingPopUp() {
+      if(selectedMassTransitStopModel.isWalkingCyclingLink()){
+        new GenericConfirmPopup('Oletko varma, että haluat luoda pysäkin kävelyn ja pyöräilyn väylälle?', {
+          successCallback: function () {
+            saveStop();
+          }});
+      } else saveStop();
+    }
+
     var deleteMessage = 'pysäkin';
 
     if (selectedMassTransitStopModel.isTerminalType(busStopTypeSelected))
@@ -125,34 +133,29 @@
             selectedMassTransitStopModel.deleteMassTransitStop(poistaSelected);
           }
         });
-      } else if(tramStopToSave) {
-        new GenericConfirmPopup('Oletko varma, että haluat luoda pysäkin kävelyn ja pyöräilyn väylälle?', {
-          successCallback: function () {
-            saveStop();
-          }});
       } else if (pointAssetToSave) {
-        saveStop();
+        saveWithPossibleWalkingCyclingPopUp();
       } else {
         if(optionalSave()){
           if(saveNewBusStopStrategy()) {
             new GenericConfirmPopup('Koska tämä bussipysäkki on määritetty vihjeeksi se ei saa LIVI-tunnusta. Haluatko silti tallentaa sen OTH:ssa?', {
               successCallback: function () {
                 selectedMassTransitStopModel.setAdditionalProperty('liviIdSave', [{ propertyValue: 'false' }]);
-                saveStop();
+                saveWithPossibleWalkingCyclingPopUp();
               }});
           } else {
             new GenericConfirmPopup('Haluatko antaa LIVI-tunnuksen?', {
               successCallback: function () {
-                saveStop();
+                saveWithPossibleWalkingCyclingPopUp();
               },
               closeCallback: function () {
                 selectedMassTransitStopModel.setAdditionalProperty('liviIdSave', [{ propertyValue: 'false' }]);
-                saveStop();
+                saveWithPossibleWalkingCyclingPopUp();
               }
             });
           }
         } else {
-          saveStop();
+          saveWithPossibleWalkingCyclingPopUp();
         }
       }
     });
@@ -1093,10 +1096,6 @@
           updateViranomaisdataaValue();
 
           pointAssetToSave = true;
-        }
-
-        if (property.publicId === "pysakin_tyyppi" && _.some(property.values, function (value) {return value.propertyValue === 1;})) {
-          tramStopToSave = true;
         }
 
       });

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -10,6 +10,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   var selectedAsset;
   var movementPermissionConfirmed = false;
   var requestingMovePermission  = false;
+  var walkingCyclingLinks = false;
   var massTransitStopLayerStyles = PointAssetLayerStyles(roadLayer);
   var visibleAssets;
   var overrideMessageAllow = true;
@@ -158,6 +159,14 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
 
   var dragControl = defineOpenLayersDragControl();
 
+  function getCorrectRoadLinks() {
+    if(walkingCyclingLinks) {
+      return roadCollection.getRoadsForCarPedestrianCycling();
+    } else {
+      return roadCollection.getRoadsForPointAssets();
+    }
+  }
+
   function defineOpenLayersDragControl() {
 
     var dragControl = new ol.interaction.Translate({
@@ -167,7 +176,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     dragControl.set('name', 'translate_massTransitStop');
 
     var translateSelectedAsset = function(event) {
-      var nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(),event.coordinate[0], event.coordinate[1]);
+      var roadLinks = getCorrectRoadLinks();
+      var nearestLine = geometrycalculator.findNearestLine(roadLinks, event.coordinate[0], event.coordinate[1]);
       var angle = geometrycalculator.getLineDirectionDegAngle(nearestLine);
       var position = geometrycalculator.nearestPointOnLine(nearestLine, { x: event.coordinate[0], y: event.coordinate[1]});
 
@@ -176,7 +186,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     };
 
     var translateEndedAsset = function(event){
-      var nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(),event.coordinate[0], event.coordinate[1]);
+      var roadLinks = getCorrectRoadLinks();
+      var nearestLine = geometrycalculator.findNearestLine(roadLinks, event.coordinate[0], event.coordinate[1]);
       var angle = geometrycalculator.getLineDirectionDegAngle(nearestLine);
       var position = geometrycalculator.nearestPointOnLine(nearestLine, { x: event.coordinate[0], y: event.coordinate[1]});
 
@@ -474,7 +485,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   var createNewAsset = function(coordinate, placement, stopTypes) {
 
     var default_asset_direction = {BothDirections: 2, TowardsDigitizing: 2, AgainstDigitizing: 3};
-    var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadCollection.getRoadsForCarPedestrianCycling()), coordinate.x, coordinate.y);
+    var roadLinks = getCorrectRoadLinks();
+    var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks), coordinate.x, coordinate.y);
     var lon, lat;
 
     if(nearestLine.end && nearestLine.start){
@@ -681,7 +693,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
         },
         closeCallback: function(){
           //Moves the stop to the original position
-          var nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(), originalCoordinates.lon, originalCoordinates.lat);
+          var roadLinks = getCorrectRoadLinks();
+          var nearestLine = geometrycalculator.findNearestLine(roadLinks, originalCoordinates.lon, originalCoordinates.lat);
           var angle = geometrycalculator.getLineDirectionDegAngle(nearestLine);
           doMovement(event, angle, nearestLine, originalCoordinates);
           roadLayer.clearSelection();
@@ -732,7 +745,9 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
 
       selectedMassTransitStopModel.move({
         lon: event.coordinate[0],
-        lat: event.coordinate[1]
+        lat: event.coordinate[1],
+        roadLinkId: nearestLine.roadLinkId,
+        linkId: nearestLine.linkId
       });
     }
   };
@@ -987,6 +1002,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   };
 
   var toggleWalkingCyclingLinks = function() {
+    walkingCyclingLinks = !walkingCyclingLinks;
     pointTool.toggleWalkingCycling();
   };
 

--- a/UI/src/view/point_asset/pointsCursorTool.js
+++ b/UI/src/view/point_asset/pointsCursorTool.js
@@ -33,7 +33,7 @@
     };
 
     var toggleWalkingCycling = function () {
-      settings.walkingCycling = settings.walkingCycling !== true;
+      settings.walkingCycling = !settings.walkingCycling;
     };
 
     var updateByPosition = function (mousePoint) {


### PR DESCRIPTION
Tehty omassa, sekä operaattoritestauksessa havaitut korjaustarpeet:

- CheckBoxin teksti tiivistetty haluttuun muotoon
- Tallennus-painikkeen yhteydessä korjattu popUp ilmoitusten toiminta eri tilanteissa
- Korjattu bugeja liittyen pysäkkien liikuttamiseen käpy-väylien ja auto-väylien välillä