### PR TITLE
Droth 3493 fix bugs

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -724,7 +724,7 @@ class AssetFiller {
   }
 
   /**
-    * Removes obsoleted mvalue adjustments and side code adjustments from the list
+    * Removes adjustments that were overwritten later. The latest adjustment has to be preserved.
     *
     * @param roadLink
     * @param assets

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -732,35 +732,6 @@ class AssetFiller {
     * @return
     */
   def clean(roadLink: RoadLinkForFillTopology, assets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet): (Seq[PieceWiseLinearAsset], ChangeSet) = {
-    /**
-      * Remove adjustments that were overwritten later (new version appears later in the sequence)
-      *
-      * @param adj list of adjustments
-      * @return list of adjustment final values
-      */
-    def prune(adj: Seq[MValueAdjustment]): Seq[MValueAdjustment] = {
-      if (adj.isEmpty)
-        return adj
-      adj.tail.exists(a => a.assetId == adj.head.assetId) match {
-        case true => prune(adj.tail)
-        case false => Seq(adj.head) ++ prune(adj.tail)
-      }
-    }
-
-    /**
-      * Remove side code adjustments that were overwritten
-      *
-      * @param adj original list
-      * @return list of final values
-      */
-    def pruneSideCodes(adj: Seq[SideCodeAdjustment]): Seq[SideCodeAdjustment] = {
-      if (adj.isEmpty)
-        return adj
-      adj.tail.exists(a => a.assetId == adj.head.assetId) match {
-        case true => pruneSideCodes(adj.tail)
-        case false => Seq(adj.head) ++ pruneSideCodes(adj.tail)
-      }
-    }
 
     val droppedIds = changeSet.droppedAssetIds
     val groupedMValueAdjustments = changeSet.adjustedMValues.filterNot(a => droppedIds.contains(a.assetId)).groupBy(_.assetId)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -763,14 +763,11 @@ class AssetFiller {
     }
 
     val droppedIds = changeSet.droppedAssetIds
-    //TODO remove logging after stackOverFlow error is fixed
-    val adjustmentsToPrune = changeSet.adjustedMValues.filterNot(a => droppedIds.contains(a.assetId))
-    logger.info(adjustmentsToPrune.toString())
-    val sideCodesToPrune = changeSet.adjustedSideCodes.filterNot(a => droppedIds.contains(a.assetId))
-    logger.info(sideCodesToPrune.toString())
-    val adjustments = prune(changeSet.adjustedMValues.filterNot(a => droppedIds.contains(a.assetId)))
-    val sideAdjustments = pruneSideCodes(changeSet.adjustedSideCodes.filterNot(a => droppedIds.contains(a.assetId)))
-    (assets, changeSet.copy(droppedAssetIds = Set(), expiredAssetIds = (changeSet.expiredAssetIds ++ changeSet.droppedAssetIds) -- Set(0), adjustedMValues = adjustments, adjustedSideCodes = sideAdjustments))
+    val groupedMValueAdjustments = changeSet.adjustedMValues.filterNot(a => droppedIds.contains(a.assetId)).groupBy(_.assetId)
+    val adjustments = groupedMValueAdjustments.map(grouped => grouped._2.last).toSeq
+    val groupedSideCodeAdjustments = changeSet.adjustedSideCodes.filterNot(a => droppedIds.contains(a.assetId)).groupBy(_.assetId)
+    val sideCodeAdjustments = groupedSideCodeAdjustments.map(grouped => grouped._2.last).toSeq
+    (assets, changeSet.copy(droppedAssetIds = Set(), expiredAssetIds = (changeSet.expiredAssetIds ++ changeSet.droppedAssetIds) -- Set(0), adjustedMValues = adjustments, adjustedSideCodes = sideCodeAdjustments))
 
   }
 

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.linearasset
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
 import fi.liikennevirasto.digiroad2.asset.SideCode.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
-import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment}
+import fi.liikennevirasto.digiroad2.linearasset.LinearAssetFiller.{ChangeSet, MValueAdjustment, SideCodeAdjustment}
 import fi.liikennevirasto.digiroad2.{GeometryUtils, Point}
 import org.joda.time.DateTime
 import org.scalatest._
@@ -606,7 +606,12 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(4.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(4.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)))
   }
 
 
