### PR TITLE
 DROTH-3855 fix so it use adjustLinearAssets as wrapper

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -599,7 +599,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
     def adjusting(typeId: Int, changeSet: Option[ChangeSet], assetsByLink: mutable.HashMap[String, LinkAndAssets]): (Seq[PieceWiseLinearAsset], ChangeSet) = {
       val assets = assetsByLink.flatMap(_._2.assets).toSeq.groupBy(_.linkId)
       val roadLinks = assetsByLink.map(_._2.link).toList
-      assetFiller.fillTopologyChangesGeometry(roadLinks, assets, typeId, changeSet)
+      adjustLinearAssets(typeId,roadLinks, assets, changeSet)
     }
 
     /**


### PR DESCRIPTION
Korjattu niin että alkuperäinen design  säilyy viellä, adjustLinearAssets niin helppo vaihtaa filltopology