### PR TITLE
Droth 3822 csv import for service points

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/GeometryUtils.scala
@@ -1,6 +1,7 @@
 package fi.liikennevirasto.digiroad2
 
 import fi.liikennevirasto.digiroad2.linearasset.{PolyLine, RoadLink}
+import com.vividsolutions.jts.geom._
 
 object GeometryUtils {
 
@@ -466,4 +467,23 @@ object GeometryUtils {
     else
       headPoint
   }
+
+  def isPointInsideGeometry(point: Point, geometry: Geometry): Boolean = {
+    val jtsPoint = new GeometryFactory().createPoint(new Coordinate(point.x, point.y))
+    convertToJTSGeometry(geometry).contains(jtsPoint)
+  }
+
+  def convertToJTSGeometry(geometry: Geometry): Polygon = {
+    val coordinates = geometry.`type` match {
+      case "Polygon" => List(geometry.coordinates)
+      case "MultiPolygon" => geometry.coordinates
+      case _ => List.empty[List[Double]]
+    }
+
+    val polygonCoordinates = coordinates.flatMap(coordList =>
+      coordList.map(coords => new Coordinate(coords.asInstanceOf[List[Double]](0), coords.asInstanceOf[List[Double]](1)))
+    ).toArray
+    new GeometryFactory().createPolygon(polygonCoordinates)
+  }
+
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -50,6 +50,28 @@ class KgvRoadLinkClient(collection: Option[KgvCollection] = None,linkGeomSourceV
   override type LinkType = RoadLinkFetched
 }
 
+/**
+ * Client for Municipality Border interface
+ * @param collection
+ * @param linkGeomSourceValue TODO: remove inherited RoadLink dependecies as the client does not use them
+ * @param extractor
+ */
+class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSourceValue: Option[LinkGeomSource] = None, extractor: ExtractorBase) extends KgvOperation(extractor) {
+  override def restApiEndPoint: String = Digiroad2Properties.kgvEndpoint
+  protected val serviceName:String = collection.getOrElse(throw new ClientException("Collection is not defined") ).value
+  protected val linkGeomSource: LinkGeomSource = linkGeomSourceValue.getOrElse("LinkGeomSource is not defined")
+
+  val filter: Filter = FilterOgc
+
+  def fetchByMunicipality(municipality: Int): Seq[LinkType] = {
+    queryByMunicipality(municipality)
+  }
+
+  def fetchByMunicipalityF(municipality: Int): Future[Seq[LinkType]] = {
+    Future(queryByMunicipality(municipality))
+  }
+}
+
 class KgvRoadLinkClientBase(collection: Option[KgvCollection] = None, linkGeomSourceValue:Option[LinkGeomSource] = None, extractor:ExtractorBase = new Extractor) extends KgvOperation(extractor) {
 
   override type LinkType

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -165,10 +165,6 @@ class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSou
     municipalities.find(municipality => municipality.geometry.exists(geometry => isPointInsideGeometry(point, geometry)))
   }
 
