### PR TITLE
 DROTH-3744 Fixed error which led to all links being treated as pedestrian

### DIFF
--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -3,7 +3,6 @@
   var poistaSelected = false;
   var authorizationPolicy;
   var pointAssetToSave = false;
-  var tramStopToSave = false;
 
   var rootElement = $("#feature-attributes");
 
@@ -131,11 +130,6 @@
             selectedMassTransitStopModel.deleteMassTransitStop(poistaSelected);
           }
         });
-      } else if(tramStopToSave) {
-        new GenericConfirmPopup('Oletko varma, että haluat luoda pysäkin kävelyn ja pyöräilyn väylälle?', {
-          successCallback: function () {
-            saveStop();
-          }});
       } else if (pointAssetToSave) {
         saveWithPossibleWalkingCyclingPopUp();
       } else {
@@ -1098,10 +1092,6 @@
           updateViranomaisdataaValue();
 
           pointAssetToSave = true;
-        }
-
-        if (property.publicId === "pysakin_tyyppi" && _.some(property.values, function (value) {return value.propertyValue === 1;})) {
-          tramStopToSave = true;
         }
 
       });


### PR DESCRIPTION
Merge conflictista johtunut bugi korjattu.
Poistettu vanhentunut tramStopToSave-muuttuja ja siihen sidonnainen logiikka.
Testattu lopputulosta seuraavasti:

- Luodaan ratikkapysäkki autotielle, ei pitäisi tulla käpy-varoitusta ---> OK
- Luodaan bussipysäkki autotielle, ei pitäisi tulla käpy-varoitusta ---> OK

- Luodaan ensin ratikkapysäkki käpy-väylälle, pitäisi tulla käpy-varoitus ---> OK
- Luodaan seuraavaksi ratikkapysäkki autotielle, ei pitäisi tulla käpy-varoitusta ---> OK
- Luodaan lopuksi bussipysäkki autotielle, ei pitäisi tulla käpy-varoitusta ---> OK