@@ -637,8 +642,13 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(0.0, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(0.0)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0),
-      MValueAdjustment(3, linkId1, 0.0, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0),
+      MValueAdjustment(3, linkId1, 0.0, 10.0)))
   }
 
   test("two opposite side directions with smallest start measure are adjusted") {
@@ -668,7 +678,12 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(2.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 0.0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0.0, 2.9), MValueAdjustment(2, linkId1, 0.0, 2.9)))
   }
 
   test("only the one-sided limit with the smallest start measure is adjusted when the two smallest are on the same side") {
@@ -699,7 +714,12 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(5.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(5.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0.0, 2.9)))
   }
 
   test("two opposite side directions with largest end measure and the two-sided limit in the beginning are adjusted") {
@@ -729,8 +749,12 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(2.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(3, linkId1, 2.9, 10.0), MValueAdjustment(2, linkId1, 2.9, 10.0),
-      MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0), MValueAdjustment(3, linkId1, 2.9, 10.0)))
   }
 
   test("only the one-sided limit with the largest end measure is adjusted when the two largest are on the same side") {
@@ -761,7 +785,12 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(5.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(5.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(3, linkId1, 5.9, 10.0), MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(3, linkId1, 5.9, 10.0)))
   }
 
   test("Adjust start and end m-value when difference is 0.001") {
@@ -1196,5 +1225,15 @@ class AssetFillerSpec extends FunSuite with Matchers {
     outputAssets.size should be (1)
     changeSet.expiredAssetIds should have size 317
     outputAssets.head.id should be (18116559L)
+  }
+
+  test("clean lots of adjustments") {
+    val roadLink = assetFiller.toRoadLinkForFillTopology(RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None))
+    val adjustedMValues = List.tabulate(20000)(id => MValueAdjustment(id, generateRandomLinkId(), 0, Random.nextDouble() * 100))
+    val adjustedSideCodes = List.tabulate(20000)(id => SideCodeAdjustment(id, BothDirections, RoadWidth.typeId))
+    val changeSet = ChangeSet(Set(), adjustedMValues, adjustedSideCodes, Set(), Seq())
+    val result = assetFiller.clean(roadLink, Seq(), changeSet)
+    result._2.adjustedMValues.size should be(20000)
+    result._2.adjustedSideCodes.size should be(20000)
   }
 }

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -1236,4 +1236,19 @@ class AssetFillerSpec extends FunSuite with Matchers {
     result._2.adjustedMValues.size should be(20000)
     result._2.adjustedSideCodes.size should be(20000)
   }
