### PR TITLE
Droth 3844 fix unknown speed limit

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -178,6 +178,8 @@ object DataFixture {
 
   lazy val roadWidthGenerator = new RoadWidthGenerator
 
+  lazy val unknownSpeedLimitUpdater = new UnknownSpeedLimitUpdater
+
   def importMunicipalityCodes() {
     println("\nCommencing municipality code import at time: ")
     println(DateTime.now())
@@ -2155,7 +2157,7 @@ object DataFixture {
       case Some("traffic_sign_extract") =>
         extractTrafficSigns(args.lastOption)
       case Some("remove_unnecessary_unknown_speedLimits") =>
-        removeUnnecessaryUnknownSpeedLimits()
+        unknownSpeedLimitUpdater.updateUnknownSpeedLimits()
       case Some("list_incorrect_SpeedLimits_created") =>
         printSpeedLimitsIncorrectlyCreatedOnUnknownSpeedLimitLinks()
       case Some("create_prohibition_using_traffic_signs") =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdater.scala
@@ -1,0 +1,79 @@
+package fi.liikennevirasto.digiroad2.util
+
+import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
+import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, SideCode}
+import fi.liikennevirasto.digiroad2.client.RoadLinkClient
+import fi.liikennevirasto.digiroad2.dao.Queries
+import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISSpeedLimitDao
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
+import org.joda.time.DateTime
+import org.slf4j.LoggerFactory
+
+class UnknownSpeedLimitUpdater {
+
+  val dummyEventBus = new DummyEventBus
+  val roadLinkClient: RoadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
+  val roadLinkService = new RoadLinkService(roadLinkClient, dummyEventBus, new DummySerializer)
+  val dao = new PostGISSpeedLimitDao(roadLinkService)
+  val logger = LoggerFactory.getLogger(getClass)
+
+  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
+
+  def updateUnknownSpeedLimits() = {
+    logger.info("Update unnecessary unknown speed limits.")
+    logger.info(DateTime.now().toString())
+
+    withDynTransaction {
+      val municipalities = Queries.getMunicipalities
+      municipalities.foreach { municipality =>
+        logger.info(s"Removing unnecessary unknown speed limits in municipality  + $municipality")
+        removeByMunicipality(municipality)
+        logger.info(s"Updating admin class and municipality of the unknown speed limits in municipality + $municipality")
+        updateAdminClassAndMunicipalityCode(municipality)
+      }
+    }
+  }
+
+  def removeByMunicipality(municipality: Int) = {
+    val linkIdsWithUnknownLimits = dao.getMunicipalitiesWithUnknown(municipality).map(_._1)
+    val speedLimits = dao.fetchSpeedLimitsByLinkIds(linkIdsWithUnknownLimits)
+    val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(linkIdsWithUnknownLimits.toSet, false)
+    val groupedSpeedLimits = speedLimits.groupBy(_.linkId)
+
+    val linkIdsToDelete = groupedSpeedLimits.filter { grouped =>
+      val sideCodes = grouped._2.map(_.sideCode)
+      val speedLimitIsOnBothSides = sideCodes.contains(SideCode.BothDirections) || (sideCodes.contains(SideCode.TowardsDigitizing) && sideCodes.contains(SideCode.AgainstDigitizing))
+      if (speedLimitIsOnBothSides) {
+        true
+      } else {
+        roadLinks.find(_.linkId == grouped._1) match {
+          case Some(roadLink) =>
+            val roadLinkIsOneWay = roadLink.trafficDirection != BothDirections
+            if (roadLinkIsOneWay) true else false
+          case _ => throw new NoSuchElementException(s"Road link with id ${grouped._1} not found.")
+        }
+      }
+    }.keys.toSeq
+
+    if (linkIdsToDelete.nonEmpty) {
+      logger.info(s"Speed limits cover links - $linkIdsToDelete. Deleting unknown limits.")
+      dao.deleteUnknownSpeedLimits(linkIdsToDelete)
+    }
+  }
+
+  def updateAdminClassAndMunicipalityCode(municipality: Int) = {
+    val linksAndAdminsForUnknown = dao.getMunicipalitiesWithUnknown(municipality)
+    val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(linksAndAdminsForUnknown.map(_._1).toSet)
+
+    linksAndAdminsForUnknown.foreach { case (linkIdForUnknown, adminClassForUnknown) =>
+      roadLinks.find(_.linkId == linkIdForUnknown) match {
+        case Some(r) if r.administrativeClass != AdministrativeClass.apply(adminClassForUnknown) | r.municipalityCode != municipality =>
+          println("Updated link " + linkIdForUnknown + " admin class to " + r.administrativeClass.value + " and municipality code to " + r.municipalityCode)
+          dao.updateUnknownSpeedLimitAdminClassAndMunicipality(linkIdForUnknown, r.administrativeClass, r.municipalityCode)
+        case _ => //do nothing
+      }
+    }
+  }
+}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdater.scala
@@ -70,7 +70,7 @@ class UnknownSpeedLimitUpdater {
     linksAndAdminsForUnknown.foreach { case (linkIdForUnknown, adminClassForUnknown) =>
       roadLinks.find(_.linkId == linkIdForUnknown) match {
         case Some(r) if r.administrativeClass != AdministrativeClass.apply(adminClassForUnknown) | r.municipalityCode != municipality =>
-          println("Updated link " + linkIdForUnknown + " admin class to " + r.administrativeClass.value + " and municipality code to " + r.municipalityCode)
+          logger.info("Updated link " + linkIdForUnknown + " admin class to " + r.administrativeClass.value + " and municipality code to " + r.municipalityCode)
           dao.updateUnknownSpeedLimitAdminClassAndMunicipality(linkIdForUnknown, r.administrativeClass, r.municipalityCode)
         case _ => //do nothing
       }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdaterSpec.scala
@@ -1,0 +1,142 @@
+package fi.liikennevirasto.digiroad2.util
+
+import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
+import fi.liikennevirasto.digiroad2.linearasset.{NewLimit, RoadLink, SpeedLimitValue, UnknownSpeedLimit}
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.service.linearasset.{Measures, SpeedLimitService}
+import fi.liikennevirasto.digiroad2.{DummyEventBus, GeometryUtils}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
+
+class UnknownSpeedLimitUpdaterSpec extends FunSuite with Matchers {
+
+  val mockRoadLinkService = MockitoSugar.mock[RoadLinkService]
+
+  val testUnknownSpeedLimitUpdater = new UnknownSpeedLimitUpdater() {
+    override val roadLinkService: RoadLinkService = mockRoadLinkService
+    val speedLimitService: SpeedLimitService = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
+      override def create(newLimits: Seq[NewLimit], value: SpeedLimitValue, username: String, municipalityValidation: (Int, AdministrativeClass) => Unit): Seq[Long] = {
+        withDynTransaction {
+          val createdIds = newLimits.flatMap { limit =>
+            speedLimitDao.createSpeedLimit(username, limit.linkId, Measures(limit.startMeasure, limit.endMeasure), SideCode.BothDirections, value, createTimeStamp(), municipalityValidation)
+          }
+          createdIds
+        }
+      }
+    }
+  }
+
+  def toRoadLink(l: RoadLinkFetched) = {
+    RoadLink(l.linkId, l.geometry, GeometryUtils.geometryLength(l.geometry),
+      l.administrativeClass, 1, l.trafficDirection, UnknownLinkType, None, None, l.attributes + ("MUNICIPALITYCODE" -> BigInt(l.municipalityCode)))
+  }
+
+  def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback(PostGISDatabase.ds)(test)
+
+  test("Remove unknown speed limits that have been replaced by an ordinary speed limit") {
+    val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
+    val municipalityCode = 235
+
+    val roadLink = RoadLinkFetched(linkId1, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(roadLink))
+
+    runWithRollback {
+      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId1, municipalityCode, Municipality), UnknownSpeedLimit(linkId2, municipalityCode, Municipality), UnknownSpeedLimit(linkId3, 235, Municipality)))
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId1, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.BothDirections)
+      val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
+      unknownLimitsBefore.sorted should be (Seq(linkId1, linkId2, linkId3).sorted)
+      testUnknownSpeedLimitUpdater.removeByMunicipality(municipalityCode)
+      val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
+      unknownLimitsAfter.sorted should be (Seq(linkId2, linkId3).sorted)
+    }
+  }
+
+  test("Remove unknown speed limit only if speed limits cover both sides of a two way road link") {
+    val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
+    val municipalityCode = 235
+
+    val roadLink1 = RoadLinkFetched(linkId1, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+    val roadLink2 = RoadLinkFetched(linkId2, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+    val roadLink3 = RoadLinkFetched(linkId3, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(roadLink1))
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId2)).thenReturn(Some(roadLink2))
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId3)).thenReturn(Some(roadLink3))
+    when(mockRoadLinkService.getRoadLinksAndComplementariesByLinkIds(Set(linkId1, linkId2, linkId3)))
+      .thenReturn(Seq(toRoadLink(roadLink1), toRoadLink(roadLink2), toRoadLink(roadLink3)))
+
+    runWithRollback {
+      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId1, municipalityCode, Municipality), UnknownSpeedLimit(linkId2, municipalityCode, Municipality), UnknownSpeedLimit(linkId3, municipalityCode, Municipality)))
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId1, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.BothDirections)
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId2, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.AgainstDigitizing)
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId2, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.TowardsDigitizing)
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId3, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.AgainstDigitizing)
+      val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
+      unknownLimitsBefore.sorted should be(Seq(linkId1, linkId2, linkId3).sorted)
+      testUnknownSpeedLimitUpdater.removeByMunicipality(municipalityCode)
+      val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
+      unknownLimitsAfter should be(Seq(linkId3))
+    }
+  }
+
+  test("Unknown speed limit is removed if a one way road link is covered by a speed limit") {
+    val linkId = LinkIdGenerator.generateRandom()
+    val municipalityCode = 235
+
+    val roadLink = RoadLinkFetched(linkId, municipalityCode, Nil, Municipality, TrafficDirection.TowardsDigitizing, FeatureClass.AllOthers)
+
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId)).thenReturn(Some(roadLink))
+    when(mockRoadLinkService.getRoadLinksAndComplementariesByLinkIds(Set(linkId)))
+      .thenReturn(Seq(toRoadLink(roadLink)))
+
+    runWithRollback {
+      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId, municipalityCode, Municipality)))
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.TowardsDigitizing)
+      val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
+      unknownLimitsBefore should be(Seq(linkId))
+      testUnknownSpeedLimitUpdater.removeByMunicipality(municipalityCode)
+      val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode)
+      unknownLimitsAfter.sorted should be(Seq.empty)
+    }
+  }
+
+  test("municipality codes ans admin classes of an unknown link are updated") {
+    val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
+    val municipalityCode = 235
+
+    val roadLink1 = RoadLinkFetched(linkId1, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+    val roadLink2 = RoadLinkFetched(linkId2, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+    val roadLink3 = RoadLinkFetched(linkId3, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(roadLink1))
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId2)).thenReturn(Some(roadLink2))
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId3)).thenReturn(Some(roadLink3))
+    when(mockRoadLinkService.getRoadLinksAndComplementariesByLinkIds(Set(linkId2))).thenReturn(Seq(toRoadLink(roadLink2)))
+    when(mockRoadLinkService.getRoadLinksAndComplementariesByLinkIds(Set(linkId1, linkId3))).thenReturn(Seq(toRoadLink(roadLink1), toRoadLink(roadLink3)))
+
+    runWithRollback {
+      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId1, 49, State), UnknownSpeedLimit(linkId2, municipalityCode, State), UnknownSpeedLimit(linkId3, 49, Municipality)))
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId1, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.BothDirections)
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId2, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.AgainstDigitizing)
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId2, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.TowardsDigitizing)
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId3, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.AgainstDigitizing)
+      val unknownLimits235before = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode)
+      unknownLimits235before.size should be(1)
+      unknownLimits235before.head._2 should be(State.value)
+      val unknownLimits49before = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(49)
+      unknownLimits49before.size should be(2)
+      unknownLimits49before.map(_._2).sorted should be(Seq(State.value, Municipality.value))
+      testUnknownSpeedLimitUpdater.updateAdminClassAndMunicipalityCode(235)
+      testUnknownSpeedLimitUpdater.updateAdminClassAndMunicipalityCode(49)
+      val unknownLimits235after = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode)
+      unknownLimits235after.map(_._1).sorted should be(Seq(linkId1, linkId2, linkId3).sorted)
+      unknownLimits235after.map(_._2).toSet should be(Set(Municipality.value))
+      val unknownLimits49 = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(49)
+      unknownLimits49 should be(Seq.empty)
+    }
+  }
+}


### PR DESCRIPTION
Uusittu eräajo, joka poistaa tuntemattomat rajoitukset, jos:
* Kaksisuuntaisella linkillä on molemminpuolinen rajoitus tai molemmat toispuoliset rajoitukset.
* Tielinkillä on noepusrajoitus ja linkki on yksisuuntainen

Lisäksi päivitetään tuntemattoman rajoituksen hallinnollinen luokka ja kuntakoodi kuten vanhassa eräajossa.