-  override protected def encode(url: String): String = {
-    throw new NotImplementedError("Inherited method not implemented in KgvMunicipalityBorderClient")
-  }
-
   override protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int],
                                                         filter: Option[String]): Seq[LinkType] = {
     throw new NotImplementedError("Inherited method not implemented in KgvMunicipalityBorderClient")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -69,7 +69,7 @@ class KgvRoadLinkClient(collection: Option[KgvCollection] = None,linkGeomSourceV
 class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSourceValue: Option[LinkGeomSource] = None, extractor: ExtractorBase = new Extractor) extends KgvOperation(extractor) {
   override def restApiEndPoint: String = Digiroad2Properties.kgvEndpoint
   protected val serviceName:String = collection.getOrElse(throw new ClientException("Collection is not defined") ).value
-  protected val linkGeomSource: LinkGeomSource = linkGeomSourceValue.getOrElse(LinkGeomSource.Unknown)
+  protected val linkGeomSource: LinkGeomSource = LinkGeomSource.Unknown
 
   val filter: Filter = FilterOgc
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -169,10 +169,6 @@ class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSou
     throw new NotImplementedError("Inherited method not implemented in KgvMunicipalityBorderClient")
   }
 
-  override protected def addHeaders(request: HttpRequestBase): Unit = {
-    throw new NotImplementedError("Inherited method not implemented in KgvMunicipalityBorderClient")
-  }
-
   override protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int],
                                                         filter: Option[String]): Seq[LinkType] = {
     throw new NotImplementedError("Inherited method not implemented in KgvMunicipalityBorderClient")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -73,18 +73,18 @@ class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSou
 
   val filter: Filter = FilterOgc
 
-  def fetchAllMunicipalities(): Seq[Municipality] = {
+  def fetchAllMunicipalities(): Seq[MunicipalityBorders] = {
     val format = "f=application%2Fgeo%2Bjson"
     queryMunicipalityBorders(restApiEndPoint, serviceName, format)
     match {
       case Right(features) => features.get.features.map {feature =>
         val polygonFeature = feature.asInstanceOf[PolygonFeature]
-        Municipality(polygonFeature.properties("kuntanumer").toString.toInt, polygonFeature.polygonGeometry) }
+        MunicipalityBorders(polygonFeature.properties("kuntanumer").toString.toInt, polygonFeature.polygonGeometry) }
       case Left(error) => throw new ClientException(error.toString)
     }
   }
 
-  def fetchAllMunicipalitiesF(): Future[Seq[Municipality]] = {
+  def fetchAllMunicipalitiesF(): Future[Seq[MunicipalityBorders]] = {
     Future(fetchAllMunicipalities())
   }
 
@@ -161,7 +161,7 @@ class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSou
    * @return correct Municipality
    *
    */
-  def findMunicipalityForPoint(point: Point, municipalities: Seq[Municipality]): Option[Municipality] = {
+  def findMunicipalityForPoint(point: Point, municipalities: Seq[MunicipalityBorders]): Option[MunicipalityBorders] = {
     municipalities.find(municipality => municipality.geometry.exists(geometry => isPointInsideGeometry(point, geometry)))
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
@@ -31,7 +31,7 @@ sealed class BaseFeature(`type`: String, properties: Map[String, Any])
 sealed case class LineFeature(`type`: String, geometry: Geometry, properties: Map[String, Any]) extends BaseFeature(`type`, properties)
 sealed case class PolygonFeature(`type`: String, polygonGeometry: List[UtilGeometry], properties: Map[String, Any]) extends BaseFeature(`type`, properties)
 sealed case class Geometry(`type`: String, coordinates: List[List[Double]])
-sealed case class Municipality(municipalityCode: Int, geometry: List[UtilGeometry])
+sealed case class MunicipalityBorders(municipalityCode: Int, geometry: List[UtilGeometry])
 
 trait KgvCollection {
   def value :String

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
@@ -43,6 +43,7 @@ object KgvCollection {
   case object UnFrozen extends KgvCollection { def value = "keskilinjavarasto:road_links" }
   case object LinkVersios extends KgvCollection { def value = "keskilinjavarasto:road_links_versions" }
   case object LinkCorreponceTable extends KgvCollection { def value = "keskilinjavarasto:frozenlinks_vastintaulu" }
+  case object MunicipalityBorders extends KgvCollection { def value = "paikkatiedot:kuntarajat"}
 }
 
 object FilterOgc extends Filter {
@@ -430,7 +431,18 @@ abstract class KgvOperation(extractor:ExtractorBase) extends LinkOperationsAbstr
         throw e
     }
   }
-  
+
+  /**
+   * Fetches the Municipality that matches a location point
+   *
+   * @param point
+   * @return Municipality code
+   */
+  def queryMunicipalityBorders(restApiEndPoint: String, serviceName: String, format: String): Either[LinkOperationError, Option[FeatureCollection]] = {
+    fetchFeatures(s"$restApiEndPoint/$serviceName/items?$format&crs=$crs")
+  }
+
+
   override protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int],
                                                         filter: Option[String]): Seq[LinkType] = {
     val bbox = s"${bounds.leftBottom.x},${bounds.leftBottom.y},${bounds.rightTop.x},${bounds.rightTop.y}"
@@ -519,5 +531,5 @@ abstract class KgvOperation(extractor:ExtractorBase) extends LinkOperationsAbstr
   override protected def queryByMunicipalitiesAndBounds(bounds: BoundingRectangle, municipalities: Set[Int]): Seq[LinkType] = {
     queryByMunicipalitiesAndBounds(bounds, municipalities, None)
   }
-  
+
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
@@ -45,8 +45,7 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
 
   val specificFieldsMapping: Map[String, String] = Map()
   val nonMandatoryFieldsMapping: Map[String, String] = Map()
-  val collection = Some(KgvCollection.MunicipalityBorders)
-  val municipalityBorderClient = new KgvMunicipalityBorderClient(collection)
+  val municipalityBorderClient = new KgvMunicipalityBorderClient(Some(KgvCollection.MunicipalityBorders))
 
   def mandatoryFields: Set[String] = coordinateMappings.keySet
   def mandatoryFieldsMapping: Map[String, String] = coordinateMappings

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
@@ -45,10 +45,8 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
 
   val specificFieldsMapping: Map[String, String] = Map()
   val nonMandatoryFieldsMapping: Map[String, String] = Map()
-  val (collection, linkGeomSourceValue) = (
-    Some(KgvCollection.MunicipalityBorders),
-    Some(LinkGeomSource.Unknown))
-  val municipalityBorderClient = new KgvMunicipalityBorderClient(collection, linkGeomSourceValue)
+  val collection = Some(KgvCollection.MunicipalityBorders)
+  val municipalityBorderClient = new KgvMunicipalityBorderClient(collection)
 
   def mandatoryFields: Set[String] = coordinateMappings.keySet
   def mandatoryFieldsMapping: Map[String, String] = coordinateMappings

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
@@ -2,7 +2,8 @@ package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
-import fi.liikennevirasto.digiroad2.asset.{DateParser, PropertyValue, SimplePointAssetProperty}
+import fi.liikennevirasto.digiroad2.asset.{DateParser, LinkGeomSource, PropertyValue, SimplePointAssetProperty}
+import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvMunicipalityBorderClient, Municipality}
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.lane.{LaneNumber, LaneType}
 import fi.liikennevirasto.digiroad2.{AssetProperty, CsvDataImporterOperations, ExcludedRow, GeometryUtils, ImportResult, IncompleteRow, MalformedRow, Point, Status}
@@ -13,7 +14,7 @@ import org.apache.commons.lang3.StringUtils.isBlank
 import scala.util.Try
 
 trait PointAssetCsvImporter extends CsvDataImporterOperations {
-  case class CsvAssetRowAndRoadLink(properties: ParsedProperties, roadLink: Seq[RoadLink])
+  case class CsvAssetRowAndRoadLink(properties: ParsedProperties, roadLink: Seq[RoadLink], municipalityCode: Option[Int] = None)
 
   case class NotImportedData(reason: String, csvRow: String)
   case class ImportResultPointAsset(incompleteRows: List[IncompleteRow] = Nil,
@@ -44,6 +45,10 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
 
   val specificFieldsMapping: Map[String, String] = Map()
   val nonMandatoryFieldsMapping: Map[String, String] = Map()
+  val (collection, linkGeomSourceValue) = (
+    Some(KgvCollection.MunicipalityBorders),
+    Some(LinkGeomSource.Unknown))
+  val municipalityBorderClient = new KgvMunicipalityBorderClient(collection, linkGeomSourceValue)
 
   def mandatoryFields: Set[String] = coordinateMappings.keySet
   def mandatoryFieldsMapping: Map[String, String] = coordinateMappings
@@ -234,12 +239,20 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
       override val delimiter: Char = ';'
     })
     withDynTransaction {
+      val municipalityBorders = municipalityBorderClient.fetchAllMunicipalities()
       val result = csvReader.allWithHeaders().foldLeft(ImportResultPointAsset()) {
         (result, row) =>
           val csvRow = row.map(r => (r._1.toLowerCase(), r._2))
           val missingParameters = findMissingParameters(csvRow)
           val (malformedParameters, properties) = assetRowToProperties(csvRow)
           val (notImportedParameters, parsedRowAndRoadLink) = verifyData(properties, user)
+          val isServicePoint = csvRow.exists(property => property._1 == "palvelun tyyppi")
+          val municipalityCode = isServicePoint match {
+            case true =>
+              Some(getPointLocation(properties, municipalityBorders))
+            case false =>
+              None
+          }
 
           if (missingParameters.nonEmpty || malformedParameters.nonEmpty || notImportedParameters.nonEmpty) {
             result.copy(
@@ -263,12 +276,19 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
               createdData = parsedRowAndRoadLink match {
                 case Nil => result.createdData
                 case parameters =>
-                  CsvAssetRowAndRoadLink(properties = parameters.head.properties, roadLink = parameters.head.roadLink) :: result.createdData
+                  CsvAssetRowAndRoadLink(properties = parameters.head.properties, roadLink = parameters.head.roadLink, municipalityCode = municipalityCode) :: result.createdData
               })
           }
       }
       createAsset(result.createdData, user, result)
     }
+  }
+
+  def getPointLocation(parsedRow: ParsedProperties, municipalityBorders: Seq[Municipality]): Int = {
+    val lon = getPropertyValueOption(parsedRow, "lon").asInstanceOf[Option[BigDecimal]].get
+    val lat = getPropertyValueOption(parsedRow, "lat").asInstanceOf[Option[BigDecimal]].get
+
+    municipalityBorderClient.findMunicipalityForPoint(Point(lon.toDouble, lat.toDouble), municipalityBorders).get.municipalityCode
   }
 
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.csvDataImporter
 import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
 import fi.liikennevirasto.digiroad2.asset.{DateParser, LinkGeomSource, PropertyValue, SimplePointAssetProperty}
-import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvMunicipalityBorderClient, Municipality}
+import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvMunicipalityBorderClient, MunicipalityBorders}
 import fi.liikennevirasto.digiroad2.dao.Sequences
 import fi.liikennevirasto.digiroad2.lane.{LaneNumber, LaneType}
 import fi.liikennevirasto.digiroad2.{AssetProperty, CsvDataImporterOperations, ExcludedRow, GeometryUtils, ImportResult, IncompleteRow, MalformedRow, Point, Status}
