### PR TITLE
Droth 3872 lane api linear reference api

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -137,8 +137,9 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
         }
       }
       catch {
-            //TODO tarkemmat poikkeus käsittelyt
-        case _: Exception => halt(BadRequest("Missing or invalid parameters"))
+        case _: NoSuchElementException => halt(BadRequest("No road link found on given linkID"))
+        case _: NumberFormatException => halt(BadRequest("Invalid mValue parameter"))
+        case _: Exception => halt(BadRequest("Something went wrong"))
       }
     }
   }
@@ -239,13 +240,13 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     lanes.map(laneToApi => {
       val municipalityCode = roadLink.municipalityCode
       val roadName = roadLink.roadNameIdentifier.getOrElse("")
-      val roadNumber = roadLink.roadNumber.getOrElse("")
-      val roadPartNumber = roadLink.roadPartNumber.getOrElse("")
-      val track = roadLink.track.getOrElse("")
-      val startAddrM = roadLink.startAddrM.getOrElse("")
-      val endAddrM = roadLink.endAddrM.getOrElse("")
+      val roadNumber = laneToApi.roadNumber.getOrElse("")
+      val roadPartNumber = laneToApi.roadPartNumber.getOrElse("")
+      val track = laneToApi.track.getOrElse("")
+      val startAddrM = laneToApi.startAddrM.getOrElse("")
+      val endAddrM = laneToApi.endAddrM.getOrElse("")
       val laneCode = laneService.getPropertyValue(laneToApi.laneAttributes, "lane_code").asInstanceOf[Int]
-      val laneType = laneService.getPropertyValue(laneToApi.laneAttributes, "lane_type").asInstanceOf[Int]
+      val laneType = laneService.getPropertyValue(laneToApi.laneAttributes, "lane_type").asInstanceOf[String].toInt
 
       mutable.LinkedHashMap(
         "laneCode" -> laneCode,

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -246,7 +246,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
       val startAddrM = laneToApi.startAddrM.getOrElse("")
       val endAddrM = laneToApi.endAddrM.getOrElse("")
       val laneCode = laneService.getPropertyValue(laneToApi.laneAttributes, "lane_code").asInstanceOf[Int]
-      val laneType = laneService.getPropertyValue(laneToApi.laneAttributes, "lane_type").asInstanceOf[String].toInt
+      val laneType = laneService.getPropertyValue(laneToApi.laneAttributes, "lane_type").toString.toInt
 
       mutable.LinkedHashMap(
         "laneCode" -> laneCode,

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/LaneApiSpec.scala
@@ -36,7 +36,7 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
       "SURFACETYPE" -> BigInt(2)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
 
   val pieceWiseLane = PieceWiseLane(111, linkId1, 2, false, Seq(Point(0.0, 0.0), Point(1.0, 1.0)), 0, 1, Set(Point(0.0, 0.0), Point(1.0, 1.0)),
-    None, None, None, None, 0L, None, State, Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11)))))
+    None, None, None, None, 0L, None, State, Seq(LaneProperty("lane_code", Seq(LanePropertyValue(11))),LaneProperty("lane_type", Seq(LanePropertyValue("1")))))
 
   val roadAddress = RoadAddressForLink(0, 0, 0, Track(99), 0, 0, None, None, "0", 0, 0, SideCode(1), Seq(), false, None, None, None)
 
