### PR TITLE
Droth 3808 improve bus stop integration api

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -51,6 +51,13 @@ case class RoadLink(linkId: String, geometry: Seq[Point],
   def isPaved : Boolean = surfaceType == SurfaceType.Paved.value
   def isNotPaved : Boolean = surfaceType == SurfaceType.None.value
 
+  def extractRoadNumber(roadLink: RoadLinkLike) = {
+    roadLink.attributes.find(_._1 == "ROADNUMBER") match {
+      case Some((key, value)) => Try(value.toString.toInt).toOption
+      case _ => None
+    }
+  }
+
   def extractMTKClass(attributes: Map[String, Any]): MTKClassWidth = {
     Try(attributes("MTKCLASS").asInstanceOf[BigInt])
       .map(_.toInt)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -50,7 +50,6 @@ case class RoadLink(linkId: String, geometry: Seq[Point],
   //TODO isPaved = !isNotPaved = SurfaceType.apply(surfaceType) match {case SurfaceType.Paved => true case _ => false
   def isPaved : Boolean = surfaceType == SurfaceType.Paved.value
   def isNotPaved : Boolean = surfaceType == SurfaceType.None.value
-  
   def extractMTKClass(attributes: Map[String, Any]): MTKClassWidth = {
     Try(attributes("MTKCLASS").asInstanceOf[BigInt])
       .map(_.toInt)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -50,6 +50,7 @@ case class RoadLink(linkId: String, geometry: Seq[Point],
   //TODO isPaved = !isNotPaved = SurfaceType.apply(surfaceType) match {case SurfaceType.Paved => true case _ => false
   def isPaved : Boolean = surfaceType == SurfaceType.Paved.value
   def isNotPaved : Boolean = surfaceType == SurfaceType.None.value
+
   def extractMTKClass(attributes: Map[String, Any]): MTKClassWidth = {
     Try(attributes("MTKCLASS").asInstanceOf[BigInt])
       .map(_.toInt)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -50,14 +50,7 @@ case class RoadLink(linkId: String, geometry: Seq[Point],
   //TODO isPaved = !isNotPaved = SurfaceType.apply(surfaceType) match {case SurfaceType.Paved => true case _ => false
   def isPaved : Boolean = surfaceType == SurfaceType.Paved.value
   def isNotPaved : Boolean = surfaceType == SurfaceType.None.value
-
-  def extractRoadNumber(roadLink: RoadLinkLike) = {
-    roadLink.attributes.find(_._1 == "ROADNUMBER") match {
-      case Some((key, value)) => Try(value.toString.toInt).toOption
-      case _ => None
-    }
-  }
-
+  
   def extractMTKClass(attributes: Map[String, Any]): MTKClassWidth = {
     Try(attributes("MTKCLASS").asInstanceOf[BigInt])
       .map(_.toInt)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
@@ -262,7 +262,7 @@ trait  PointAssetOperations{
     }
   }
 
-  protected def getByMunicipalityTransOption(withFilter: String => String, newTransaction: Boolean = true): Seq[PersistedAsset] = {
+  protected def getByMunicipality(withFilter: String => String, newTransaction: Boolean = true): Seq[PersistedAsset] = {
     if (newTransaction)
       withDynTransaction {
         fetchPointAssets(withFilter).toList

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
@@ -262,6 +262,15 @@ trait  PointAssetOperations{
     }
   }
 
+  protected def getByMunicipalityTransOption(withFilter: String => String, newTransaction: Boolean = true): Seq[PersistedAsset] = {
+    if (newTransaction)
+      withDynTransaction {
+        fetchPointAssets(withFilter).toList
+      }
+    else fetchPointAssets(withFilter).toList
+
+  }
+
   def getById(id: Long): Option[PersistedAsset] = {
     val persistedAsset = getPersistedAssetsByIds(Set(id)).headOption
     val roadLinks: Option[RoadLinkLike] = persistedAsset.flatMap { x => roadLinkService.getRoadLinkByLinkId(x.linkId) }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -36,7 +36,7 @@ case class AddrWithIdentifier(identifier: String, roadAddress: RoadAddress)
 case class PointWithIdentifier(identifier: String, point: Point)
 
 object VKMClient { // singleton client
- lazy val client: CloseableHttpClient = ClientUtils.clientBuilder()
+ lazy val client: CloseableHttpClient = ClientUtils.clientBuilder(5000,5000)
 }
 
 class VKMClient {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -105,10 +105,12 @@ class VKMClient {
   }
 
   private def request(url: String): Either[FeatureCollection, VKMError] = {
+    ClientUtils.retry(5, logger, commentForFailing = s"Failing url: $url") {requestBase(url)}
+  }
+  private def requestBase(url: String): Either[FeatureCollection, VKMError] = {
     val request = new HttpGet(url)
     request.addHeader("X-API-Key", Digiroad2Properties.vkmApiKey)
-    val client = HttpClientBuilder.create() .setDefaultRequestConfig(RequestConfig.custom()
-      .setCookieSpec(CookieSpecs.STANDARD).build()).build()
+    val client = VKMClient.client
     val response = client.execute(request)
     try {
       if (response.getStatusLine.getStatusCode >= 400) {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -207,7 +207,7 @@ class VKMClient {
   private def baseRequest( params: Seq[Map[String, Any]]) = {
     val jsonValue = Serialization.write(params)
     val url = vkmBaseUrl + "muunna/"
-    val response = ClientUtils.retry(3, logger, commentForFailing = s"JSON payload for failing: $jsonValue") {postRequest(url, jsonValue)}
+    val response = ClientUtils.retry(5, logger, commentForFailing = s"JSON payload for failing: $jsonValue") {postRequest(url, jsonValue)}
     val result = response match {
       case Left(address) => address.features.map(feature => mapMassQueryFields(feature))
       case Right(error) => throw new RoadAddressException(error.toString)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -26,22 +26,17 @@ import org.slf4j.LoggerFactory
 import java.nio.charset.Charset
 import java.util.ArrayList
 
-case class MassQueryParams(identifier: String, point: Point, roadNumber: Option[Long], roadPartNumber: Option[Long])
 
-case class MassQueryParamsCoord(identifier: String, point: Point, roadNumber: Option[Int], roadPartNumber:  Option[Int],track: Option[Track] = None)
-case class DeterminateSide(identifier: String, points: Seq[Point], roadNumber: Int, roadPartNumber: Int,track: Option[Track] = None)
-case class MassQuery(id:Long,coord: Point, heading: Option[Int], mValue: Double, linkId: String, assetSideCode: Option[Int], municipalityCode: Option[Int] = None, road: Option[Int] = None)
-
-
-  case class MassQueryResolve(asset: Long, coord: Point, heading: Option[Int], sideCode: SideCode, road: Option[Int] = None,
-                              roadPart: Option[Int] = None,
-                              includePedestrian: Option[Boolean] = Option(false))
+case class MassQueryParamsCoord(identifier: String, point: Point, roadNumber: Option[Int], roadPartNumber: Option[Int], track: Option[Track] = None)
+case class DeterminateSide(identifier: String, points: Seq[Point], roadNumber: Int, roadPartNumber: Int, track: Option[Track] = None)
+case class PointAssetForConversion(id: Long, coord: Point, heading: Option[Int], mValue: Double, linkId: String, sideCode: Option[Int], municipalityCode: Option[Int] = None, road: Option[Int] = None)
+case class MassQueryResolve(asset: Long, coord: Point, heading: Option[Int], sideCode: SideCode, road: Option[Int] = None, roadPart: Option[Int] = None, includePedestrian: Option[Boolean] = Option(false))
 case class RoadAddressBoundToAsset(asset: Long, address: RoadAddress, side: RoadSide)
 case class AddrWithIdentifier(identifier: String, roadAddress: RoadAddress)
 case class PointWithIdentifier(identifier: String, point: Point)
 
 object VKMClient { // singleton client
- lazy val client: CloseableHttpClient = ClientUtils.clientBuilder(10000,10000)
+ lazy val client: CloseableHttpClient = ClientUtils.clientBuilder()
 }
 
 class VKMClient {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -215,7 +215,7 @@ class VKMClient {
         val id = a._1
         val address = a._2.map(_._2)
         if (address.size >= 2) {
-          // TODO fix this logic same time you fix GET method.
+          // TODO fix this logic same time you fix coordToAddress method.
           logger.info(s"Search distance was too big to identify single response, identifier was $id and result: ${address.mkString(",")}")
         }
         (id, address.head)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -347,7 +347,7 @@ class VKMClient {
       MassQueryParamsCoord(s"${asset.identifier}:front", asset.points(2), Some(asset.roadNumber), Some(asset.roadPartNumber), asset.track)
     )
     
-    val addresses = coordToAddressMassQuery(params, searchDistance = Some(7.0)).toSeq
+    val addresses = coordToAddressMassQuery(params, searchDistance = Some(5.0)).toSeq
 
     val behind = addresses.find(_._1.split(":")(1) == "behind").getOrElse(throw new RoadAddressException(errorMessage))._2
     val correct = addresses.find(_._1.split(":")(1) == "correct").getOrElse(throw new RoadAddressException(errorMessage))._2

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -423,23 +423,6 @@ class VKMClient {
     }
   }
 
-  private def validateAndConvertToIntOpt(fieldName: String, map: Map[String, Any]) = {
-    def value = map.get(fieldName).asInstanceOf[Option[BigInt]]
-
-    if (value.isEmpty) {
-      logger.error("Missing mandatory field in response: %s".format(
-          fieldName))
-      None
-    }
-    try {
-      value.get.toInt
-    } catch {
-      case e: NumberFormatException =>
-        logger.error("Invalid value in response: %s, Int expected, got '%s'".format(fieldName, value.get))
-        None
-    }
-  }
-
   private def convertToDouble(value: Option[Any]): Option[Double] = {
     value.map {
       case x: Object =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -215,6 +215,7 @@ class VKMClient {
         val id = a._1
         val address = a._2.map(_._2)
         if (address.size >= 2) {
+          // TODO fix this logic same time you fix GET method.
           logger.info(s"Search distance was too big to identify single response, identifier was $id and result: ${address.mkString(",")}")
         }
         (id, address.head)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MassTransitStopDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MassTransitStopDao.scala
@@ -627,6 +627,9 @@ class MassTransitStopDao {
   def withId(id: Long)(query: String): String = {
     query + s" where a.id = $id"
   }
+  def withIds(ids: Seq[Long])(query: String): String = {
+    query + s" where a.id in (${ids.mkString(",")})"
+  }
 
   def withTerminalId(terminalId: Long)(query: String): String = {
     query + s" where terminal_asset_id = $terminalId and (a.valid_to is null or a.valid_to > current_timestamp)"

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
@@ -124,9 +124,7 @@ class BusStopStrategy(val typeId : Int, val massTransitStopDao: MassTransitStopD
   }
 
   override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] ={
-    val roadAddressAdded = LogUtils.time(logger, s"TEST LOG addRoadAddress ") {
-      addRoadAddress(persistedStops,links)
-    }
+     val roadAddressAdded = addRoadAddress(persistedStops,links)
     addTerminals(roadAddressAdded)
   }
 
@@ -147,13 +145,9 @@ class BusStopStrategy(val typeId : Int, val massTransitStopDao: MassTransitStopD
       }
     }
 
-    val query = LogUtils.time(logger, s"TEST LOG create mass query") {
-      assets.map(mapToQuery(links, _)).filter(_.isDefined).map(_.get)
-    }
-    LogUtils.time(logger, s"TEST LOG conversion and mapping tooks") {
-      val roadAddress = geometryTransform.resolveMultipleAddressAndLocations(query)
-      assets.map(mapAssetToRoadAddress(roadAddress, _))
-    }
+    val query = assets.map(mapToQuery(links, _)).filter(_.isDefined).map(_.get)
+    val roadAddress = geometryTransform.resolveMultipleAddressAndLocations(query)
+    assets.map(mapAssetToRoadAddress(roadAddress, _))
   }
 
   private def extractRoadNumber(link: RoadLinkLike) = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
@@ -123,7 +123,7 @@ class BusStopStrategy(val typeId : Int, val massTransitStopDao: MassTransitStopD
     }
   }
 
-  def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] ={
+  override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] ={
     val roadAddressAdded = LogUtils.time(logger, s"TEST LOG addRoadAddress ") {
       addRoadAddress(persistedStops,links)
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
@@ -123,17 +123,17 @@ class BusStopStrategy(val typeId : Int, val massTransitStopDao: MassTransitStopD
     }
   }
 
-  override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] ={
-     val roadAddressAdded = addRoadAddress(persistedStops,links)
+  override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] = {
+    val roadAddressAdded = addRoadAddress(persistedStops, links)
     addTerminals(roadAddressAdded)
   }
 
   private def addRoadAddress(assets: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] = {
     def mapToQuery(links: Seq[RoadLink], stop: PersistedMassTransitStop): Option[PointAssetForConversion] = {
       links.find(_.linkId == stop.linkId) match {
-        case Some(link) => 
+        case Some(link) =>
           val road = extractRoadNumber(link)
-          Some(PointAssetForConversion(stop.id, Point(stop.lon, stop.lat), stop.bearing, stop.mValue, stop.linkId, stop.validityDirection, road = road ))
+          Some(PointAssetForConversion(stop.id, Point(stop.lon, stop.lat), stop.bearing, stop.mValue, stop.linkId, stop.validityDirection, road = road))
         case None => None
       }
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -452,20 +452,11 @@ trait MassTransitStopService extends PointAssetOperations {
   }
 
   def getByMunicipality(municipalityCode: Int, withEnrich: Boolean): Seq[PersistedAsset] = {
-    logger.info("request start")
-    LogUtils.time(logger, s"TEST LOG getByMunicipality tooks") {
       withDynSession {
-        val assets = LogUtils.time(logger, s"TEST LOG getByMunicipality from DB") {
-          super.getByMunicipality(withMunicipality(municipalityCode), false)
-        }
-
-        val links = LogUtils.time(logger, s"TEST LOG fetch roadlink") {
-          fetchRoadLinks(assets.map(_.linkId).toSet)
-        }
-
+        val assets = super.getByMunicipality(withMunicipality(municipalityCode), false)
+        val links = fetchRoadLinks(assets.map(_.linkId).toSet)
         if (withEnrich) enrichBusStops(assets,links) else assets
       }
-    }
   }
   
   def getFloatingAssetsWithReason(includedMunicipalities: Option[Set[Int]], isOperator: Option[Boolean] = None): Map[String, Map[String, Seq[Map[String, Long]]]] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -453,7 +453,7 @@ trait MassTransitStopService extends PointAssetOperations {
 
   def getByMunicipality(municipalityCode: Int, withEnrich: Boolean): Seq[PersistedAsset] = {
       withDynSession {
-        val assets = LogUtils.time(logger, s"Getting Bus Stop by Municipality from municipality ${municipalityCode}") {
+        val assets = LogUtils.time(logger, s"Getting Bus Stop by municipality code from municipality ${municipalityCode}") {
           super.getByMunicipality(withMunicipality(municipalityCode), false)
         }
         val links = fetchRoadLinks(assets.map(_.linkId).toSet)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -280,9 +280,9 @@ trait MassTransitStopService extends PointAssetOperations {
 
   override def getNormalAndComplementaryById(id: Long, roadLink: RoadLink): Option[PersistedAsset] = {
     val persistedAsset = getPersistedAssetsByIds(Set(id)).headOption
-    val roadLinks: Option[RoadLink] = Some(roadLink)
+    val roadLinks: Option[RoadLinkLike] = Some(roadLink)
 
-    def findRoadlink(linkId: String): Option[RoadLink] =
+    def findRoadlink(linkId: String): Option[RoadLinkLike] =
       roadLinks.find(_.linkId == linkId)
 
     withDynSession {
@@ -709,7 +709,7 @@ trait MassTransitStopService extends PointAssetOperations {
     massTransitStopDao.deleteNumberPropertyValue(assetId, "kellumisen_syy")
   }
 
-  private def fetchRoadLink(linkId: String): Option[RoadLink] = {
+  private def fetchRoadLink(linkId: String): Option[RoadLinkLike] = {
     roadLinkService.getRoadLinkAndComplementaryByLinkId(linkId, newTransaction = false)
   }
   private def fetchRoadLinks(linkIds: Set[String]): Seq[RoadLink] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -490,7 +490,7 @@ trait MassTransitStopService extends PointAssetOperations {
     LogUtils.time(logger, s"TEST LOG getByMunicipality tooks") {
       withDynSession {
         val assets = LogUtils.time(logger, s"TEST LOG getByMunicipality from DB") {
-          super.getByMunicipalityTransOption(withMunicipality(municipalityCode), false)
+          super.getByMunicipality(withMunicipality(municipalityCode), false)
         }
         logger.info(s"assets count: ${assets.size}")
         val roadAddressAdded = LogUtils.time(logger, s"TEST LOG addRoadAddress ") {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -568,7 +568,7 @@ trait MassTransitStopService extends PointAssetOperations {
       assets.map(mapToQuery(links, _)).filter(_.isDefined).map(_.get)
     }
     LogUtils.time(logger, s"TEST LOG conversion and mapping tooks") {
-      val roadAddress = geometryTransform.resolveAddressAndLocationM(query)
+      val roadAddress = geometryTransform.resolveMultipleAddressAndLocations(query)
       assets.map(mapAssetToRoadAddress(roadAddress, _))
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -453,9 +453,14 @@ trait MassTransitStopService extends PointAssetOperations {
 
   def getByMunicipality(municipalityCode: Int, withEnrich: Boolean): Seq[PersistedAsset] = {
       withDynSession {
-        val assets = super.getByMunicipality(withMunicipality(municipalityCode), false)
+        val assets = LogUtils.time(logger, s"Getting Bus Stop by Municipality from municipality ${municipalityCode}") {
+          super.getByMunicipality(withMunicipality(municipalityCode), false)
+        }
         val links = fetchRoadLinks(assets.map(_.linkId).toSet)
-        if (withEnrich) enrichBusStops(assets,links) else assets
+        if (withEnrich) 
+          LogUtils.time(logger, s"Bus Stop enrichment") {
+          enrichBusStops(assets,links)} 
+        else assets
       }
   }
   

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
@@ -65,8 +65,8 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
     massTransitStopDao.updateTextPropertyValue(existingAsset.id, MassTransitStopOperations.LiViIdentifierPublicId, null)
   }
 
-  override def enrichBusStop(persistedStop: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None): (PersistedMassTransitStop, Boolean) = {
-    val enrichPersistedStop = { super.enrichBusStop(persistedStop, roadLinkOption)._1 }
+  override def enrichBusStop(persistedStop: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None, terminalAdded:Boolean = false): (PersistedMassTransitStop, Boolean) = {
+    val enrichPersistedStop = { super.enrichBusStop(persistedStop, roadLinkOption,terminalAdded)._1 }
     if(enrichPersistedStop.id !=0 ){
       (enrichPersistedStop,true)
     }else{

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
@@ -73,6 +73,10 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
     }
     
   }
+
+  override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] = {
+    persistedStops
+  }
   
   override def publishSaveEvent(publishInfo: AbstractPublishInfo): Unit = {
     super.publishSaveEvent(publishInfo)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
@@ -2,12 +2,11 @@ package fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop
 
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.dao.{AssetPropertyConfiguration, MassTransitStopDao, Queries, Sequences}
+import fi.liikennevirasto.digiroad2.dao.{AssetPropertyConfiguration, MassTransitStopDao, Sequences}
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.util.GeometryTransform
-import org.joda.time.format.DateTimeFormat
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
 
 object OthBusStopLifeCycleBusStopStrategy{
@@ -31,7 +30,7 @@ object OthBusStopLifeCycleBusStopStrategy{
 
 class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopDao, roadLinkService: RoadLinkService, eventbus: DigiroadEventBus, geometryTransform: GeometryTransform) extends BusStopStrategy(typeId, massTransitStopDao, roadLinkService, eventbus, geometryTransform)
 {
-  lazy val logger = LoggerFactory.getLogger(getClass)
+  override lazy val logger: Logger = LoggerFactory.getLogger(getClass)
 
   val toLiviId = "OTHJ%d"
   val MaxMovementDistanceMeters = 50
@@ -65,8 +64,8 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
     massTransitStopDao.updateTextPropertyValue(existingAsset.id, MassTransitStopOperations.LiViIdentifierPublicId, null)
   }
 
-  override def enrichBusStop(persistedStop: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None, terminalAdded:Boolean = false): (PersistedMassTransitStop, Boolean) = {
-    val enrichPersistedStop = { super.enrichBusStop(persistedStop, roadLinkOption,terminalAdded)._1 }
+  override def enrichBusStop(persistedStop: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None): (PersistedMassTransitStop, Boolean) = {
+    val enrichPersistedStop = { super.enrichBusStop(persistedStop, roadLinkOption)._1 }
     if(enrichPersistedStop.id !=0 ){
       (enrichPersistedStop,true)
     }else{

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
@@ -15,6 +15,11 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
   private val terminalChildrenPublicId = "liitetyt_pysakit"
   private val validityDirectionPublicId = "vaikutussuunta"
   private val ignoredProperties = Seq(terminalChildrenPublicId, validityDirectionPublicId)
+  
+  def isTerminal( properties: Seq[AbstractProperty]):Boolean ={
+    properties.exists(p => p.publicId == MassTransitStopOperations.MassTransitStopTypePublicId &&
+      p.values.exists(v => v.asInstanceOf[PropertyValue].propertyValue == BusStopType.Terminal.value.toString))
+  }
 
   override def is(newProperties: Set[SimplePointAssetProperty], roadLink: Option[RoadLink], existingAssetOption: Option[PersistedMassTransitStop]): Boolean = {
     //If the stop have the property stop type with the terminal value
@@ -26,9 +31,7 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
           filterNot(property => AssetPropertyConfiguration.commonAssetProperties.exists(_._1 == property.publicId))
       case _ => newProperties.toSeq
     }
-
-    properties.exists(p => p.publicId == MassTransitStopOperations.MassTransitStopTypePublicId &&
-      p.values.exists(v => v.asInstanceOf[PropertyValue].propertyValue == BusStopType.Terminal.value.toString))
+    isTerminal(properties)
   }
 
   override def enrichBusStop(asset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None,terminalAdded:Boolean = false): (PersistedMassTransitStop, Boolean) = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
@@ -31,7 +31,7 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
       p.values.exists(v => v.asInstanceOf[PropertyValue].propertyValue == BusStopType.Terminal.value.toString))
   }
 
-  override def enrichBusStop(asset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None): (PersistedMassTransitStop, Boolean) = {
+  override def enrichBusStop(asset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None,terminalAdded:Boolean = false): (PersistedMassTransitStop, Boolean) = {
     val childFilters =  massTransitStopDao.fetchByRadius(Point(asset.lon, asset.lat), radiusMeters, Some(asset.id))
       .filter(a =>  a.terminalId.isEmpty || a.terminalId.contains(asset.id))
       .filter(a => !MassTransitStopOperations.extractStopType(a).contains(BusStopType.Terminal))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
@@ -15,8 +15,8 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
   private val terminalChildrenPublicId = "liitetyt_pysakit"
   private val validityDirectionPublicId = "vaikutussuunta"
   private val ignoredProperties = Seq(terminalChildrenPublicId, validityDirectionPublicId)
-  
-  def isTerminal( properties: Seq[AbstractProperty]):Boolean ={
+
+  def isTerminal(properties: Seq[AbstractProperty]): Boolean = {
     properties.exists(p => p.publicId == MassTransitStopOperations.MassTransitStopTypePublicId &&
       p.values.exists(v => v.asInstanceOf[PropertyValue].propertyValue == BusStopType.Terminal.value.toString))
   }
@@ -55,7 +55,7 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
     val selectTerminalsIds = selectTerminals.map(_.id)
     persistedStops.filterNot(a => selectTerminalsIds.contains(a.id)) ++ selectTerminals.map(addChild(persistedStops, _))
   }
-  
+
   private def addChild(potentialChild: Seq[PersistedMassTransitStop], terminal: PersistedMassTransitStop): PersistedMassTransitStop = {
     val childFilters = potentialChild.filter(a => a.terminalId.contains(terminal.id))
       .filter(a => !MassTransitStopOperations.extractStopType(a).contains(BusStopType.Terminal))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
@@ -34,15 +34,34 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
     isTerminal(properties)
   }
 
-  override def enrichBusStop(asset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None,terminalAdded:Boolean = false): (PersistedMassTransitStop, Boolean) = {
-    if(!terminalAdded) {
+  def extractTerminalChilds(terminal: PersistedMassTransitStop, childFilters: Seq[PersistedMassTransitStop]): Property = {
+     Property(0, terminalChildrenPublicId, PropertyTypes.MultipleChoice, required = true, values = childFilters.map { a =>
+      val stopName = MassTransitStopOperations.extractStopName(a.propertyData)
+      PropertyValue(a.id.toString, Some(s"""${a.nationalId} $stopName"""), checked = a.terminalId.contains(terminal.id))
+    })
+  }
+
+  override def enrichBusStop(asset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None): (PersistedMassTransitStop, Boolean) = {
       val childFilters = massTransitStopDao.fetchByRadius(Point(asset.lon, asset.lat), radiusMeters, Some(asset.id))
         .filter(a => a.terminalId.isEmpty || a.terminalId.contains(asset.id))
         .filter(a => !MassTransitStopOperations.extractStopType(a).contains(BusStopType.Terminal))
         .filter(a => !MassTransitStopOperations.extractStopType(a).contains(BusStopType.ServicePoint))
-      val newProperty: Property = super.extractTerminalChilds(asset, childFilters)
+      val newProperty: Property = extractTerminalChilds(asset, childFilters)
       (asset.copy(propertyData = asset.propertyData.filterNot(p => p.publicId == terminalChildrenPublicId) ++ Seq(newProperty)), false)
-    } else (asset,false)
+  }
+
+  override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] = {
+    val selectTerminals = persistedStops.filter(a => isTerminal(a.propertyData))
+    val selectTerminalsIds = selectTerminals.map(_.id)
+    persistedStops.filterNot(a => selectTerminalsIds.contains(a.id)) ++ selectTerminals.map(addChild(persistedStops, _))
+  }
+  
+  private def addChild(potentialChild: Seq[PersistedMassTransitStop], terminal: PersistedMassTransitStop): PersistedMassTransitStop = {
+    val childFilters = potentialChild.filter(a => a.terminalId.contains(terminal.id))
+      .filter(a => !MassTransitStopOperations.extractStopType(a).contains(BusStopType.Terminal))
+      .filter(a => !MassTransitStopOperations.extractStopType(a).contains(BusStopType.ServicePoint))
+    val newProperty: Property = extractTerminalChilds(terminal, childFilters)
+    terminal.copy(propertyData = terminal.propertyData.filterNot(p => p.publicId == terminalChildrenPublicId) ++ Seq(newProperty))
   }
   
   override def isFloating(persistedAsset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike]): (Boolean, Option[FloatingReason]) = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
@@ -21,6 +21,10 @@ class TerminatedBusStopStrategy(typeId: Int, massTransitStopDao: MassTransitStop
     properties.filter(prop => defaultChanges.contains(prop.publicId)).map(_.values).toSeq.diff(asset.propertyData.filter(prop => defaultChanges.contains(prop.publicId)).map(_.values)).nonEmpty
   }
 
+  override def enrichBusStopsOperation(persistedStops: Seq[PersistedMassTransitStop], links: Seq[RoadLink]): Seq[PersistedMassTransitStop] = {
+    persistedStops
+  }
+  
   override def create(asset: NewMassTransitStop, username: String, point: Point, roadLink: RoadLink): (PersistedMassTransitStop, AbstractPublishInfo) = {
     throw new UnsupportedOperationException
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ClientUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ClientUtils.scala
@@ -31,10 +31,11 @@ object ClientUtils {
     }
   }
 
-  def clientBuilder(maxConnTotal: Int = 1000,
-                            maxConnPerRoute: Int = 1000,
-                            timeout: Int = 60 * 1000
-                           ): CloseableHttpClient = {
+  def clientBuilder(
+                     maxConnTotal: Int = 1000,
+                     maxConnPerRoute: Int = 1000,
+                     timeout: Int = 60 * 1000
+                   ): CloseableHttpClient = {
     HttpClientBuilder.create()
       .setDefaultRequestConfig(
         RequestConfig.custom()

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ClientUtils.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/ClientUtils.scala
@@ -1,6 +1,9 @@
 package fi.liikennevirasto.digiroad2.util
 
+import org.apache.http.client.config.{CookieSpecs, RequestConfig}
+import org.apache.http.impl.client.{CloseableHttpClient, HttpClientBuilder}
 import org.slf4j.Logger
+
 import scala.annotation.tailrec
 
 object ClientUtils {
@@ -26,5 +29,22 @@ object ClientUtils {
         else throw e
       
     }
+  }
+
+  def clientBuilder(maxConnTotal: Int = 1000,
+                            maxConnPerRoute: Int = 1000,
+                            timeout: Int = 60 * 1000
+                           ): CloseableHttpClient = {
+    HttpClientBuilder.create()
+      .setDefaultRequestConfig(
+        RequestConfig.custom()
+          .setCookieSpec(CookieSpecs.STANDARD)
+          .setSocketTimeout(timeout)
+          .setConnectTimeout(timeout)
+          .build()
+      )
+      .setMaxConnTotal(maxConnTotal)
+      .setMaxConnPerRoute(maxConnPerRoute)
+      .build()
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
@@ -117,9 +117,7 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
   }
   def resolveMultipleAddressAndLocations(assets: Seq[PointAssetForConversion]): Seq[RoadAddressBoundToAsset] = {
     val roadAddress = roadAddressService.getAllByLinkIds(assets.map(_.linkId))
-    val foundFromViite = LogUtils.time(logger, s"Map viite road address to assets") {
-      assets.map(mapRoadAddressToAsset(roadAddress, _)).filter(_.isDefined).map(_.get)
-    }
+    val foundFromViite = assets.map(mapRoadAddressToAsset(roadAddress, _)).filter(_.isDefined).map(_.get)
     val allReadyMapped = foundFromViite.map(_.asset)
     val stillMissing = assets.filterNot(a => allReadyMapped.contains(a.id))
     logger.info(s"still missing road address: ${stillMissing.size}")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.util
 
 
 import fi.liikennevirasto.digiroad2.asset.SideCode
-import fi.liikennevirasto.digiroad2.client.{MassQuery, MassQueryParamsCoord, MassQueryResolve, RoadAddressBoundToAsset, VKMClient}
+import fi.liikennevirasto.digiroad2.client.{PointAssetForConversion, MassQueryParamsCoord, MassQueryResolve, RoadAddressBoundToAsset, VKMClient}
 import fi.liikennevirasto.digiroad2.client.viite.ViiteClientException
 import fi.liikennevirasto.digiroad2.service.{RoadAddressForLink, RoadAddressService}
 import fi.liikennevirasto.digiroad2.{Point, RoadAddress, RoadAddressException, Track}
@@ -65,23 +65,8 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
       })
     }
   }
-
+  
   def resolveAddressAndLocation(coord: Point, heading: Int, mValue: Double, linkId: String, assetSideCode: Int, municipalityCode: Option[Int] = None, road: Option[Int] = None): (RoadAddress, RoadSide) = {
-
-    def againstDigitizing(addr: RoadAddressForLink) = {
-      val addressLength: Long = addr.endAddrMValue - addr.startAddrMValue
-      val lrmLength: Double = Math.abs(addr.endMValue - addr.startMValue)
-      val newMValue = (addr.endAddrMValue - ((mValue-addr.startMValue) * addressLength / lrmLength)).toInt
-      RoadAddress(Some(municipalityCode.toString), addr.roadNumber.toInt, addr.roadPartNumber.toInt, addr.track, newMValue)
-    }
-
-    def towardsDigitizing (addr: RoadAddressForLink) = {
-      val addressLength: Long = addr.endAddrMValue - addr.startAddrMValue
-      val lrmLength: Double = Math.abs(addr.endMValue - addr.startMValue)
-      val newMValue = (((mValue-addr.startMValue) * addressLength) / lrmLength + addr.startAddrMValue).toInt
-      RoadAddress(Some(municipalityCode.toString), addr.roadNumber.toInt, addr.roadPartNumber.toInt, addr.track, newMValue)
-    }
-
     val roadAddress =
       try {
         roadAddressService.getByLrmPosition(linkId, mValue)
@@ -95,6 +80,24 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
     if(roadAddress.isEmpty && road.isDefined)
       return vkmClient.resolveAddressAndLocation(coord, heading, SideCode.apply(assetSideCode), road)
 
+    determinateRoadSide(mValue, assetSideCode, municipalityCode, roadAddress)
+  }
+  
+  private def againstDigitizing(addr: RoadAddressForLink, mValue: Double, municipalityCode: Option[Int]): RoadAddress = {
+    val addressLength: Long = addr.endAddrMValue - addr.startAddrMValue
+    val lrmLength: Double = Math.abs(addr.endMValue - addr.startMValue)
+    val newMValue = (addr.endAddrMValue - ((mValue - addr.startMValue) * addressLength / lrmLength)).toInt
+    RoadAddress(Some(municipalityCode.toString), addr.roadNumber.toInt, addr.roadPartNumber.toInt, addr.track, newMValue)
+  }
+
+  private def towardsDigitizing(addr: RoadAddressForLink, mValue: Double, municipalityCode: Option[Int]): RoadAddress = {
+    val addressLength: Long = addr.endAddrMValue - addr.startAddrMValue
+    val lrmLength: Double = Math.abs(addr.endMValue - addr.startMValue)
+    val newMValue = (((mValue - addr.startMValue) * addressLength) / lrmLength + addr.startAddrMValue).toInt
+    RoadAddress(Some(municipalityCode.toString), addr.roadNumber.toInt, addr.roadPartNumber.toInt, addr.track, newMValue)
+  }
+
+  private def determinateRoadSide(mValue: Double, assetSideCode: Int, municipalityCode: Option[Int], roadAddress: Option[RoadAddressForLink]): (RoadAddress, RoadSide) = {
     val roadSide = roadAddress match {
       case Some(addrSide) if addrSide.sideCode.value == assetSideCode => RoadSide.Right //TowardsDigitizing //
       case Some(addrSide) if addrSide.sideCode.value != assetSideCode => RoadSide.Left //AgainstDigitizing //
@@ -104,34 +107,33 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
     val address = roadAddress match {
       case Some(addr) if addr.track.eq(Track.Unknown) => throw new RoadAddressException("Invalid value for Track: %d".format(addr.track.value))
       case Some(addr) if addr.sideCode.value != assetSideCode =>
-        if (assetSideCode == SideCode.AgainstDigitizing.value) towardsDigitizing(addr) else againstDigitizing(addr)
+        if (assetSideCode == SideCode.AgainstDigitizing.value) towardsDigitizing(addr, mValue, municipalityCode) else againstDigitizing(addr, mValue, municipalityCode)
       case Some(addr) =>
-        if (assetSideCode == SideCode.TowardsDigitizing.value) towardsDigitizing(addr) else againstDigitizing(addr)
+        if (assetSideCode == SideCode.TowardsDigitizing.value) towardsDigitizing(addr, mValue, municipalityCode) else againstDigitizing(addr, mValue, municipalityCode)
       case None => throw new RoadAddressException("No road address found")
     }
 
-    (address, roadSide )
+    (address, roadSide)
   }
-
-
-
-  def resolveAddressAndLocationM(assets: Seq[MassQuery]): Seq[RoadAddressBoundToAsset] = {
-    //val roadAddress = roadAddressService.getAllByLinkIds(assets.map(_.linkId))
-
-  /*  assets.map(a=> { // TODO check viability of this
-      val address = roadAddress.filter(_.linkId == a.linkId).sortBy(_.startAddrMValue)
-      val aPosition = a.mValue
-      
-      address.find(a=> {
-        val startAddrM = a.startAddrMValue
-        val endAddrM = a.endAddrMValue
-        aPosition<=endAddrM && startAddrM>=aPosition
-      }
-      )
-      //RoadAddressBoundToAsset()
-    })*/
-    
-    vkmClient.resolveAddressAndLocations(assets.map(a=>MassQueryResolve(a.id,a.coord,a.heading,SideCode.apply(a.assetSideCode.get),a.road) ))
+  def resolveAddressAndLocationM(assets: Seq[PointAssetForConversion]): Seq[RoadAddressBoundToAsset] = {
+    val roadAddress = roadAddressService.getAllByLinkIds(assets.map(_.linkId))
+    val foundFromViite = LogUtils.time(logger, s"Map viite road address to assets") {
+      assets.map(mapRoadAddressToAsset(roadAddress, _)).filter(_.isDefined).map(_.get)
+    }
+    val allReadyMapped = foundFromViite.map(_.asset)
+    val stillMissing = assets.filterNot(a => allReadyMapped.contains(a.id)).filter(_.road.isDefined)
+    logger.info(s"still missing road address: ${stillMissing.size}")
+    val foundFromVKM = vkmClient.resolveAddressAndLocations(stillMissing.map(a => MassQueryResolve(a.id, a.coord, a.heading, SideCode.apply(a.sideCode.get), a.road)))
+    foundFromVKM ++ foundFromViite
+  }
+  private def mapRoadAddressToAsset(roadAddress: Seq[RoadAddressForLink], asset: PointAssetForConversion): Option[RoadAddressBoundToAsset] = {
+    // copy pasted from Viite code base Search API
+    roadAddress.find(ra => ra.linkId == asset.linkId && (ra.startMValue >= asset.mValue || ra.startMValue < asset.mValue && asset.mValue < ra.endMValue)) match {
+      case Some(selected) =>
+        val (roadAddress, side) = determinateRoadSide(asset.mValue, asset.sideCode.get, asset.municipalityCode, Some(selected))
+        Some(RoadAddressBoundToAsset(asset.id, roadAddress, side))
+      case None => None
+    }
   }
 }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
@@ -2,7 +2,7 @@ package fi.liikennevirasto.digiroad2.util
 
 
 import fi.liikennevirasto.digiroad2.asset.SideCode
-import fi.liikennevirasto.digiroad2.client.VKMClient
+import fi.liikennevirasto.digiroad2.client.{MassQuery, MassQueryParamsCoord, MassQueryResolve, RoadAddressBoundToAsset, VKMClient}
 import fi.liikennevirasto.digiroad2.client.viite.ViiteClientException
 import fi.liikennevirasto.digiroad2.service.{RoadAddressForLink, RoadAddressService}
 import fi.liikennevirasto.digiroad2.{Point, RoadAddress, RoadAddressException, Track}
@@ -111,6 +111,12 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
     }
 
     (address, roadSide )
+  }
+
+
+
+  def resolveAddressAndLocationM(assets: Seq[MassQuery]): Seq[RoadAddressBoundToAsset] = {
+    vkmClient.resolveAddressAndLocations(assets.map(a=>MassQueryResolve(a.id,a.coord,a.heading,SideCode.apply(a.assetSideCode),a.road) ))
   }
 }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
@@ -116,7 +116,22 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
 
 
   def resolveAddressAndLocationM(assets: Seq[MassQuery]): Seq[RoadAddressBoundToAsset] = {
-    vkmClient.resolveAddressAndLocations(assets.map(a=>MassQueryResolve(a.id,a.coord,a.heading,SideCode.apply(a.assetSideCode),a.road) ))
+    //val roadAddress = roadAddressService.getAllByLinkIds(assets.map(_.linkId))
+
+  /*  assets.map(a=> { // TODO check viability of this
+      val address = roadAddress.filter(_.linkId == a.linkId).sortBy(_.startAddrMValue)
+      val aPosition = a.mValue
+      
+      address.find(a=> {
+        val startAddrM = a.startAddrMValue
+        val endAddrM = a.endAddrMValue
+        aPosition<=endAddrM && startAddrM>=aPosition
+      }
+      )
+      //RoadAddressBoundToAsset()
+    })*/
+    
+    vkmClient.resolveAddressAndLocations(assets.map(a=>MassQueryResolve(a.id,a.coord,a.heading,SideCode.apply(a.assetSideCode.get),a.road) ))
   }
 }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/GeometryTransform.scala
@@ -115,7 +115,7 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
 
     (address, roadSide)
   }
-  def resolveAddressAndLocationM(assets: Seq[PointAssetForConversion]): Seq[RoadAddressBoundToAsset] = {
+  def resolveMultipleAddressAndLocations(assets: Seq[PointAssetForConversion]): Seq[RoadAddressBoundToAsset] = {
     val roadAddress = roadAddressService.getAllByLinkIds(assets.map(_.linkId))
     val foundFromViite = LogUtils.time(logger, s"Map viite road address to assets") {
       assets.map(mapRoadAddressToAsset(roadAddress, _)).filter(_.isDefined).map(_.get)
@@ -129,8 +129,8 @@ class GeometryTransform(roadAddressService: RoadAddressService) {
   private def mapRoadAddressToAsset(roadAddress: Seq[RoadAddressForLink], asset: PointAssetForConversion): Option[RoadAddressBoundToAsset] = {
     // copy pasted from Viite code base Search API get by LRM
     // will return the road addresses with the start and end measure in between mValue or start measure equal or greater than mValue
-    def selectRoadAddress(ra: RoadAddressForLink,asset: PointAssetForConversion) = {
-      val isBetween =  ra.startMValue < asset.mValue && asset.mValue < ra.endMValue
+    def selectRoadAddress(ra: RoadAddressForLink, asset: PointAssetForConversion): Boolean = {
+      val isBetween = ra.startMValue < asset.mValue && asset.mValue < ra.endMValue
       ra.linkId == asset.linkId && (ra.startMValue >= asset.mValue || isBetween)
     }
     roadAddress.find(selectRoadAddress(_,asset)) match {


### PR DESCRIPTION
Paranettu performanssia käyttäen HTTP POST kun haetaan tieosoitteita.
Ei tehdä jatkuvasti pieniä kantakyselyitä.
Käsitellään terminaalit jo haetuilla bussi pysäkeillä.
Lisätty uudelleen yrittelyä siltä varalta että tulee connection reset, nyt kun käytetään connection pool.

Pilkottu koodia paljon pienempiin osiin jotta vanhaa logiikaa voisi uudelleen käyttää tehokkaasti.

DEV kanta dumpilla tehdyillä testeillä haut helsingissä saatu menemään 1 minuutissa. Ennen meni 10 minuuttia tai enemmän.