### PR TITLE
DROTH-3887 prevent point asset movement on property update

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISServicePointDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISServicePointDao.scala
@@ -12,10 +12,7 @@ import fi.liikennevirasto.digiroad2.dao.{Queries, Sequences}
 import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery}
 
-case class IncomingServicePoint(lon: Double,
-                                lat: Double,
-                                services: Set[IncomingService],
-                                propertyData: Set[SimplePointAssetProperty])
+case class IncomingServicePoint(lon: Double, lat: Double, services: Set[IncomingService], propertyData: Set[SimplePointAssetProperty], mValue: Option[Double] = None)
 
 case class IncomingService(serviceType: Int,
                            name: Option[String],

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/DirectionalTrafficSignService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/DirectionalTrafficSignService.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.linearasset.{LinkId, RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import org.joda.time.DateTime
 
-case class IncomingDirectionalTrafficSign(lon: Double, lat: Double, linkId: String, validityDirection: Int, bearing: Option[Int], propertyData: Set[SimplePointAssetProperty]) extends IncomingPointAsset
+case class IncomingDirectionalTrafficSign(lon: Double, lat: Double, linkId: String, validityDirection: Int, bearing: Option[Int], propertyData: Set[SimplePointAssetProperty], mValue: Option[Double] = None) extends IncomingPointAsset
 
 
 class DirectionalTrafficSignService(val roadLinkService: RoadLinkService) extends PointAssetOperations {
@@ -88,7 +88,7 @@ class DirectionalTrafficSignService(val roadLinkService: RoadLinkService) extend
   }
 
   def updateWithoutTransaction(id: Long, updatedAsset: IncomingDirectionalTrafficSign, roadLink: RoadLink,  username: String): Long = {
-    val mValue = GeometryUtils.calculateLinearReferenceFromPoint(Point(updatedAsset.lon, updatedAsset.lat), roadLink.geometry)
+    val mValue = updatedAsset.mValue.getOrElse(GeometryUtils.calculateLinearReferenceFromPoint(Point(updatedAsset.lon, updatedAsset.lat), roadLink.geometry))
     updateWithoutTransaction(id, updatedAsset, Some(mValue), roadLink.geometry, roadLink.municipalityCode, username)
   }
 
@@ -101,7 +101,7 @@ class DirectionalTrafficSignService(val roadLinkService: RoadLinkService) extend
         PostGISDirectionalTrafficSignDao.create(setAssetPosition(updatedAsset, linkGeom, value), value,
           linkMunicipality, username, old.createdBy, old.createdAt, old.externalId, fromPointAssetUpdater, old.modifiedBy, old.modifiedAt)
       case _ =>
-        PostGISDirectionalTrafficSignDao.update(id, setAssetPosition(updatedAsset, linkGeom, value), value,
+        PostGISDirectionalTrafficSignDao.update(id, updatedAsset, value,
           linkMunicipality, username, fromPointAssetUpdater)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleService.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.linearasset.{LinkId, RoadLink, RoadLinkLike}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.User
 
-case class IncomingObstacle(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty]) extends IncomingPointAsset
+case class IncomingObstacle(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty], mValue: Option[Double] = None) extends IncomingPointAsset
 
 case class IncomingObstacleAsset(linkId: String, mValue: Long, propertyData: Set[SimplePointAssetProperty])  extends IncomePointAsset
 
@@ -88,7 +88,7 @@ class ObstacleService(val roadLinkService: RoadLinkService) extends PointAssetOp
 
   override def update(id: Long, updatedAsset: IncomingObstacle, roadLink: RoadLink, username: String): Long = {
     withDynTransaction {
-      updateWithoutTransaction(id, updatedAsset, roadLink, username, None, None)
+      updateWithoutTransaction(id, updatedAsset, roadLink, username, updatedAsset.mValue, None)
     }
   }
 
@@ -106,7 +106,7 @@ class ObstacleService(val roadLinkService: RoadLinkService) extends PointAssetOp
         PostGISObstacleDao.create(setAssetPosition(updatedAsset, linkGeom, value), value, username, linkMunicipality,
           timeStamp.getOrElse(createTimeStamp()), linkSource, old.createdBy, old.createdAt, old.externalId, fromPointAssetUpdater, old.modifiedBy, old.modifiedAt)
       case _ =>
-        PostGISObstacleDao.update(id, setAssetPosition(updatedAsset, linkGeom, value), value, username, linkMunicipality,
+        PostGISObstacleDao.update(id, updatedAsset, value, username, linkMunicipality,
           Some(timeStamp.getOrElse(createTimeStamp())), linkSource, fromPointAssetUpdater)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PedestrianCrossingService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/PedestrianCrossingService.scala
@@ -10,7 +10,7 @@ import fi.liikennevirasto.digiroad2.process.AssetValidatorInfo
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.User
 
-case class IncomingPedestrianCrossing(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty]) extends IncomingPointAsset
+case class IncomingPedestrianCrossing(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty], mValue: Option[Double] = None) extends IncomingPointAsset
 case class IncomingPedestrianCrossingAsset(linkId: String, mValue: Long, propertyData: Set[SimplePointAssetProperty]) extends IncomePointAsset
 
 class PedestrianCrossingService(val roadLinkService: RoadLinkService, eventBus: DigiroadEventBus) extends PointAssetOperations {
@@ -86,7 +86,7 @@ class PedestrianCrossingService(val roadLinkService: RoadLinkService, eventBus: 
   override def update(id: Long, updatedAsset: IncomingPedestrianCrossing, roadLink: RoadLink, username: String): Long = {
     val pedestrianIdUpdated =
     withDynTransaction {
-      updateWithoutTransaction(id, updatedAsset, roadLink, username, None, None)
+      updateWithoutTransaction(id, updatedAsset, roadLink, username, updatedAsset.mValue, None)
     }
     pedestrianCrossingValidatorActor(Set(id, pedestrianIdUpdated))
     pedestrianIdUpdated
@@ -106,7 +106,7 @@ class PedestrianCrossingService(val roadLinkService: RoadLinkService, eventBus: 
         dao.create(setAssetPosition(updatedAsset, linkGeom, value), value, username, linkMunicipality,
           timeStamp.getOrElse(createTimeStamp()), linkSource, old.createdBy, old.createdAt, old.externalId, fromPointAssetUpdater, old.modifiedBy, old.modifiedAt)
       case _ =>
-        dao.update(id, setAssetPosition(updatedAsset, linkGeom, value), value, username, linkMunicipality,
+        dao.update(id, updatedAsset, value, username, linkMunicipality,
           Some(timeStamp.getOrElse(createTimeStamp())), linkSource, fromPointAssetUpdater)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingService.scala
@@ -9,7 +9,7 @@ import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.User
 import org.joda.time.DateTime
 
-case class IncomingRailwayCrossing(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty]) extends IncomingPointAsset
+case class IncomingRailwayCrossing(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty], mValue: Option[Double] = None) extends IncomingPointAsset
 case class IncomingRailwayCrossingtAsset(linkId: String, mValue: Long, propertyData: Set[SimplePointAssetProperty])  extends IncomePointAsset
 
 class RailwayCrossingService(val roadLinkService: RoadLinkService) extends PointAssetOperations {
@@ -104,7 +104,7 @@ class RailwayCrossingService(val roadLinkService: RoadLinkService) extends Point
 
   override def update(id: Long, updatedAsset: IncomingRailwayCrossing, roadLink: RoadLink, username: String): Long = {
     withDynTransaction {
-      updateWithoutTransaction(id, updatedAsset, roadLink, username, None, None)
+      updateWithoutTransaction(id, updatedAsset, roadLink, username, updatedAsset.mValue, None)
     }
   }
 
@@ -122,7 +122,7 @@ class RailwayCrossingService(val roadLinkService: RoadLinkService) extends Point
         PostGISRailwayCrossingDao.create(setAssetPosition(updatedAsset, linkGeom, value), value, linkMunicipality, username,
           timeStamp.getOrElse(createTimeStamp()), linkSource, old.createdBy, old.createdAt, old.externalId, fromPointAssetUpdater, old.modifiedBy, old.modifiedAt)
       case _ =>
-        PostGISRailwayCrossingDao.update(id, setAssetPosition(updatedAsset, linkGeom, value), value, linkMunicipality, username,
+        PostGISRailwayCrossingDao.update(id, updatedAsset, value, linkMunicipality, username,
           Some(timeStamp.getOrElse(createTimeStamp())), linkSource, fromPointAssetUpdater)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightService.scala
@@ -9,7 +9,7 @@ import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.user.User
 import org.joda.time.DateTime
 
-case class IncomingTrafficLight(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty], validityDirection: Option[Int] = None, bearing: Option[Int] = None) extends IncomingPointAsset
+case class IncomingTrafficLight(lon: Double, lat: Double, linkId: String, propertyData: Set[SimplePointAssetProperty], validityDirection: Option[Int] = None, bearing: Option[Int] = None, mValue: Option[Double] = None) extends IncomingPointAsset
 case class IncomingTrafficLightAsset(linkId: String, mValue: Long, propertyData: Set[SimplePointAssetProperty]) extends IncomePointAsset
 
 class TrafficLightService(val roadLinkService: RoadLinkService) extends PointAssetOperations {
@@ -29,7 +29,7 @@ class TrafficLightService(val roadLinkService: RoadLinkService) extends PointAss
 
   override def update(id: Long, updatedAsset: IncomingTrafficLight, roadLink: RoadLink, username: String): Long = {
     withDynTransaction {
-      updateWithoutTransaction(id, updatedAsset, roadLink, username, None, None)
+      updateWithoutTransaction(id, updatedAsset, roadLink, username, updatedAsset.mValue, None)
     }
   }
 
@@ -48,7 +48,7 @@ class TrafficLightService(val roadLinkService: RoadLinkService) extends PointAss
         PostGISTrafficLightDao.create(setAssetPosition(updatedAsset, linkGeometry, value), value, username, municipality,
           timeStamp.getOrElse(createTimeStamp()), linkSource, old.createdBy, old.createdAt, old.externalId, fromPointAssetUpdater, old.modifiedBy, old.modifiedAt)
       case _ =>
-        PostGISTrafficLightDao.update(id, setAssetPosition(updatedAsset, linkGeometry, value), value, username, municipality,
+        PostGISTrafficLightDao.update(id, updatedAsset, value, username, municipality,
           Some(timeStamp.getOrElse(createTimeStamp())), linkSource, fromPointAssetUpdater)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopService.scala
@@ -19,7 +19,7 @@ import slick.driver.JdbcDriver.backend.Database.dynamicSession
 import slick.jdbc.StaticQuery
 import slick.jdbc.StaticQuery.interpolation
 
-case class NewMassTransitStop(lon: Double, lat: Double, linkId: String, bearing: Int, properties: Seq[SimplePointAssetProperty]) extends IncomingPointAsset
+case class NewMassTransitStop(lon: Double, lat: Double, linkId: String, bearing: Int, properties: Seq[SimplePointAssetProperty], mValue: Option[Double] = None) extends IncomingPointAsset
 
 case class MassTransitStop(id: Long, nationalId: Long, lon: Double, lat: Double, bearing: Option[Int],
                            validityDirection: Int, municipalityNumber: Int,

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/DirectionalTrafficSignServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/DirectionalTrafficSignServiceSpec.scala
@@ -142,7 +142,7 @@ class DirectionalTrafficSignServiceSpec extends FunSuite with Matchers {
   }
 
   test("Update directional traffic sign without geometry changes") {
-    val linkGeometry = Seq(Point(0.0, 0.0), Point(100.0, 0.0))
+    val linkGeometry = Seq(Point(73.0, 9.0), Point(100.0, 18.0))
     val linkId = LinkIdGenerator.generateRandom()
     when(mockRoadLinkService.getRoadLinksWithComplementaryByMunicipalityUsingCache(235)).thenReturn(Seq(
       RoadLinkFetched(linkId, 235, linkGeometry, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)).map(toRoadLink))
@@ -154,16 +154,16 @@ class DirectionalTrafficSignServiceSpec extends FunSuite with Matchers {
     runWithRollback {
       val textValues = Seq(PropertyValue("HELSINKI:HELSINGFORS;;;;1;1;"))
       val simpleProperty = SimplePointAssetProperty("opastustaulun_teksti", textValues)
-      val assetCreatedID = service.create(IncomingDirectionalTrafficSign(100, 0, linkId, 3, Some(0), Set(simpleProperty)), "test", roadLink)
+      val assetCreatedID = service.create(IncomingDirectionalTrafficSign(76, 10, linkId, 3, Some(0), Set(simpleProperty)), "test", roadLink)
       val assets = service.getPersistedAssetsByIds(Set(assetCreatedID))
 
       val beforeUpdate = assets.head
 
       beforeUpdate.id should be(assetCreatedID)
       beforeUpdate.linkId should be(linkId)
-      beforeUpdate.lon should be(100)
-      beforeUpdate.lat should be(0)
-      beforeUpdate.mValue should be(100)
+      beforeUpdate.lon should be(76.0)
+      beforeUpdate.lat should be(10.0)
+      beforeUpdate.mValue should be(3.162)
       beforeUpdate.floating should be(false)
       beforeUpdate.municipalityCode should be(235)
       beforeUpdate.validityDirection should be(3)
@@ -173,13 +173,13 @@ class DirectionalTrafficSignServiceSpec extends FunSuite with Matchers {
 
       val updatedTextValues = Seq(PropertyValue("New text"))
       val updatedSimpleProperty = SimplePointAssetProperty("opastustaulun_teksti", updatedTextValues)
-      service.update(assetCreatedID, IncomingDirectionalTrafficSign(100, 0, linkId, 3, Some(0), Set(updatedSimpleProperty)), roadLink, "test")
+      service.update(assetCreatedID, IncomingDirectionalTrafficSign(beforeUpdate.lon, beforeUpdate.lat, linkId, 3, Some(0), Set(updatedSimpleProperty), Some(beforeUpdate.mValue)), roadLink, "test")
 
       val afterUpdate = service.getByMunicipality(235).find(_.id == assetCreatedID).get
       afterUpdate.id should equal(assetCreatedID)
-      afterUpdate.lon should equal(100)
-      afterUpdate.lat should equal(0.0)
-      afterUpdate.mValue should equal(100.0)
+      afterUpdate.lon should equal(beforeUpdate.lon)
+      afterUpdate.lat should equal(beforeUpdate.lat)
+      afterUpdate.mValue should equal(beforeUpdate.mValue)
       afterUpdate.linkId should equal(linkId)
       afterUpdate.municipalityCode should equal(235)
       afterUpdate.createdBy should equal(Some("test"))

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/ObstacleServiceSpec.scala
@@ -335,20 +335,21 @@ class ObstacleServiceSpec extends FunSuite with Matchers {
   test("Update obstacle without geometry changes"){
     runWithRollback {
       val linkId = LinkIdGenerator.generateRandom()
-      val roadLink = RoadLink(linkId, Seq(Point(0.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
+      val roadLink = RoadLink(linkId, Seq(Point(5.0, 0.0), Point(10.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       val values = Seq(PropertyValue("2"))
       val simpleProperty = SimplePointAssetProperty("esterakennelma", values)
-      val id = service.create(IncomingObstacle(0.0, 20.0, linkId, Set(simpleProperty)), "jakke", roadLink )
+      val id = service.create(IncomingObstacle(9.5, 19.0, linkId, Set(simpleProperty)), "jakke", roadLink )
       val asset = service.getPersistedAssetsByIds(Set(id)).head
 
       val updatedValues = Seq(PropertyValue("1"))
       val updatedSimpleProperty = SimplePointAssetProperty("esterakennelma", updatedValues)
-      val newId = service.update(id, IncomingObstacle(0.0, 20.0, linkId, Set(updatedSimpleProperty)), roadLink, "test")
+      val newId = service.update(id, IncomingObstacle(asset.lon, asset.lat, linkId, Set(updatedSimpleProperty), Some(asset.mValue)), roadLink, "test")
 
       val updatedAsset = service.getPersistedAssetsByIds(Set(newId)).head
       updatedAsset.id should be (id)
       updatedAsset.lon should be (asset.lon)
       updatedAsset.lat should be (asset.lat)
+      updatedAsset.mValue should be (asset.mValue)
       updatedAsset.createdBy should equal (Some("jakke"))
       updatedAsset.modifiedBy should equal (Some("test"))
       updatedAsset.propertyData.find(_.publicId == "esterakennelma").get.values.head.asInstanceOf[PropertyValue].propertyValue.toInt should equal(1)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PedestrianCrossingServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/PedestrianCrossingServiceSpec.scala
@@ -172,16 +172,17 @@ class PedestrianCrossingServiceSpec extends FunSuite with Matchers {
   test("Update pedestrian crossing without geometry changes"){
     runWithRollback {
       val linkId = randomLinkId
-      val roadLink = RoadLink(linkId, Seq(Point(0.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
-      val id = service.create(IncomingPedestrianCrossing(0.0, 20.0, linkId, Set()), "jakke", roadLink )
+      val roadLink = RoadLink(linkId, Seq(Point(2.0, 0.0), Point(4.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
+      val id = service.create(IncomingPedestrianCrossing(3.15, 11.5, linkId, Set()), "jakke", roadLink )
       val asset = service.getPersistedAssetsByIds(Set(id)).head
 
-      val newId = service.update(id, IncomingPedestrianCrossing(0.0, 20.0, linkId, Set()), roadLink, "test")
+      val newId = service.update(id, IncomingPedestrianCrossing(asset.lon, asset.lat, linkId, Set(), Some(asset.mValue)), roadLink, "test")
 
       val updatedAsset = service.getPersistedAssetsByIds(Set(newId)).head
       updatedAsset.id should be (id)
       updatedAsset.lon should be (asset.lon)
       updatedAsset.lat should be (asset.lat)
+      updatedAsset.mValue should be(asset.mValue)
       updatedAsset.createdBy should equal (Some("jakke"))
       updatedAsset.modifiedBy should equal (Some("test"))
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/RailwayCrossingServiceSpec.scala
@@ -121,14 +121,14 @@ class RailwayCrossingServiceSpec extends FunSuite with Matchers {
   test("Update railway crossing without geometry changes"){
     runWithRollback {
       val linkId = randomLinkId
-      val roadLink = RoadLink(linkId, Seq(Point(0.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
+      val roadLink = RoadLink(linkId, Seq(Point(3.0, 5.0), Point(9.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       val codeValue = PropertyValue("")
       val safetyEquipmentValue = PropertyValue("1")
       val nameValue = PropertyValue("testCode")
       val simpleCodeProperty = SimplePointAssetProperty("tasoristeystunnus", Seq(codeValue))
       val simpleSafetyEquipmentProperty = SimplePointAssetProperty("turvavarustus", Seq(safetyEquipmentValue))
       val simpleNameProperty = SimplePointAssetProperty("rautatien_tasoristeyksen_nimi", Seq(nameValue))
-      val id = service.create(IncomingRailwayCrossing(0.0, 20.0, linkId, Set(simpleCodeProperty, simpleSafetyEquipmentProperty, simpleNameProperty)), "jakke", roadLink )
+      val id = service.create(IncomingRailwayCrossing(7.0, 15.0, linkId, Set(simpleCodeProperty, simpleSafetyEquipmentProperty, simpleNameProperty)), "jakke", roadLink )
       val asset = service.getPersistedAssetsByIds(Set(id)).head
 
       val updatedCodeValue = PropertyValue("")
@@ -137,12 +137,13 @@ class RailwayCrossingServiceSpec extends FunSuite with Matchers {
       val updatedSimpleCodeProperty = SimplePointAssetProperty("tasoristeystunnus", Seq(updatedCodeValue))
       val updatedSimpleSafetyEquipmentProperty = SimplePointAssetProperty("turvavarustus", Seq(updatedSafetyEquipmentValue))
       val updatedSimpleNameProperty = SimplePointAssetProperty("rautatien_tasoristeyksen_nimi", Seq(updatedNameValue))
-      val newId = service.update(id, IncomingRailwayCrossing(0.0, 20.0, linkId, Set(updatedSimpleCodeProperty, updatedSimpleNameProperty, updatedSimpleSafetyEquipmentProperty)), roadLink, "test")
+      val newId = service.update(id, IncomingRailwayCrossing(asset.lon, asset.lat, linkId, Set(updatedSimpleCodeProperty, updatedSimpleNameProperty, updatedSimpleSafetyEquipmentProperty), Some(asset.mValue)), roadLink, "test")
 
       val updatedAsset = service.getPersistedAssetsByIds(Set(newId)).head
       updatedAsset.id should be (id)
       updatedAsset.lon should be (asset.lon)
       updatedAsset.lat should be (asset.lat)
+      updatedAsset.mValue should be (asset.mValue)
       updatedAsset.createdBy should equal (Some("jakke"))
       updatedAsset.modifiedBy should equal (Some("test"))
     }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficLightServiceSpec.scala
@@ -252,15 +252,15 @@ class TrafficLightServiceSpec  extends FunSuite with Matchers {
   test("Update traffic light with geometry changes"){
     runWithRollback {
       val linkId = randomLinkId1
-      val roadLink = RoadLink(linkId, Seq(Point(0.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
+      val roadLink = RoadLink(linkId, Seq(Point(5.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
       val id = service.create(IncomingTrafficLight(0.0, 20.0, linkId, Set()), "jakke", roadLink )
       val oldAsset = service.getPersistedAssetsByIds(Set(id)).head
       oldAsset.modifiedAt.isDefined should equal(false)
-      val newId = service.update(id, IncomingTrafficLight(0.0, 10.0, linkId, Set()), roadLink, "test")
+      val newId = service.update(id, IncomingTrafficLight(2.5, 10.0, linkId, Set()), roadLink, "test")
 
       val updatedAsset = service.getPersistedAssetsByIds(Set(newId)).head
       updatedAsset.id should not be id
-      updatedAsset.lon should equal (0.0)
+      updatedAsset.lon should equal (2.5)
       updatedAsset.lat should equal (10.0)
       updatedAsset.createdBy should equal (oldAsset.createdBy)
       updatedAsset.createdAt should equal (oldAsset.createdAt)
@@ -272,16 +272,17 @@ class TrafficLightServiceSpec  extends FunSuite with Matchers {
   test("Update traffic light without geometry changes"){
     runWithRollback {
       val linkId = randomLinkId1
-      val roadLink = RoadLink(linkId, Seq(Point(0.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
-      val id = service.create(IncomingTrafficLight(0.0, 20.0, linkId, Set()), "jakke", roadLink )
+      val roadLink = RoadLink(linkId, Seq(Point(10.0, 40.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
+      val id = service.create(IncomingTrafficLight(6.0, 28.0, linkId, Set()), "jakke", roadLink )
       val asset = service.getPersistedAssetsByIds(Set(id)).head
 
-      val newId = service.update(id, IncomingTrafficLight(0.0, 20.0, linkId, Set()), roadLink,  "test")
+      val newId = service.update(id, IncomingTrafficLight(asset.lon, asset.lat, linkId, Set(), asset.getValidityDirection, asset.getBearing, Some(asset.mValue)), roadLink,  "test")
 
       val updatedAsset = service.getPersistedAssetsByIds(Set(newId)).head
       updatedAsset.id should be (id)
       updatedAsset.lon should be (asset.lon)
       updatedAsset.lat should be (asset.lat)
+      updatedAsset.mValue should be (asset.mValue)
       updatedAsset.createdBy should equal (Some("jakke"))
       updatedAsset.modifiedBy should equal (Some("test"))
     }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignServiceSpec.scala
@@ -213,16 +213,17 @@ class TrafficSignServiceSpec extends FunSuite with Matchers with BeforeAndAfter 
 
       val propertiesToUpdate = properties60
 
-      val roadLink = RoadLink(randomLinkId1, Seq(Point(0.0, 0.0), Point(0.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
-      val id = service.create(IncomingTrafficSign(0.0, 20.0, randomLinkId1, properties, 1, None), "jakke", roadLink )
+      val roadLink = RoadLink(randomLinkId1, Seq(Point(2.0, 0.0), Point(4.0, 20.0)), 10, Municipality, 1, TrafficDirection.AgainstDigitizing, Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(235)))
+      val id = service.create(IncomingTrafficSign(3.15, 11.5, randomLinkId1, properties, 1, None), "jakke", roadLink )
       val asset = service.getPersistedAssetsByIds(Set(id)).head
 
-      val newId = service.update(id, IncomingTrafficSign(0.0, 20.0, randomLinkId1, propertiesToUpdate, 1, None), roadLink, "test")
+      val newId = service.update(id, IncomingTrafficSign(asset.lon, asset.lat, randomLinkId1, propertiesToUpdate, 1, None, Some(asset.mValue)), roadLink, "test")
 
       val updatedAsset = service.getPersistedAssetsByIds(Set(newId)).head
       updatedAsset.id should be (id)
       updatedAsset.lon should be (asset.lon)
       updatedAsset.lat should be (asset.lat)
+      updatedAsset.mValue should be(asset.mValue)
       updatedAsset.createdBy should equal (Some("jakke"))
       updatedAsset.modifiedBy should equal (Some("test"))
       updatedAsset.propertyData.find(p => p.publicId == "trafficSigns_type").get.values.head.asInstanceOf[PropertyValue].propertyValue should be ("2")

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/MassTransitStopUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/MassTransitStopUpdaterSpec.scala
@@ -98,6 +98,8 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
       adjustedAsset1.nationalId should be(createdStop1.nationalId)
       adjustedAsset1.floating should be(false)
       adjustedAsset1.validityDirection should be(Some(SideCode.TowardsDigitizing.value))
+      adjustedAsset1.lon should be(corrected1.lon)
+      adjustedAsset1.lat should be(corrected1.lat)
       distanceToOldLocation1 should be < updater.MaxDistanceDiffAllowed
       adjustedAsset1.propertyData.filterNot(_.publicId == "muokattu_viimeksi").foreach{ property =>
         val oldProperty = createdStop1.propertyData.find(_.publicId == property.publicId).get
@@ -111,6 +113,8 @@ class MassTransitStopUpdaterSpec extends FunSuite with Matchers {
       adjustedAsset2.nationalId should be(createdStop2.nationalId)
       adjustedAsset2.floating should be(false)
       adjustedAsset2.validityDirection should be(Some(SideCode.AgainstDigitizing.value))
+      adjustedAsset2.lon should be(corrected2.lon)
+      adjustedAsset2.lat should be(corrected2.lat)
       distanceToOldLocation2 should be < updater.MaxDistanceDiffAllowed
       adjustedAsset2.propertyData.filterNot(_.publicId == "muokattu_viimeksi").foreach{ property =>
         val oldProperty = createdStop2.propertyData.find(_.publicId == property.publicId).get


### PR DESCRIPTION
Otettu pois geometrian uudelleenlaskenta, jos geometria ei muutu. Lisätty "IncomingAsset" objekteille mArvo, jotta mahdollinen uudelleenlaskenta on deterministinen. Muokattu testejä siten, että mahdolliset virheet tulevat esiin. Aiemmissa testeissä, jossa testattiin täysin suoran viivan geometrialla, tulos saattoi olla uudelleenlaskennankin jälkeen oikein, vaikka se ei käytännön tapauksissa ollut.