@@ -181,6 +181,21 @@ class LaneApiSpec extends FunSuite with ScalatraSuite {
     //TODO Remove after walking and cycling lanes are enabled in laneApi
     get("/lanes_in_range?road_number=70001&track=1&start_part=208&start_addrm=8500&end_part=208&end_addrm=9000") {
       status should equal(400)
+    }
+  }
+
+  test("Lanes on linearly referenced point API requires correct linkID and mValue params") {
+    //Missing both params
+    get("/lanes_on_point") {
+      status should equal(400)
+    }
+    //MValue param missing
+    get("/lanes_on_point?linkId=linkId=abb902fe-96a2-4423-b619-2af7f06f410a:1&mValue=INVALIDMVALUE") {
+      status should equal(400)
+    }
+    //Correct params
+    get("/lanes_on_point?linkId=abb902fe-96a2-4423-b619-2af7f06f410a:1&mValue=50.567") {
+      status should equal(200)
     }
   }
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/lane/Lane.scala
@@ -20,12 +20,22 @@ case class ChangedSegment(startMeasure: Double, startAddrM: Int, endMeasure: Dou
 
 case class LightLane ( value: Int, expired: Boolean,  sideCode: Int )
 
-case class PieceWiseLane ( id: Long, linkId: String, sideCode: Int, expired: Boolean, geometry: Seq[Point],
-                                startMeasure: Double, endMeasure: Double,
-                                endpoints: Set[Point], modifiedBy: Option[String], modifiedDateTime: Option[DateTime],
-                                createdBy: Option[String], createdDateTime: Option[DateTime],
-                                timeStamp: Long, geomModifiedDate: Option[DateTime], administrativeClass: AdministrativeClass,
-                           laneAttributes: Seq[LaneProperty],  attributes: Map[String, Any] = Map() ) extends Lane
+case class PieceWiseLane(id: Long, linkId: String, sideCode: Int, expired: Boolean, geometry: Seq[Point],
+                         startMeasure: Double, endMeasure: Double,
+                         endpoints: Set[Point], modifiedBy: Option[String], modifiedDateTime: Option[DateTime],
+                         createdBy: Option[String], createdDateTime: Option[DateTime],
+                         timeStamp: Long, geomModifiedDate: Option[DateTime], administrativeClass: AdministrativeClass,
+                         laneAttributes: Seq[LaneProperty], attributes: Map[String, Any] = Map()) extends Lane {
+  def roadNumber: Option[String] = attributes.get("ROAD_NUMBER").map(_.toString)
+
+  def roadPartNumber: Option[String] = attributes.get("ROAD_PART_NUMBER").map(_.toString)
+
+  def track: Option[String] = attributes.get("TRACK").map(_.toString)
+
+  def startAddrM: Option[String] = attributes.get("START_ADDR").map(_.toString)
+
+  def endAddrM: Option[String] = attributes.get("END_ADDR").map(_.toString)
+}
 
 case class PersistedLane ( id: Long, linkId: String, sideCode: Int, laneCode: Int, municipalityCode: Long,
                            startMeasure: Double, endMeasure: Double,

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -42,6 +42,9 @@ case class RoadLink(linkId: String, geometry: Seq[Point],
   def surfaceType : Int = attributes("SURFACETYPE").asInstanceOf[BigInt].intValue
   def roadNumber: Option[String] = attributes.get("ROADNUMBER").map(_.toString)
   def roadPartNumber: Option[String] = attributes.get("ROADPARTNUMBER").map(_.toString)
+  def track: Option[String] = attributes.get("TRACK").map(_.toString)
+  def startAddrM: Option[String] = attributes.get("START_ADDR").map(_.toString)
+  def endAddrM: Option[String] = attributes.get("END_ADDR").map(_.toString)
   val timeStamp: Long = attributes.getOrElse("LAST_EDITED_DATE", attributes.getOrElse("CREATED_DATE", BigInt(0))).asInstanceOf[BigInt].longValue()
   def accessRightId: Option[String] = attributes.get("ACCESS_RIGHT_ID").map(_.toString)
   def privateRoadAssociation: Option[String] = attributes.get("PRIVATE_ROAD_ASSOCIATION").map(_.toString)


### PR DESCRIPTION
Lisätty uusi rajapinta kaistatiedon kyselyä varten lineaarisesti referoidulta pisteeltä. 
Palauttaa kaistatiedot mahdollisten tieosoitetietojen kanssa pisteeltä. 