### PR TITLE
Droth 3728 expired ely admined bus stops can be redeployed with same national

### DIFF
--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -938,10 +938,6 @@
             });
         });
 
-        if (isBusStopExpired && isTRMassTransitStop)  {
-          readOnly = true;
-        }
-
         if(authorizationPolicy.isActiveTrStopWithoutPermission(isBusStopExpired, isTRMassTransitStop))
           readOnly = true;
       }


### PR DESCRIPTION
- Kattaa myös DROTH-3727 samoilla muutoksilla.
- Poistaa front endistä poikkeuskäsittelyn, jolla estetään vanhentuneiden/geometrialta pudonneiden ELY-pysäkkien muokkaus ja tallennus.
- Perusteluna muuttuneet käytännöt, joiden myötä kyseiset pysäkit eivät enää ole riippuvaisia Tierekisterin vastineista.