### PR TITLE
DROTH-3868 fix service road undefined value bug

### DIFF
--- a/UI/src/view/linear_asset/serviceRoadLabel.js
+++ b/UI/src/view/linear_asset/serviceRoadLabel.js
@@ -32,7 +32,7 @@
 
     var obtainValue = function(value){
       var property = _.find(value.properties, function(val) { return val.publicId === 'huoltotie_tarkistettu'; });
-      if(property)
+      if(property && !_.isEmpty(property.values))
         return _.head(property.values).value;
       return 0;
     };


### PR DESCRIPTION
Jos huoltotie tarkistettu - arvoa ei ole, property.values on tyhjä lista, jolloin yritetään etsiä arvoa undefinedille. Tarkistetaan, että property.values ei ole tyhjä. Jos on, niin huoltotie tarkistettu -arvoksi asetetaan "ei tarkistettu".