### PR TITLE
Droth 3802 allow tramp stops on pedestrian ways during csv import

### DIFF
--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -481,7 +481,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
     runWithRollback {
       val xCoord = 2
       val yCoord = 2
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(Seq[RoadLink]())
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(Seq.empty[RoadLink])
 
       val assetFields = Map("koordinaatti x" -> xCoord, "koordinaatti y" -> yCoord, "pysäkin tyyppi" -> "2", "tietojen ylläpitäjä" -> "1")
       val csv = massTransitStopImporterCreate.csvRead(assetFields)


### PR DESCRIPTION
-korjattu rikkinäinen syntaksi