### PR TITLE
DROTH-3847 fix one way road asset visualization

### DIFF
--- a/UI/src/utils/geometryUtils.js
+++ b/UI/src/utils/geometryUtils.js
@@ -68,7 +68,7 @@
   };
 
   root.offsetBySideCode = function (zoom, asset) {
-    if (asset.sideCode === 1) {
+    if (asset.sideCode === 1 || asset.trafficDirection != "BothDirections") {
       return asset;
     }
     asset.points = _.map(asset.points, function (point, index, geometry) {

--- a/UI/src/view/linear_asset/piecewiseLinearAssetStyle.js
+++ b/UI/src/view/linear_asset/piecewiseLinearAssetStyle.js
@@ -19,13 +19,13 @@
     ];
 
     var oneWayRules = [
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(9).use({ stroke: {width: 2 }}),
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(10).use({ stroke: {width: 4 }}),
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(11).use({ stroke: {width: 4 }}),
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(12).use({ stroke: {width: 5 }}),
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(13).use({ stroke: {width: 5 }}),
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(14).use({ stroke: {width: 8 }}),
-      new StyleRule().where('sideCode').isIn([2,3]).and('zoomLevel').is(15).use({ stroke: {width: 8 }})
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(9).use({ stroke: {width: 2 }}),
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(10).use({ stroke: {width: 4 }}),
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(11).use({ stroke: {width: 4 }}),
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(12).use({ stroke: {width: 5 }}),
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(13).use({ stroke: {width: 5 }}),
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(14).use({ stroke: {width: 8 }}),
+      new StyleRule().where('sideCode').isIn([2,3]).and('trafficDirection').is('BothDirections').and('zoomLevel').is(15).use({ stroke: {width: 8 }})
     ];
 
     var featureTypeRules = [


### PR DESCRIPTION
Visualisoidaan yksisuuntaisen tien yksipuolinen asset paksulla viivalla keskellä tietä. Pitäisi loppujen lopuksi mennä melko yksinkertaisella muutoksella. Kävin tietolajit läpi, enkä löytänyt, että jollakin olisi erikoiskäsittely.