### PR TITLE
DROTH-3502 fix insertin empty geometry, ignore TR-assets

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/AssetsOnExpiredLinksDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/AssetsOnExpiredLinksDAO.scala
@@ -62,7 +62,8 @@ class AssetsOnExpiredLinksDAO {
     val roadLinkExpiredDate = asset.roadLinkExpiredDate.toString
     val geometryWKT = if(asset.geometry.length > 1) {
       GeometryUtils.toWktLineString(asset.geometry).string
-    } else GeometryUtils.toWktPoint(asset.geometry.head.x, asset.geometry.head.y).string
+    } else if(asset.geometry.length == 1) GeometryUtils.toWktPoint(asset.geometry.head.x, asset.geometry.head.y).string
+    else ""
 
     sqlu"""INSERT INTO assets_on_expired_road_links (asset_id, asset_type_id, link_id, side_code, start_measure, end_measure, road_link_expired_date, asset_geometry)
           VALUES ($assetId,


### PR DESCRIPTION
Korjattu tyhjän geometrian käsittely (viime ajossa geom oli jäänyt tyhjäksi rikkinäisillä TR-asseteilla, jotka olivat linkin ulkopuolella)
Jätetty TR-assetit pois käsittelystä, koska näitä ei samuuteta