### PR TITLE
DROTH-3493 Add logging for roadLink change

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/MValueCalculator.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/MValueCalculator.scala
@@ -33,7 +33,7 @@ object MValueCalculator {
     }else {
       val start = Math.min(linksLenght, Math.max(0.0, newStartMValue)) // take new start if it is greater than zero and smaller than roadLinkLength
       val end = Math.max(0.0, Math.min(linksLenght, newEndMValue)) // take new end if it is greater than zero and smaller than roadLinkLength
-      logAndWarn(asset, start, end)
+      logAndWarn(asset, start, end, projection)
       (roundMeasure(start), roundMeasure(end), asset.sideCode)
     }
   }
@@ -49,12 +49,12 @@ object MValueCalculator {
     logger.debug(s"new start $newStart, new end $newEnd, factor number $factor")
     val start = Math.min(newLinksLength, Math.max(0.0, newStart))
     val end = Math.max(0.0, Math.min(newLinksLength, newEnd))
-    logAndWarn(asset, start, end)
+    logAndWarn(asset, start, end, projection)
     (roundMeasure(start), roundMeasure(end), newSideCode)
   }
-  private def logAndWarn(asset: AssetLinearReference, start: Double, end: Double): Unit = {
-    if (end - start <= 0) logger.warn(s"new size is zero, start: $start, end: $end, asset ${asset}")
-    if (start > end) logger.warn(s"invalid meters start: $start , end $end")
+  private def logAndWarn(asset: AssetLinearReference, start: Double, end: Double, projection: Projection): Unit = {
+    if (end - start <= 0) logger.warn(s"new size is zero, start: $start, end: $end, asset ${asset}, projected link id: ${projection.linkId}")
+    if (start > end) logger.warn(s"invalid meters start: $start , end $end, projected link id: ${projection.linkId}")
     logger.debug(s"adjusting asset: ${asset.id}")
     logger.debug(s"old start ${asset.startMeasure}, old end ${asset.endMeasure}, old length ${asset.endMeasure - asset.startMeasure}")
     logger.debug(s"new start $start, new end $end, new length ${end - start}")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -80,6 +80,12 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
     logger.info(s"valueAdjustments size: ${changeSet.valueAdjustments.size}")
     logger.info(s"droppedAssetIds size: ${changeSet.droppedAssetIds.size}")
   }
+
+  def logRoadLinkChange(change: RoadLinkChange): Unit = {
+    val oldLinkId = if(change.oldLink.nonEmpty) change.oldLink.get.linkId else ""
+    val newLinkIds = change.newLinks.map(_.linkId).mkString(", ")
+    logger.info(s"RoadLink change changeType: ${change.changeType.value} old linkId: $oldLinkId new link ids: $newLinkIds")
+  }
   
   private val isDeleted: RoadLinkChange => Boolean = (change: RoadLinkChange) => {
     change.changeType.value == RoadLinkChangeType.Remove.value
@@ -390,6 +396,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   
   private def goThroughChanges(assetsAll: Seq[PersistedLinearAsset], changeSets: ChangeSet,
                                initStep: OperationStep, change: RoadLinkChange,initStepSplit:OperationStepSplit): Option[OperationStep] = {
+    logRoadLinkChange(change)
     nonAssetUpdate(change, Seq(), null)
     change.changeType match {
       case RoadLinkChangeType.Add =>


### PR DESCRIPTION
Lisätty tielinkki muutoksen lokitus. Aikaisempien lokien perusteella tien leveys ja käpy samuutukset jää saman tielinkki muutoksen käsittelyssä jumiin, uusi lokitus auttaa selvittämään mikä muutos kyseessä.