### PR TITLE
Droth 3853 optimize lane saving

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
@@ -59,7 +59,8 @@ sealed trait LaneValue {
 case class LanePropertyValue(value: Any) {
   def toJson: JValue = JString(value.toString)
 }
-case class LaneProperty(publicId: String,  values: Seq[LanePropertyValue]) {
+case class LaneProperty(publicId: String,  values: Seq[LanePropertyValue], createdDate: Option[DateTime] = None,
+                        createdBy: Option[String] = None, modifiedDate: Option[DateTime] = None, modifiedBy: Option[String] = None) {
   def toJson = List(JField("publicId", JString(publicId)), JField("values", JArray(values.map(_.toJson).toList)))
 }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneHistoryDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/lane/LaneHistoryDao.scala
@@ -7,7 +7,9 @@ import fi.liikennevirasto.digiroad2.asset.Decode
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.lane.{LaneProperty, LanePropertyValue, OldLaneWithNewId, PersistedHistoryLane, PersistedLane}
 import fi.liikennevirasto.digiroad2.postgis.MassQuery
+import fi.liikennevirasto.digiroad2.util.LogUtils
 import org.joda.time.DateTime
+import org.slf4j.{Logger, LoggerFactory}
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery}
 import slick.jdbc.StaticQuery.interpolation
 
@@ -23,7 +25,7 @@ case class laneToHistoryLane(oldId: Long, historyId: Long, historyPositionId: Lo
 case class HistoryLaneWithIds(newLaneId: Long, laneHistoryId: Long, positionHistoryId: Long, historyEventOrderNumber: Long, oldLane: PersistedLane)
 
 class LaneHistoryDao() {
-
+  val logger: Logger = LoggerFactory.getLogger(getClass)
   implicit val getLaneHistoryAsset: GetResult[LaneHistoryRow] = new GetResult[LaneHistoryRow] {
     def apply(r: PositionedResult): LaneHistoryRow = {
       val id = r.nextLong()
@@ -152,86 +154,98 @@ class LaneHistoryDao() {
       s"""insert into lane_history
          |  values( (?), (?), (?), (?), (?), (?), (?), (?), current_timestamp, '$username', null,  current_timestamp, (?), current_timestamp, '$username', (?) )
          |  """.stripMargin
-    MassQuery.executeBatch(insertLaneHistory) { statement =>
-      oldLanesWithHistory.foreach(lane => {
-        val createdTimeStamp = new Timestamp(lane.oldLane.createdDateTime.get.getMillis)
 
-        statement.setLong(1, lane.laneHistoryId)
-        statement.setLong(2, lane.newLaneId)
-        statement.setLong(3, lane.oldLane.id)
-        statement.setInt(4, lane.oldLane.laneCode)
-        statement.setTimestamp(5, createdTimeStamp)
-        if(lane.oldLane.createdBy.nonEmpty) {
-          statement.setString(6, lane.oldLane.createdBy.get)
-        } else statement.setNull(6, java.sql.Types.VARCHAR)
-        if(lane.oldLane.modifiedDateTime.nonEmpty) {
-          statement.setTimestamp(7, new Timestamp(lane.oldLane.modifiedDateTime.get.getMillis))
-        } else statement.setNull(7, java.sql.Types.TIMESTAMP)
-        if(lane.oldLane.modifiedBy.nonEmpty) {
-          statement.setString(8, lane.oldLane.modifiedBy.get)
-        } else statement.setNull(8, java.sql.Types.VARCHAR)
-        statement.setLong(9, lane.oldLane.municipalityCode)
-        statement.setLong(10, lane.historyEventOrderNumber)
-        statement.addBatch()
-      })
+    LogUtils.time(logger, "MassQuery insert to lane_history") {
+      MassQuery.executeBatch(insertLaneHistory) { statement =>
+        oldLanesWithHistory.foreach(lane => {
+          val createdTimeStamp = new Timestamp(lane.oldLane.createdDateTime.get.getMillis)
+
+          statement.setLong(1, lane.laneHistoryId)
+          statement.setLong(2, lane.newLaneId)
+          statement.setLong(3, lane.oldLane.id)
+          statement.setInt(4, lane.oldLane.laneCode)
+          statement.setTimestamp(5, createdTimeStamp)
+          if(lane.oldLane.createdBy.nonEmpty) {
+            statement.setString(6, lane.oldLane.createdBy.get)
+          } else statement.setNull(6, java.sql.Types.VARCHAR)
+          if(lane.oldLane.modifiedDateTime.nonEmpty) {
+            statement.setTimestamp(7, new Timestamp(lane.oldLane.modifiedDateTime.get.getMillis))
+          } else statement.setNull(7, java.sql.Types.TIMESTAMP)
+          if(lane.oldLane.modifiedBy.nonEmpty) {
+            statement.setString(8, lane.oldLane.modifiedBy.get)
+          } else statement.setNull(8, java.sql.Types.VARCHAR)
+          statement.setLong(9, lane.oldLane.municipalityCode)
+          statement.setLong(10, lane.historyEventOrderNumber)
+          statement.addBatch()
+        })
+      }
     }
 
     val insertHistoryPosition =
       s"""insert into lane_history_position
          |  values( (?), (?), (?), (?), (?), (?), (?), null)""".stripMargin
-    MassQuery.executeBatch(insertHistoryPosition) { statement =>
-      oldLanesWithHistory.foreach(lane => {
-        statement.setLong(1, lane.positionHistoryId)
-        statement.setLong(2, lane.oldLane.sideCode)
-        statement.setDouble(3, lane.oldLane.startMeasure)
-        statement.setDouble(4, lane.oldLane.endMeasure)
-        statement.setString(5, lane.oldLane.linkId)
-        statement.setLong(6, lane.oldLane.timeStamp)
-        if(lane.oldLane.geomModifiedDate.nonEmpty) {
-          statement.setTimestamp(7, new Timestamp(lane.oldLane.geomModifiedDate.get.getMillis))
-        } else statement.setNull(7, java.sql.Types.TIMESTAMP)
 
-        statement.addBatch()
-      })
+    LogUtils.time(logger, "MassQuery insert to lane_history_position") {
+      MassQuery.executeBatch(insertHistoryPosition) { statement =>
+        oldLanesWithHistory.foreach(lane => {
+          statement.setLong(1, lane.positionHistoryId)
+          statement.setLong(2, lane.oldLane.sideCode)
+          statement.setDouble(3, lane.oldLane.startMeasure)
+          statement.setDouble(4, lane.oldLane.endMeasure)
+          statement.setString(5, lane.oldLane.linkId)
+          statement.setLong(6, lane.oldLane.timeStamp)
+          if(lane.oldLane.geomModifiedDate.nonEmpty) {
+            statement.setTimestamp(7, new Timestamp(lane.oldLane.geomModifiedDate.get.getMillis))
+          } else statement.setNull(7, java.sql.Types.TIMESTAMP)
+
+          statement.addBatch()
+        })
+      }
     }
 
     val insertLaneHistoryLink =
       s"""insert into lane_history_link (lane_id, lane_position_id)
          |values ((?), (?))""".stripMargin
-    MassQuery.executeBatch(insertLaneHistoryLink) { statement =>
-      oldLanesWithHistory.foreach(lane => {
-        statement.setLong(1, lane.laneHistoryId)
-        statement.setLong(2, lane.positionHistoryId)
-        statement.addBatch()
-      })
+
+    LogUtils.time(logger, "MassQuery insert to lane_history_link") {
+      MassQuery.executeBatch(insertLaneHistoryLink) { statement =>
+        oldLanesWithHistory.foreach(lane => {
+          statement.setLong(1, lane.laneHistoryId)
+          statement.setLong(2, lane.positionHistoryId)
+          statement.addBatch()
+        })
+      }
     }
 
     val insertLaneHistoryAttribute =
       s"""insert into lane_history_attribute
          |values (nextval('primary_key_seq'), (?), (?), (?), (?), (?), (?), (?), (?))
          |""".stripMargin
-    MassQuery.executeBatch(insertLaneHistoryAttribute) { statement =>
-      oldLanesWithHistory.foreach(lane => {
-        lane.oldLane.attributes.filterNot(_.publicId == "lane_code").foreach(attribute => {
-          statement.setLong(1, lane.laneHistoryId)
-          statement.setString(2, attribute.publicId)
-          statement.setString(3, attribute.values.head.value.toString)
-          statement.setBoolean(4, false)
-          if(attribute.createdDate.nonEmpty) {
-            statement.setTimestamp(5, new Timestamp(attribute.createdDate.get.getMillis))
-          } else statement.setNull(5, java.sql.Types.TIMESTAMP)
-          if(attribute.createdBy.nonEmpty) {
-            statement.setString(6, attribute.createdBy.get)
-          } else statement.setNull(6, java.sql.Types.VARCHAR)
-          if(attribute.modifiedDate.nonEmpty) {
-            statement.setTimestamp(7, new Timestamp(attribute.modifiedDate.get.getMillis))
-          } else statement.setNull(7, java.sql.Types.TIMESTAMP)
-          if(attribute.modifiedBy.nonEmpty) {
-            statement.setString(8, attribute.modifiedBy.get)
-          } else statement.setNull(8, java.sql.Types.VARCHAR)
-          statement.addBatch()
+
+    LogUtils.time(logger, "MassQuery insert to lane_history_attribute") {
+      MassQuery.executeBatch(insertLaneHistoryAttribute) { statement =>
+        oldLanesWithHistory.foreach(lane => {
+          lane.oldLane.attributes.filterNot(_.publicId == "lane_code").foreach(attribute => {
+            statement.setLong(1, lane.laneHistoryId)
+            statement.setString(2, attribute.publicId)
+            statement.setString(3, attribute.values.head.value.toString)
+            statement.setBoolean(4, false)
+            if (attribute.createdDate.nonEmpty) {
+              statement.setTimestamp(5, new Timestamp(attribute.createdDate.get.getMillis))
+            } else statement.setNull(5, java.sql.Types.TIMESTAMP)
+            if (attribute.createdBy.nonEmpty) {
+              statement.setString(6, attribute.createdBy.get)
+            } else statement.setNull(6, java.sql.Types.VARCHAR)
+            if (attribute.modifiedDate.nonEmpty) {
+              statement.setTimestamp(7, new Timestamp(attribute.modifiedDate.get.getMillis))
+            } else statement.setNull(7, java.sql.Types.TIMESTAMP)
+            if (attribute.modifiedBy.nonEmpty) {
+              statement.setString(8, attribute.modifiedBy.get)
+            } else statement.setNull(8, java.sql.Types.VARCHAR)
+            statement.addBatch()
+          })
         })
-      })
+      }
     }
 
     laneHistoryIds

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/lane/LaneServiceSpec.scala
@@ -220,7 +220,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       oldLaneData.oldId should be(newLane1.head)
       oldLaneData.expired should be(false)
       oldLaneData.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
     }
   }
@@ -260,13 +260,13 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane11 = currentLanes.filter(_.id == newMainLaneid).head
       lane11.id should be(newMainLaneid)
       lane11.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane12 = currentLanes.filter(_.id == newSubLaneId).head
       lane12.id should be(newSubLaneId)
       lane12.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -282,7 +282,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane11AfterDelete = currentLanesAfterDelete.filter(_.id == newMainLaneid).head
       lane11AfterDelete.id should be(newMainLaneid)
       lane11AfterDelete.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Verify the presence of the deleted lane on histories tables
@@ -293,7 +293,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane12AfterDelete.oldId should be(newSubLaneId)
       lane12AfterDelete.expired should be(true)
       lane12AfterDelete.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
     }
   }
@@ -318,7 +318,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane12 = currentLanes.filter(_.id == newSubLane2Id).head
@@ -326,7 +326,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane12.startMeasure should be(0)
       lane12.endMeasure should be(500)
       lane12.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -340,7 +340,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane11AfterSplit = lanesAfterSplit.filter(_.id == mainLane1Id).head
       lane11AfterSplit.id should be(mainLane1Id)
       lane11AfterSplit.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane12AfterSplit = lanesAfterSplit.filter(_.laneCode == 2).head
@@ -348,7 +348,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane12AfterSplit.startMeasure should be(0)
       lane12AfterSplit.endMeasure should be(250)
       lane12AfterSplit.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -364,7 +364,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historyLane12.endMeasure should be(500)
       historyLane12.expired should be(true)
       historyLane12.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
 
       }
     }
@@ -385,7 +385,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2 = currentLanes.filter(_.id == subLane2SplitedId).head
@@ -393,7 +393,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2.startMeasure should be(0)
       lane2.endMeasure should be(250.0)
       lane2.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
     }
   }
@@ -415,7 +415,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2A = currentLanes.filter(_.id == subLane2SplitedAId).head
@@ -423,7 +423,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2A.startMeasure should be(0)
       lane2A.endMeasure should be(250.0)
       lane2A.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2B = currentLanes.filter(_.id == subLane2SplitedBId).head
@@ -431,7 +431,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2B.startMeasure should be(250.0)
       lane2B.endMeasure should be(500.0)
       lane2B.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
     }
   }
@@ -462,7 +462,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2 = currentLanes.filter(_.id == newSubLane2Id).head
@@ -470,7 +470,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2.startMeasure should be(0)
       lane2.endMeasure should be(500.0)
       lane2.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -484,7 +484,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane11AfterSplit = lanesAfterSplit.filter(_.id == mainLane1Id).head
       lane11AfterSplit.id should be(mainLane1Id)
       lane11AfterSplit.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       lanesAfterSplit.count(_.laneCode == 2) should be(2)
@@ -493,7 +493,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane12A.startMeasure should be(0)
       lane12A.endMeasure should be(250.0)
       lane12A.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2B = lanesAfterSplit.filter(l => l.startMeasure == 250.0).head
@@ -501,7 +501,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2B.startMeasure should be(250.0)
       lane2B.endMeasure should be(500.0)
       lane2B.attributes.foreach { laneProp =>
-        lanePropertiesSubLaneSplit2WithStartDate.contains(laneProp) should be(true)
+        lanePropertiesSubLaneSplit2WithStartDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -516,7 +516,7 @@ class LaneServiceSpec extends LaneTestSupporter {
         historyLane2.endMeasure should be(500)
         historyLane2.expired should be(true)
         historyLane2.attributes.foreach { laneProp =>
-          lanePropertiesValues2.contains(laneProp) should be(true)
+          lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
         }
       }
 
@@ -551,7 +551,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2A = currentLanes.filter(_.id == newSubLane2SplitAId).head
@@ -559,7 +559,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2A.startMeasure should be(0)
       lane2A.endMeasure should be(250.0)
       lane2A.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -569,7 +569,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2B.startMeasure should be(250.0)
       lane2B.endMeasure should be(500.0)
       lane2B.attributes.foreach { laneProp =>
-        lanePropertiesSubLaneSplit2WithStartDate.contains(laneProp) should be(true)
+        lanePropertiesSubLaneSplit2WithStartDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -586,7 +586,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1AfterSplit = lanesAfterSplit.filter(_.id == mainLane1Id).head
       lane1AfterSplit.id should be(mainLane1Id)
       lane1AfterSplit.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2AfterSplit = lanesAfterSplit.filter(_.laneCode == 2).head
@@ -594,7 +594,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2AfterSplit.endMeasure should be(500)
       lane2AfterSplit.expired should be(false)
       lane2AfterSplit.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -609,7 +609,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historylane2A.endMeasure should be(250.0)
       historylane2A.expired should be(true)
       historylane2A.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val historylane2B = historyLanes.filter(_.oldId == newSubLane2SplitBId).head
@@ -619,7 +619,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historylane2B.endMeasure should be(500.0)
       historylane2B.expired should be(true)
       historylane2B.attributes.foreach { laneProp =>
-        lanePropertiesSubLaneSplit2.contains(laneProp) should be(true)
+        lanePropertiesSubLaneSplit2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
     }
@@ -662,7 +662,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2A = currentLanes.filter(_.id == newSubLane2SplitAId).head
@@ -670,7 +670,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2A.startMeasure should be(0)
       lane2A.endMeasure should be(250.0)
       lane2A.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2B = currentLanes.filter(_.id == newSubLane2SplitBId).head
@@ -678,7 +678,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2B.startMeasure should be(250.0)
       lane2B.endMeasure should be(500.0)
       lane2B.attributes.foreach { laneProp =>
-        modifiedLaneProperties1WithStartDate.contains(laneProp) should be(true)
+        modifiedLaneProperties1WithStartDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -694,7 +694,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1AfterUpdate = lanesAfterSplit.filter(_.id == mainLane1Id).head
       lane1AfterUpdate.id should be(mainLane1Id)
       lane1AfterUpdate.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val laneA2AfterUpdate = lanesAfterSplit.filter(_.id == newSubLane2SplitAId).head
@@ -703,7 +703,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       laneA2AfterUpdate.endMeasure should be(250.0)
       laneA2AfterUpdate.expired should be(false)
       laneA2AfterUpdate.attributes.foreach { laneProp =>
-        modifiedLaneProperties1WithStartDate.contains(laneProp) should be(true)
+        modifiedLaneProperties1WithStartDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val laneB2AfterUpdate = lanesAfterSplit.filter(_.id == newSubLane2SplitBId).head
@@ -712,7 +712,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       laneB2AfterUpdate.endMeasure should be(500.0)
       laneB2AfterUpdate.expired should be(false)
       laneB2AfterUpdate.attributes.foreach { laneProp =>
-        modifiedLaneProperties2WithStartDate.contains(laneProp) should be(true)
+        modifiedLaneProperties2WithStartDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Verify the presence of the old splitted lanes attributes on histories tables
@@ -725,7 +725,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historylane2A.endMeasure should be(250.0)
       historylane2A.expired should be(false)
       historylane2A.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val historylane2B = historyLanes.filter(_.oldId == newSubLane2SplitBId).head
@@ -734,7 +734,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historylane2B.endMeasure should be(500.0)
       historylane2B.expired should be(false)
       historylane2B.attributes.foreach { laneProp =>
-        modifiedLaneProperties1.contains(laneProp) should be(true)
+        modifiedLaneProperties1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
     }
   }
@@ -773,7 +773,7 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val newSubLane2 = lanes.find(_.id == newSubLane4Id).head
       newSubLane2.attributes.foreach { laneProp =>
-        updatedSubLane4.properties.contains(laneProp) should be(true)
+        updatedSubLane4.properties.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       newSubLane2.startMeasure should be(0.0)
       newSubLane2.endMeasure should be(500.0)
@@ -786,7 +786,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val deletedSubLane2 = historyLanes.find(_.oldId == newSubLane2Id).head
       deletedSubLane2.newId should be(newSubLane4Id)
       deletedSubLane2.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       deletedSubLane2.startMeasure should be(0.0)
       deletedSubLane2.endMeasure should be(500.0)
@@ -795,7 +795,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val oldDataSubLane4 = historyLanes.find(_.oldId == newSubLane4Id).head
       oldDataSubLane4.newId should be(0)
       oldDataSubLane4.attributes.foreach { laneProp =>
-        lanePropertiesValues4.contains(laneProp) should be(true)
+        lanePropertiesValues4.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       oldDataSubLane4.expired should be(false)
       oldDataSubLane4.startMeasure should be(0.0)
@@ -822,12 +822,12 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val lane1 = currentLanes.filter(_.id == newMainLaneId).head
       lane1.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2 = currentLanes.filter(_.id == newSubLaneId).head
       lane2.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -842,12 +842,12 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val lane1After = currentLanesAfterProcess.filter(_.id == newMainLaneId).head
       lane1After.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2After = currentLanesAfterProcess.filter(_.id == newSubLaneId).head
       lane2After.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Nothing changed so nothing will be in history
@@ -882,12 +882,12 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val lane1 = currentLanes.filter(_.id == newMainLaneId).head
       lane1.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2 = currentLanes.filter(_.id == newSubLaneId).head
       lane2.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
 
@@ -902,12 +902,12 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val lane1After = currentLanesAfterProcess.filter(_.id == newMainLaneId).head
       lane1After.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2After = currentLanesAfterProcess.filter(_.id == newSubLaneId).head
       lane2After.attributes.foreach{ laneProp =>
-        newLanePropertiesValues2.contains(laneProp) should be(true)
+        newLanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Verify history for old properties of lane 12
@@ -917,7 +917,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val oldSubLane2 = historyLanes.find(_.oldId == newSubLaneId).head
       oldSubLane2.newId should be(0)
       oldSubLane2.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       oldSubLane2.expired should be(false)
 
@@ -947,22 +947,22 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val lane1Link100 = currentLanes.filter(_.id == newMainLaneIdLink100).head
       lane1Link100.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2Link100 = currentLanes.filter(_.id == newSubLaneIdLink100).head
       lane2Link100.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane1Link101 = currentLanes.filter(_.id == newMainLaneIdLink101).head
       lane1Link101.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2Link101 = currentLanes.filter(_.id == newSubLaneIdLink101).head
       lane2Link101.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Delete sublane 12 and verify the movement to history tables
@@ -977,12 +977,12 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val lane1Link100AfterDelete = currentLanesAfterDelete.filter(_.id == newMainLaneIdLink100).head
       lane1Link100AfterDelete.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane1Link101AfterDelete = currentLanesAfterDelete.filter(_.id == newMainLaneIdLink101).head
       lane1Link101AfterDelete.attributes.foreach{ laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Verify the presence of the deleted lane on histories tables
@@ -994,7 +994,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2Link100AfterDelete.newId should be(0)
       lane2Link100AfterDelete.expired should be(true)
       lane2Link100AfterDelete.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2Link101AfterDelete = historyLanes.filter(_.oldId == newSubLaneIdLink101).head
@@ -1002,7 +1002,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       lane2Link101AfterDelete.newId should be(0)
       lane2Link101AfterDelete.expired should be(true)
       lane2Link101AfterDelete.attributes.foreach{ laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
     }
   }
@@ -1047,14 +1047,14 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       val newSubLane2Link100 = lanes.find(_.id == newSubLane4IdLink100).head
       newSubLane2Link100.attributes.foreach { laneProp =>
-        updatedSubLane4.properties.contains(laneProp) should be(true)
+        updatedSubLane4.properties.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       newSubLane2Link100.startMeasure should be(0.0)
       newSubLane2Link100.endMeasure should be(500.0)
 
       val newSubLane2Link101 = lanes.find(_.id == newSubLane4IdLink101).head
       newSubLane2Link101.attributes.foreach { laneProp =>
-        updatedSubLane4.properties.contains(laneProp) should be(true)
+        updatedSubLane4.properties.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       newSubLane2Link101.startMeasure should be(0.0)
       newSubLane2Link101.endMeasure should be(500.0)
@@ -1068,7 +1068,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       deletedSubLane2Link100.linkId should be(linkId1)
       deletedSubLane2Link100.newId should be(newSubLane4IdLink100)
       deletedSubLane2Link100.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       deletedSubLane2Link100.startMeasure should be(0.0)
       deletedSubLane2Link100.endMeasure should be(500.0)
@@ -1078,7 +1078,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       deletedSubLane4Link100.linkId should be(linkId1)
       deletedSubLane4Link100.newId should be(0)
       deletedSubLane4Link100.attributes.foreach { laneProp =>
-        lanePropertiesValues4.contains(laneProp) should be(true)
+        lanePropertiesValues4.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       deletedSubLane4Link100.expired should be(false)
       deletedSubLane4Link100.startMeasure should be(0.0)
@@ -1088,7 +1088,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       deletedSubLane2Link101.linkId should be(linkId2)
       deletedSubLane2Link101.newId should be(newSubLane4IdLink101)
       deletedSubLane2Link101.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       deletedSubLane2Link101.startMeasure should be(0.0)
       deletedSubLane2Link101.endMeasure should be(500.0)
@@ -1098,7 +1098,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       deletedSubLane4Link101.linkId should be(linkId2)
       deletedSubLane4Link101.newId should be(0)
       deletedSubLane4Link101.attributes.foreach { laneProp =>
-        lanePropertiesValues4.contains(laneProp) should be(true)
+        lanePropertiesValues4.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
       deletedSubLane4Link101.expired should be(false)
       deletedSubLane4Link101.startMeasure should be(0.0)
@@ -1457,7 +1457,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val splitLanes = currentLanes.filter(_.laneCode == 2).sortBy(_.startMeasure)
@@ -1473,7 +1473,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       splitLanes.foreach { lane =>
         lane.attributes.foreach {
           laneProp =>
-            lanePropertiesValues2.contains(laneProp) should be(true)
+            lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
         }
       }
 
@@ -1518,7 +1518,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val splitLanes = currentLanes.filter(_.laneCode == 2).sortBy(_.startMeasure)
@@ -1534,7 +1534,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       splitLanes.foreach { lane =>
         lane.attributes.foreach {
           laneProp =>
-            lanePropertiesValues2.contains(laneProp) should be(true)
+            lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
         }
       }
 
@@ -1666,27 +1666,27 @@ class LaneServiceSpec extends LaneTestSupporter {
 
       splitLanes(0).attributes.foreach {
         laneProp =>
-          lanePropertiesValues2.contains(laneProp) should be(true)
+          lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       splitLanes(1).attributes.foreach {
         laneProp =>
-          newPropertyValues1.contains(laneProp) should be(true)
+          newPropertyValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       splitLanes(2).attributes.foreach {
         laneProp =>
-          newPropertyValues2.contains(laneProp) should be(true)
+          newPropertyValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       splitLanes(3).attributes.foreach {
         laneProp =>
-          lanePropertiesValues2.contains(laneProp) should be(true)
+          lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       splitLanes(4).attributes.foreach {
         laneProp =>
-          newPropertyValues2.contains(laneProp) should be(true)
+          newPropertyValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val expiredLanes = laneHistoryDao.fetchHistoryLanesByLinkIdsAndLaneCode(Seq(linkId1), Seq(2), true)
@@ -1711,11 +1711,11 @@ class LaneServiceSpec extends LaneTestSupporter {
       attributesChanged.map(_.lane.endMeasure) should be(Seq(200, 300, 500))
 
       attributesChanged.foreach{change =>
-        change.oldLane.get.attributes.foreach(laneProp => lanePropertiesValues2.contains(laneProp) should be(true))}
+        change.oldLane.get.attributes.foreach(laneProp => lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true))}
 
-      attributesChanged(0).lane.attributes.foreach(laneProp => newPropertyValues1.contains(laneProp) should be(true))
-      attributesChanged(1).lane.attributes.foreach(laneProp => newPropertyValues2.contains(laneProp) should be(true))
-      attributesChanged(2).lane.attributes.foreach(laneProp => newPropertyValues2.contains(laneProp) should be(true))
+      attributesChanged(0).lane.attributes.foreach(laneProp => newPropertyValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true))
+      attributesChanged(1).lane.attributes.foreach(laneProp => newPropertyValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true))
+      attributesChanged(2).lane.attributes.foreach(laneProp => newPropertyValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true))
     }
   }
 
@@ -1808,7 +1808,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val splitLanes = currentLanes.filter(_.laneCode == 2).sortBy(_.startMeasure)
@@ -1822,7 +1822,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       splitLanes.foreach { lane =>
         lane.attributes.foreach {
           laneProp =>
-            lanePropertiesValues2.contains(laneProp) should be(true)
+            lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
         }
       }
       when(mockRoadLinkService.getRoadLinksByLinkIds(Set(linkId1), false)).thenReturn(Seq(roadlink1))
@@ -1886,7 +1886,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val splitLanes = currentLanes.filter(_.laneCode == 2).sortBy(_.startMeasure)
@@ -1900,7 +1900,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       splitLanes.foreach { lane =>
         lane.attributes.foreach {
           laneProp =>
-            lanePropertiesValues2.contains(laneProp) should be(true)
+            lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
         }
       }
 
@@ -1956,7 +1956,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Send created main lane and new lane 2 which has passed end date
@@ -1969,7 +1969,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1After = lanesAfterLane2CreationAndExpire.filter(_.id == mainLane1Id).head
       lane1After.id should be(mainLane1Id)
       lane1After.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Verify that lane2 was created and moved to history
@@ -1982,7 +1982,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historyLane2.endMeasure should be(500)
       historyLane2.expired should be(true)
       historyLane2.attributes.foreach { laneProp =>
-        lanePropertiesPassedEndDate.contains(laneProp) should be(true)
+        lanePropertiesPassedEndDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
 
       }
     }
@@ -2007,13 +2007,13 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1 = currentLanes.filter(_.id == mainLane1Id).head
       lane1.id should be(mainLane1Id)
       lane1.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       val lane2 = currentLanes.filter(_.id == subLane2Id).head
       lane2.id should be(subLane2Id)
       lane2.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Send created main lane and updated lane 2 which has passed end date
@@ -2027,7 +2027,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       val lane1After = lanesAfterLane2CreationAndExpire.filter(_.id == mainLane1Id).head
       lane1After.id should be(mainLane1Id)
       lane1After.attributes.foreach { laneProp =>
-        lanePropertiesValues1.contains(laneProp) should be(true)
+        lanePropertiesValues1.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       //Verify that lane2 was created and moved to history
@@ -2043,7 +2043,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historyLane2Update.endMeasure should be(500)
       historyLane2Update.expired should be(false)
       historyLane2Update.attributes.foreach { laneProp =>
-        lanePropertiesValues2.contains(laneProp) should be(true)
+        lanePropertiesValues2.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
       historyLane2Expire.newId should be (0)
@@ -2051,7 +2051,7 @@ class LaneServiceSpec extends LaneTestSupporter {
       historyLane2Expire.endMeasure should be(500)
       historyLane2Expire.expired should be(true)
       historyLane2Expire.attributes.foreach { laneProp =>
-        lanePropertiesPassedEndDate.contains(laneProp) should be(true)
+        lanePropertiesPassedEndDate.map(prop => (prop.publicId, prop.values)).contains((laneProp.publicId, laneProp.values)) should be(true)
       }
 
     }


### PR DESCRIPTION
Lisätty LaneProperty luokkaan tarvittavat tiedot, jotta voidaan historioida ilman SELECT subqueryä. Lisätty MassQuery insertteihin timerit