### PR TITLE
Droth 3839 uniform modified at field usage

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MassTransitStopDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MassTransitStopDao.scala
@@ -482,6 +482,7 @@ class MassTransitStopDao {
             set start_measure = $mValue,
             link_id = $linkId,
             link_source = ${linkSource.value},
+            modified_date = current_timestamp,
             adjusted_timestamp = ${adjustedTimeStamp}
            where id = (
             select pos.id
@@ -493,7 +494,7 @@ class MassTransitStopDao {
       case _ =>
         sqlu"""
            update lrm_position
-           set start_measure = $mValue, link_id = $linkId, link_source = ${linkSource.value}
+           set start_measure = $mValue, link_id = $linkId, modified_date = current_timestamp, link_source = ${linkSource.value}
            where id = (
             select pos.id
             from asset a

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISDirectionalTrafficSignDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISDirectionalTrafficSignDao.scala
@@ -205,7 +205,8 @@ object PostGISDirectionalTrafficSignDao {
        set
        start_measure = $mValue,
        link_id = ${sign.linkId},
-       side_code = ${sign.validityDirection}
+       side_code = ${sign.validityDirection},
+       modified_date = current_timestamp
        where id = (select position_id from asset_link where asset_id = $id)
     """.execute
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISObstacleDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISObstacleDao.scala
@@ -232,6 +232,7 @@ object PostGISObstacleDao {
            start_measure = $mValue,
            link_id = ${obstacle.linkId},
            adjusted_timestamp = $adjustedTimeStamp,
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
           where id = (select position_id from asset_link where asset_id = $id)
         """.execute
@@ -241,6 +242,7 @@ object PostGISObstacleDao {
            set
            start_measure = $mValue,
            link_id = ${obstacle.linkId},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
           where id = (select position_id from asset_link where asset_id = $id)
         """.execute

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISPedestrianCrossingDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISPedestrianCrossingDao.scala
@@ -69,6 +69,7 @@ class PostGISPedestrianCrossingDao() {
            start_measure = ${mValue},
            link_id = ${persisted.linkId},
            adjusted_timestamp = ${adjustedTimeStamp},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute
@@ -78,6 +79,7 @@ class PostGISPedestrianCrossingDao() {
            set
            start_measure = ${mValue},
            link_id = ${persisted.linkId},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISRailwayCrossingDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISRailwayCrossingDao.scala
@@ -199,6 +199,7 @@ object PostGISRailwayCrossingDao {
            start_measure = $mValue,
            link_id = ${railwayCrossing.linkId},
            adjusted_timestamp = ${adjustedTimeStamp},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute
@@ -208,6 +209,7 @@ object PostGISRailwayCrossingDao {
            set
            start_measure = $mValue,
            link_id = ${railwayCrossing.linkId},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISTrafficLightDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISTrafficLightDao.scala
@@ -237,6 +237,7 @@ object PostGISTrafficLightDao {
            start_measure = ${mValue},
            link_id = ${trafficLight.linkId},
            adjusted_timestamp = ${adjustedTimeStamp},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute
@@ -246,6 +247,7 @@ object PostGISTrafficLightDao {
            set
            start_measure = ${mValue},
            link_id = ${trafficLight.linkId},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISTrafficSignDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/pointasset/PostGISTrafficSignDao.scala
@@ -334,6 +334,7 @@ object PostGISTrafficSignDao {
            link_id = ${trafficSign.linkId},
            side_code = ${trafficSign.validityDirection},
            adjusted_timestamp = ${adjustedTimeStamp},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute
@@ -344,6 +345,7 @@ object PostGISTrafficSignDao {
            start_measure = $mValue,
            link_id = ${trafficSign.linkId},
            side_code = ${trafficSign.validityDirection},
+           modified_date = current_timestamp,
            link_source = ${linkSource.value}
            where id = (select position_id from asset_link where asset_id = $id)
         """.execute

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -779,7 +779,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
     
     if (changeSet.adjustedMValues.nonEmpty) {
       logger.debug(s"Saving adjustments for asset/link ids=${changeSet.adjustedMValues.map(a => s"${a.assetId}/${a.linkId} start measure: ${a.startMeasure} end measure: ${a.endMeasure}").mkString(", ")}")
-      dao.updateMValuesChangeInfos(changeSet.adjustedMValues.map(a => MValueUpdate(a.assetId, a.linkId, Measures(a.startMeasure, a.endMeasure).roundMeasures(), LinearAssetUtils.createTimeStamp())))
+      dao.updateMValuesChangeInfos(changeSet.adjustedMValues.map(a => MValueUpdate(a.assetId, a.linkId, Measures(a.startMeasure, a.endMeasure).roundMeasures())))
     }
     
     val ids = changeSet.expiredAssetIds.toSeq


### PR DESCRIPTION
- Päivitetään LRM_POSITION modified_date myös pistemäisillä asseteilla, kun riviä muokataan.
- Poistettu viivamaisten samuutuksen tallennuksesta LRM_POSITION adjusted_timestamp asettaminen

adjusted_timestamp kenttä ja siihen liittyvä turha koodi poistetaan myöhemmin tiketissä [DROTH-3760](https://extranet.vayla.fi/jira/browse/DROTH-3760)