### PR TITLE
Droth 3727 floating ely admined bus stops keep national id when reattached to geometry

### DIFF
--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -149,7 +149,6 @@
       currentAsset.payload.roadLinkId = position.roadLinkId;
       currentAsset.payload.linkId = position.linkId;
       currentAsset.payload.validityDirection = position.validityDirection;
-      currentAsset.payload.municipalityCode = position.municipalityCode;
       assetHasBeenModified = true;
       changedProps = _.union(changedProps, ['bearing', 'lon', 'lat', 'roadLinkId']);
       eventbus.trigger('asset:moved', position);

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -149,6 +149,7 @@
       currentAsset.payload.roadLinkId = position.roadLinkId;
       currentAsset.payload.linkId = position.linkId;
       currentAsset.payload.validityDirection = position.validityDirection;
+      currentAsset.payload.municipalityCode = position.municipalityCode;
       assetHasBeenModified = true;
       changedProps = _.union(changedProps, ['bearing', 'lon', 'lat', 'roadLinkId']);
       eventbus.trigger('asset:moved', position);

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -71,10 +71,6 @@ trait AbstractBusStopStrategy {
   def delete(asset: PersistedMassTransitStop): Option[AbstractPublishInfo]
   def pickRoadLink(optRoadLink: Option[RoadLink], optHistoric: Option[RoadLink]): RoadLink = {optRoadLink.getOrElse(throw new NoSuchElementException)}
 
-  /***
-   * Removes LiViId TextPropertyValue from the given MassTransitStop
-   * @param existingAsset
-   */
   def undoLiviId(existingAsset: PersistedMassTransitStop): Unit = {
     massTransitStopDao.updateTextPropertyValue(existingAsset.id, MassTransitStopOperations.LiViIdentifierPublicId, null)
   }
@@ -315,7 +311,7 @@ trait MassTransitStopService extends PointAssetOperations {
 
   }
 
-  def updateExistingById(assetId: Long, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, newTransaction: Boolean = true, liviId: Option[String] = None): MassTransitStopWithProperties = {
+  def updateExistingById(assetId: Long, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, newTransaction: Boolean = true): MassTransitStopWithProperties = {
     def updateExistingById() = {
       val asset = fetchPointAssets(massTransitStopDao.withId(assetId)).headOption.getOrElse(throw new NoSuchElementException)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
@@ -60,11 +60,6 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
   stopLiviId.isDefined && OthBusStopLifeCycleBusStopStrategy.isOthLiviId(existingAsset.propertyData, administrationClass)
   }
 
-  override def undo(existingAsset: PersistedMassTransitStop, newProperties: Set[SimplePointAssetProperty], username: String): Unit = {
-    //Remove the Livi ID
-    massTransitStopDao.updateTextPropertyValue(existingAsset.id, MassTransitStopOperations.LiViIdentifierPublicId, null)
-  }
-
   override def enrichBusStop(persistedStop: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike] = None): (PersistedMassTransitStop, Boolean) = {
     val enrichPersistedStop = { super.enrichBusStop(persistedStop, roadLinkOption)._1 }
     if(enrichPersistedStop.id !=0 ){

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
@@ -54,5 +54,4 @@ class TerminatedBusStopStrategy(typeId: Int, massTransitStopDao: MassTransitStop
   }
 
   override def isFloating(persistedAsset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike]): (Boolean, Option[FloatingReason]) = { (true, Some(FloatingReason.TerminatedRoad)) }
-
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
@@ -1,13 +1,13 @@
 package fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop
 
 import java.util.NoSuchElementException
-
 import fi.liikennevirasto.digiroad2.{DigiroadEventBus, FloatingReason, Point}
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, Position, Property, PropertyValue, SimplePointAssetProperty}
 import fi.liikennevirasto.digiroad2.dao.{AssetPropertyConfiguration, MassTransitStopDao}
 import fi.liikennevirasto.digiroad2.linearasset.{RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.masstransitstop.MassTransitStopOperations._
+import fi.liikennevirasto.digiroad2.util.DataFixture.massTransitStopService.updateFloating
 import fi.liikennevirasto.digiroad2.util.GeometryTransform
 
 class TerminatedBusStopStrategy(typeId: Int, massTransitStopDao: MassTransitStopDao, roadLinkService: RoadLinkService, eventbus: DigiroadEventBus, geometryTransform: GeometryTransform) extends BusStopStrategy(typeId, massTransitStopDao, roadLinkService, eventbus, geometryTransform) {
@@ -45,11 +45,14 @@ class TerminatedBusStopStrategy(typeId: Int, massTransitStopDao: MassTransitStop
 
     municipalityValidation(asset.municipalityCode, roadLink.administrativeClass)
     massTransitStopDao.updateAssetLastModified(asset.id, username)
+    optionalPosition.map(updatePositionWithBearing(asset.id, roadLink))
+    updateFloating(asset.id, false, None)
     updatePropertiesForAsset(asset.id, properties.toSeq, roadLink.administrativeClass, asset.nationalId)
 
-    val resultAsset = enrichBusStop(fetchAsset(asset.id))._1
+    val resultAsset = enrichBusStop(asset.copy(linkId = roadLink.linkId))._1
     (resultAsset, PublishInfo(Some(resultAsset)))
   }
 
   override def isFloating(persistedAsset: PersistedMassTransitStop, roadLinkOption: Option[RoadLinkLike]): (Boolean, Option[FloatingReason]) = { (true, Some(FloatingReason.TerminatedRoad)) }
+
 }


### PR DESCRIPTION
Geometrialta pudonneiden pysäkkien palautus mahdollistettu niin, että nationalID säilyy. Mikäli ylläpitäjä on kunta, LiVi-tunnus poistetaan.