### PR TITLE
 DROTH-3822 Fixed use of nordic alphabet in column names. Using a numeric instead of string in type extensions creates an error message on UI.

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ServicePointCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ServicePointCsvImporter.scala
@@ -23,9 +23,9 @@ class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl
   override val nonMandatoryFieldsMapping: Map[String, String] = Map(
     "tarkenne" -> "type extension",
     "palvelun nimi" -> "name",
-    "palvelun lisätieto" -> "additional info",
+    "palvelun lisatieto" -> "additional info",
     "viranomaisdataa" -> "is authority data",
-    "pysäkköintipaikkojen lukumäärä" -> "parking place count",
+    "pysakointipaikkojen lukumaara" -> "parking place count",
     "painorajoitus" -> "weight limit"
   )
   override val mandatoryFieldsMapping: Map[String, String] = coordinateMappings ++ stringValueFieldsMapping
@@ -66,13 +66,19 @@ class ServicePointCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl
 
       val incomingService = IncomingService(validatedServiceType, name, additionalInfo, validatedTypeExtension, parkingPlaceCount, validatedAuthorityData, weightLimit)
 
-      val servicePointInfo =
-        if(validatedServiceType == ServicePointsClass.Unknown.value)
-          Seq(NotImportedData(reason = s"Service Point type $serviceType does not exist.", csvRow = rowToString(csvProperties.flatMap{x => Map(x.columnName -> x.value)}.toMap)))
-        else
-          Seq()
+      val servicePointInfo = if (validatedServiceType == ServicePointsClass.Unknown.value) {
+        Seq(NotImportedData(reason = s"Service Point type $serviceType does not exist.", csvRow = rowToString(csvProperties.flatMap { x => Map(x.columnName -> x.value) }.toMap)))
+      } else {
+        Seq()
+      }
+      val typeExtensionInfo = if (validatedTypeExtension.isEmpty) {
+        Seq(NotImportedData(reason = s"Service Point type extension ${typeExtension.getOrElse("")} does not exist.", csvRow = rowToString(csvProperties.flatMap { x => Map(x.columnName -> x.value) }.toMap)))
+      } else {
+        Seq()
+      }
+
       val municipalityCode = servicePointAttribute.municipalityCode.get
-      CsvServicePoint(position, incomingService, municipalityCode, servicePointInfo)
+      CsvServicePoint(position, incomingService, municipalityCode, servicePointInfo ++ typeExtensionInfo)
     }
 
     val (validServicePoints, nonValidServicePoints) = incomingServicePoint.partition(servicePoint => servicePoint.importInformation.isEmpty)


### PR DESCRIPTION
- Operaattorin toiveesta yhdenmukaistettu ääkkösten käyttöä palvelupisteiden kentän nimissä.
- tarkenne tulee toimittaa merkkijonona. Mikäli yritetään toimittaa koodiarvona, import ei mene läpi ja käyttöliittymään tulee tavanmukainen virheilmoitus. 