### PR TITLE
Droth 3727 floating ely admined bus stops keep national id when reattached to geometry to development

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
@@ -24,13 +24,6 @@ object BusStopType {
   case object Unknown extends BusStopType { def value = 99 }
 }
 
-object BusStopAdministrator {
-  case object Municipality { def value = 1 }
-  case object Ely {def value = 2 }
-  case object HSL { def value = 3 }
-}
-
-
 object MassTransitStopOperations {
   val toIso8601 = DateTimeFormat.forPattern("yyyy-MM-dd")
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -363,7 +363,7 @@ trait MassTransitStopService extends PointAssetOperations {
       val roadLink = currentStrategy.pickRoadLink(optRoadLink, optHistoric)
       val newProperties = excludeProperties(properties.toSeq)
 
-      if (properties.exists(property => property.publicId == "tietojen_yllapitaja" && property.values.head == PropertyValue(BusStopAdministrator.Municipality.value.toString)))
+      if (properties.exists(property => property.publicId == "tietojen_yllapitaja" && property.values.head == PropertyValue(MassTransitStopOperations.MunicipalityPropertyValue)))
         previousStrategy.undoLiviId(asset)
 
       val (persistedAsset, publishInfo) = currentStrategy.update(asset, optionalPosition, newProperties, username, municipalityValidation, roadLink)


### PR DESCRIPTION
Poistettu ylimääräinen enum ja muutettu tarkistustapaa.