+
+  test("clean takes the latest adjustment for each asset") {
+    val roadLink = assetFiller.toRoadLinkForFillTopology(RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality, 1, TrafficDirection.BothDirections, Motorway, None, None))
+    val adjustedMValuesId1 = List.tabulate(10)(id => MValueAdjustment(1, generateRandomLinkId(), 0, Random.nextDouble() * 100))
+    val adjustedMValuesId2 = List.tabulate(10)(id => MValueAdjustment(2, generateRandomLinkId(), 0, Random.nextDouble() * 100))
+    val adjustedMValuesId3 = List.tabulate(10)(id => MValueAdjustment(3, generateRandomLinkId(), 0, Random.nextDouble() * 100))
+    val changeSet = ChangeSet(Set(), adjustedMValuesId1 ++ adjustedMValuesId2 ++ adjustedMValuesId3, Nil, Set(), Seq())
+    val result = assetFiller.clean(roadLink, Seq(), changeSet)
+    result._2.adjustedMValues.filter(_.assetId == 1).size should be(1)
+    result._2.adjustedMValues.filter(_.assetId == 1).head should be(adjustedMValuesId1.last)
+    result._2.adjustedMValues.filter(_.assetId == 2).size should be(1)
+    result._2.adjustedMValues.filter(_.assetId == 2).head should be(adjustedMValuesId2.last)
+    result._2.adjustedMValues.filter(_.assetId == 3).size should be(1)
+    result._2.adjustedMValues.filter(_.assetId == 3).head should be(adjustedMValuesId3.last)
+  }
 }

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFillerSpec.scala
@@ -88,7 +88,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     filledTopology.head.geometry should be(Seq(Point(0.0, 0.0), Point(10.0, 0.0)))
     filledTopology.head.startMeasure should be(0.0)
     filledTopology.head.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 10.0)))
   }
 
   test("adjust two-sided speed limits from both ends leaving the middle limit intact") {
@@ -116,7 +121,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(4.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(4.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)))
   }
 
   test("adjust two-sided speed limits from both ends leaving the middle with two one-sided limits intact") {
@@ -150,7 +160,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(4.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(4.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(4, linkId1, 4.9, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(4, linkId1, 4.9, 10.0)))
   }
 
   test("adjust two-sided speed limits from both ends leaving the middle with one one-sided limit intact") {
@@ -178,7 +193,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(4.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(4.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.0), MValueAdjustment(3, linkId1, 4.9, 10.0)))
   }
 
   test("adjust one-sided limits when there is one on one side and two on the other") {
@@ -206,8 +226,13 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(0.0, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(0.0)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0),
-      MValueAdjustment(3, linkId1, 0.0, 10.0)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0),
+      MValueAdjustment(3, linkId1, 0.0, 10.0)))
   }
 
   test("two opposite side directions with smallest start measure are adjusted") {
@@ -235,8 +260,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(2.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 0.0, 2.9)),
-      Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0.0, 2.9), MValueAdjustment(2, linkId1, 0.0, 2.9)))
   }
 
   test("only the one-sided limit with the smallest start measure is adjusted when the two smallest are on the same side") {
@@ -265,7 +294,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(5.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(5.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0.0, 2.9)))
   }
 
   test("two opposite side directions with largest end measure and the two-sided limit in the beginning are adjusted") {
@@ -293,8 +327,13 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(2.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(2.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(3, linkId1, 2.9, 10.0), MValueAdjustment(2, linkId1, 2.9, 10.0),
-      MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(2, linkId1, 2.9, 10.0),
+      MValueAdjustment(3, linkId1, 2.9, 10.0)))
   }
 
   test("only the one-sided limit with the largest end measure is adjusted when the two largest are on the same side") {
@@ -323,7 +362,12 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     sortedFilledTopology.last.geometry should be(Seq(Point(5.9, 0.0), Point(10.0, 0.0)))
     sortedFilledTopology.last.startMeasure should be(5.9)
     sortedFilledTopology.last.endMeasure should be(10.0)
-    changeSet should be(ChangeSet(Set.empty, Seq(MValueAdjustment(3, linkId1, 5.9, 10.0), MValueAdjustment(1, linkId1, 0, 2.9)), Nil, Set.empty, Nil))
+    changeSet.droppedAssetIds should be(Set.empty)
+    changeSet.adjustedSideCodes should be(Nil)
+    changeSet.expiredAssetIds should be(Set.empty)
+    changeSet.valueAdjustments should be(Nil)
+    val adjustedMValues = changeSet.adjustedMValues
+    adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 2.9), MValueAdjustment(3, linkId1, 5.9, 10.0)))
   }
 
   test("adjust one way speed limits to cover whole link when there are no multiple speed limits on one side of the link") {
@@ -345,7 +389,7 @@ class SpeedLimitFillerSpec extends FunSuite with Matchers {
     filledTopology.map(_.startMeasure) should be(Seq(0.0, 0.0))
     filledTopology.map(_.endMeasure) should be(Seq(10.0, 10.0))
     changeSet.adjustedMValues should have size 2
-    changeSet.adjustedMValues should be(Seq(MValueAdjustment(1, linkId1, 0, 10.0), MValueAdjustment(2, linkId1, 0, 10.0)))
+    changeSet.adjustedMValues.sortBy(_.assetId) should be(Seq(MValueAdjustment(1, linkId1, 0, 10.0), MValueAdjustment(2, linkId1, 0, 10.0)))
   }
 
   case class Measure(startMeasure: Double, endMeasure: Double)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -529,7 +529,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
       logger.info(s"Saving adjustments for asset/link ids=${changeSet.adjustedMValues.map(a => s"${a.assetId}/${a.linkId}").mkString(", ")}")
       logger.debug(s"Saving adjustments for asset/link ids=${changeSet.adjustedMValues.map(a => s"${a.assetId}/${a.linkId} start measure: ${a.startMeasure} end measure: ${a.endMeasure}").mkString(", ")}")
     changeSet.adjustedMValues.foreach { adjustment =>
-      dao.updateMValuesChangeInfo(adjustment.assetId, adjustment.linkId, Measures(adjustment.startMeasure, adjustment.endMeasure).roundMeasures(), adjustment.timeStamp)
+      dao.updateMValuesChangeInfo(adjustment.assetId, adjustment.linkId, Measures(adjustment.startMeasure, adjustment.endMeasure).roundMeasures(), LinearAssetUtils.createTimeStamp())
     }
 
     val ids = changeSet.expiredAssetIds.toSeq


### PR DESCRIPTION
Vaihdettu rekursiivinen metodi siihen, että ryhmitellään muutokset id:n mukaan ja otetaan viimeisin muutos. Tulkitsin googlailun ja yksikkötestin perusteella, että muutosten ryhmän sisäinen järjetys säilyy.

Testejä jouduttu muokkaamaan, koska eri asset_id:llä olevien muutosten järjestys ei välttämättä säily.

Lisäksi vaihdoin updateMValuesChangeInfo luomaan timeStampin, koska adjustmentin timestamp assetFilleriltä tullessa on nolla. Voin vaihtaa takaisin, jos on väärin tai ei ole väliä.