@@ -281,7 +281,7 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
     }
   }
 
-  def getLocationFromProperties(parsedRow: ParsedProperties, municipalityBorders: Seq[Municipality]): Int = {
+  def getLocationFromProperties(parsedRow: ParsedProperties, municipalityBorders: Seq[MunicipalityBorders]): Int = {
     val lon = getPropertyValueOption(parsedRow, "lon").asInstanceOf[Option[BigDecimal]].get
     val lat = getPropertyValueOption(parsedRow, "lat").asInstanceOf[Option[BigDecimal]].get
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PointAssetCsvImporter.scala
@@ -249,7 +249,7 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
           val isServicePoint = csvRow.exists(property => property._1 == "palvelun tyyppi")
           val municipalityCode = isServicePoint match {
             case true =>
-              Some(getPointLocation(properties, municipalityBorders))
+              Some(getLocationFromProperties(properties, municipalityBorders))
             case false =>
               None
           }
@@ -284,7 +284,7 @@ trait PointAssetCsvImporter extends CsvDataImporterOperations {
     }
   }
 
-  def getPointLocation(parsedRow: ParsedProperties, municipalityBorders: Seq[Municipality]): Int = {
+  def getLocationFromProperties(parsedRow: ParsedProperties, municipalityBorders: Seq[Municipality]): Int = {
     val lon = getPropertyValueOption(parsedRow, "lon").asInstanceOf[Option[BigDecimal]].get
     val lat = getPropertyValueOption(parsedRow, "lat").asInstanceOf[Option[BigDecimal]].get
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ServicePointCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ServicePointCsvImporter.scala
@@ -1,8 +1,7 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import java.text.Normalizer
-
-import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, Point}
 import fi.liikennevirasto.digiroad2.asset.{ServicePointsClass, State}
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{IncomingService, IncomingServicePoint}
@@ -11,6 +10,7 @@ import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.{ServicePointException, ServicePointService}
 import fi.liikennevirasto.digiroad2.user.User
+import scala.util.{Try, Success, Failure}
 
 class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends PointAssetCsvImporter {
   override def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
@@ -32,7 +32,8 @@ class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl
 
   lazy val servicePointService: ServicePointService = new ServicePointService
 
-  case class CsvServicePoint(position: Point, incomingService: IncomingService, roadLink: RoadLink, importInformation: Seq[NotImportedData] = Seq.empty)
+  val municipalityBorders = municipalityBorderClient.fetchAllMunicipalities()
+  case class CsvServicePoint(position: Point, incomingService: IncomingService, municipalityCode: Int, importInformation: Seq[NotImportedData] = Seq.empty)
 
   private def serviceTypeConverter(serviceType: String): Int = {
     val value = Normalizer.normalize(serviceType, Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "").replaceAll("-|\\s", "").toLowerCase
@@ -50,10 +51,7 @@ class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl
   override def createAsset(pointAssetAttributes: Seq[CsvAssetRowAndRoadLink], user: User, result: ImportResultPointAsset): ImportResultPointAsset = {
     val incomingServicePoint = pointAssetAttributes.map { servicePointAttribute =>
       val csvProperties = servicePointAttribute.properties
-      val nearbyLinks = servicePointAttribute.roadLink
       val position = getCoordinatesFromProperties(csvProperties)
-      val nearestRoadLink = nearbyLinks.filter(_.administrativeClass != State).minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
-
       val serviceType = getPropertyValue(csvProperties, "type").asInstanceOf[String]
       val typeExtension = getPropertyValueOption(csvProperties, "type extension").map(_.toString)
       val name = getPropertyValueOption(csvProperties, "name").map(_.toString)
@@ -73,8 +71,8 @@ class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl
           Seq(NotImportedData(reason = s"Service Point type $serviceType does not exist.", csvRow = rowToString(csvProperties.flatMap{x => Map(x.columnName -> x.value)}.toMap)))
         else
           Seq()
-
-      CsvServicePoint(position, incomingService, nearestRoadLink, servicePointInfo)
+      val municipalityCode = servicePointAttribute.municipalityCode.get
+      CsvServicePoint(position, incomingService, municipalityCode, servicePointInfo)
     }
 
     val (validServicePoints, nonValidServicePoints) = incomingServicePoint.partition(servicePoint => servicePoint.importInformation.isEmpty)
@@ -82,18 +80,38 @@ class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl
     val groupedServicePoints = validServicePoints.groupBy(_.position)
 
     val incomingServicePoints = groupedServicePoints.map { servicePoint =>
-      (IncomingServicePoint(servicePoint._1.x, servicePoint._1.y, servicePoint._2.map(_.incomingService).toSet, Set()), servicePoint._2.map(_.roadLink).head.municipalityCode)
+      (IncomingServicePoint(servicePoint._1.x, servicePoint._1.y, servicePoint._2.map(_.incomingService).toSet, Set()), servicePoint._2.head.municipalityCode)
     }
 
-    incomingServicePoints.foreach { incomingAsset =>
-      try {
-        servicePointService.create(incomingAsset._1, incomingAsset._2, user.username, false)
-      } catch {
-        case e: ServicePointException => result.copy(notImportedData = List(NotImportedData(reason = e.getMessage, csvRow = "")) ++ result.notImportedData)
+    val unauthoredData = incomingServicePoints.flatMap { elem =>
+      Try {
+        servicePointService.create(elem._1, elem._2, user.username, false)
+      } match {
+        case Success(_) => None
+        case Failure(e: ServicePointException) =>
+          Some(NotImportedData(reason = e.getMessage, csvRow = ""))
       }
     }
 
-    result.copy(notImportedData = notImportedInfo.toList ++ result.notImportedData)
+    result.copy(notImportedData = notImportedInfo.toList ++ result.notImportedData ++ unauthoredData)
+  }
+
+  override def verifyData(parsedRow: ParsedProperties, user: User): ParsedCsv = {
+    val optLon = getPropertyValueOption(parsedRow, "lon").asInstanceOf[Option[BigDecimal]]
+    val optLat = getPropertyValueOption(parsedRow, "lat").asInstanceOf[Option[BigDecimal]]
+
+    (optLon, optLat) match {
+      case (Some(lon), Some(lat)) =>
+        val municipality = municipalityBorderClient.findMunicipalityForPoint(Point(lon.toDouble, lat.toDouble), municipalityBorders)
+        municipality match {
+          case Some(foundMunicipality) =>
+            (List(), Seq(CsvAssetRowAndRoadLink(parsedRow, Seq.empty[RoadLink])))
+          case None =>
+            (Nil, Nil)
+        }
+      case _ =>
+        (Nil, Nil)
+    }
   }
 }
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvMunicipalityBorderClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvMunicipalityBorderClientSpec.scala
@@ -11,7 +11,7 @@ import scala.concurrent.duration.Duration
 
 class KgvMunicipalityBorderClientSpec extends FunSuite with Matchers{
 
-  test("Should fetch municipalities") {
+  ignore("Should fetch municipalities") {
     val (collection, linkGeomSourceValue) = (
       Some(KgvCollection.MunicipalityBorders),
       Some(LinkGeomSource.Unknown))
@@ -23,7 +23,7 @@ class KgvMunicipalityBorderClientSpec extends FunSuite with Matchers{
     municipalities.size should be(309)
   }
 
-  test("Should find correct Municipality with a given point") {
+  ignore("Should find correct Municipality with a given point") {
     val (collection, linkGeomSourceValue) = (
       Some(KgvCollection.MunicipalityBorders),
       Some(LinkGeomSource.Unknown))

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvMunicipalityBorderClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvMunicipalityBorderClientSpec.scala
@@ -1,0 +1,40 @@
+package fi.liikennevirasto.digiroad2.client
+
+import fi.liikennevirasto.digiroad2.Point
+import fi.liikennevirasto.digiroad2.asset.LinkGeomSource
+import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvMunicipalityBorderClient}
+
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+class KgvMunicipalityBorderClientSpec extends FunSuite with Matchers{
+
+  test("Should fetch municipalities") {
+    val (collection, linkGeomSourceValue) = (
+      Some(KgvCollection.MunicipalityBorders),
+      Some(LinkGeomSource.Unknown))
+    val municipalityBorderClient = new KgvMunicipalityBorderClient(collection, linkGeomSourceValue)
+    val begin = System.currentTimeMillis()
+    val municipalities = Await.result(municipalityBorderClient.fetchAllMunicipalitiesF(), atMost = Duration.Inf)
+    val duration = System.currentTimeMillis() - begin
+    println(s"all Municipalities fetched in $duration ms and in second ${duration / 1000}")
+    municipalities.size should be(309)
+  }
+
+  test("Should find correct Municipality with a given point") {
+    val (collection, linkGeomSourceValue) = (
+      Some(KgvCollection.MunicipalityBorders),
+      Some(LinkGeomSource.Unknown))
+    val municipalityBorderClient = new KgvMunicipalityBorderClient(collection, linkGeomSourceValue)
+    val begin = System.currentTimeMillis()
+    val municipalities = Await.result(municipalityBorderClient.fetchAllMunicipalitiesF(), atMost = Duration.Inf)
+    val point = Point(594921.82429447, 7342797.0430049)
+    val municipality = municipalityBorderClient.findMunicipalityForPoint(point, municipalities)
+    val duration = System.currentTimeMillis() - begin
+    println(s"correct Municipality found in $duration ms and in second ${duration / 1000}")
+    municipality should not be (None)
+    municipality.get.municipalityCode should be(305)
+  }
+}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.client
 import com.vividsolutions.jts.geom.GeometryFactory
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource}
-import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvRoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvMunicipalityBorderClient, KgvRoadLinkClient}
 import org.geotools.geometry.jts.GeometryBuilder
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}
@@ -116,5 +116,18 @@ class KgvRoadLinkClientSpec extends FunSuite with Matchers{
     val duration = System.currentTimeMillis() - begin
     println(s"roadlink with municipality completed in $duration ms and in second ${duration / 1000}")
     result.size should be(4447)
+  }
+
+  test("Fetch municipalities") {
+    val (collection,linkGeomSourceValue) = (
+      Some(KgvCollection.MunicipalityBorders),
+      Some(LinkGeomSource.Unknown))
+    val municipalityBorderClient = new KgvMunicipalityBorderClient(collection, linkGeomSourceValue)
+    val begin = System.currentTimeMillis()
+    /*val municipalities = Await.result(municipalityBorderClient.fetchAllMunicipalityBorders(), atMost = Duration.Inf)
+    val duration = System.currentTimeMillis() - begin*/
+    val municipalities = municipalityBorderClient.fetchAllMunicipalityBorders()
+    //println(s"all Municipalities fetched in $duration ms and in second ${duration / 1000}")
+    municipalities.size should be(309)
   }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
@@ -117,17 +117,4 @@ class KgvRoadLinkClientSpec extends FunSuite with Matchers{
     println(s"roadlink with municipality completed in $duration ms and in second ${duration / 1000}")
     result.size should be(4447)
   }
-
-  test("Fetch municipalities") {
-    val (collection,linkGeomSourceValue) = (
-      Some(KgvCollection.MunicipalityBorders),
-      Some(LinkGeomSource.Unknown))
-    val municipalityBorderClient = new KgvMunicipalityBorderClient(collection, linkGeomSourceValue)
-    val begin = System.currentTimeMillis()
-    /*val municipalities = Await.result(municipalityBorderClient.fetchAllMunicipalityBorders(), atMost = Duration.Inf)
-    val duration = System.currentTimeMillis() - begin*/
-    val municipalities = municipalityBorderClient.fetchAllMunicipalityBorders()
-    //println(s"all Municipalities fetched in $duration ms and in second ${duration / 1000}")
-    municipalities.size should be(309)
-  }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/client/KgvRoadLinkClientSpec.scala
@@ -3,7 +3,7 @@ package fi.liikennevirasto.digiroad2.client
 import com.vividsolutions.jts.geom.GeometryFactory
 import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset.{BoundingRectangle, LinkGeomSource}
-import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvMunicipalityBorderClient, KgvRoadLinkClient}
+import fi.liikennevirasto.digiroad2.client.kgv.{KgvCollection, KgvRoadLinkClient}
 import org.geotools.geometry.jts.GeometryBuilder
 import org.joda.time.DateTime
 import org.scalatest.{FunSuite, Matchers}


### PR DESCRIPTION
Lisätty KGVClient operaatioineen kuntarajojen hakemiseen ja pisteen sijainnin paikallistamiseen.

PointAssetCsvImporter ja ServicePointCsvImporter muokattu niin, ettei palvelupisteiden tarvitse olla tielinkillä. Kuntakoodi haetaan kgv clientin avulla. Käytetty olemassaolevia rakenteita niin pitkälle kuin mahdollista.

Muokattu virheilmoitusta niin, että viranomaisdatavaatimusten aiheuttama epäonnistuminen esitetään käyttöliittymässä oranssilla ikonilla.