### PR TITLE
DROTH-3903 prevent creating duplicate assets on new links

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -3,6 +3,7 @@ package fi.liikennevirasto.digiroad2.util.assetUpdater
 import fi.liikennevirasto.digiroad2.GeometryUtils.{Projection, getDefaultEpsilon}
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.RoadLinkChangeType.Add
 import fi.liikennevirasto.digiroad2.client._
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.dao.linearasset.{MValueUpdate, PostGISLinearAssetDao}
@@ -394,11 +395,17 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
     resetReport()
   }
   /**
-    * 2) [[filterChanges]] Apply only needed changes to assets by writing your own filtering logic. Default is do nothing.
+    * 2) [[filterChanges]] Apply only needed changes to assets by writing your own filtering logic. Default is to remove
+    * new links that already have assets, so that duplicate assets will not be created.
+    * @param typeId
     * @param changes
-    * @return
+    * @return filtered changes
     */
-  def filterChanges(changes: Seq[RoadLinkChange]): Seq[RoadLinkChange] = changes
+  def filterChanges(typeId: Int, changes: Seq[RoadLinkChange]): Seq[RoadLinkChange] = {
+    val newLinkIds = changes.flatMap(_.newLinks.map(_.linkId))
+    val linkIdsWithExistingAsset = service.fetchExistingAssetsByLinksIdsString(typeId, newLinkIds.toSet, Set(), newTransaction = false).map(_.linkId)
+    changes.filterNot(c => c.changeType == Add && linkIdsWithExistingAsset.contains(c.newLinks.head.linkId))
+  }
   /**
     * 4.2) Add logic to create assets when link is created. Default is do nothing.
     * @param change
@@ -458,7 +465,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   }
 
   def updateByRoadLinks(typeId: Int, changesAll: Seq[RoadLinkChange]): Unit = {
-    val changes = filterChanges(changesAll)
+    val changes = filterChanges(typeId, changesAll)
     val oldIds = changes.filterNot(isDeletedOrNew).map(_.oldLink.get.linkId)
     val deletedLinks = changes.filter(isDeleted).map(_.oldLink.get.linkId)
     val addedLinksCount = changes.filter(isNew).flatMap(_.newLinks).size

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/MaintenanceRoadUpdater.scala
@@ -9,8 +9,8 @@ import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
 
 class MaintenanceRoadUpdater(service: MaintenanceService) extends DynamicLinearAssetUpdater(service) {
 
-  override def filterChanges(changes: Seq[RoadLinkChange]): Seq[RoadLinkChange] = {
-    val (remove, other) = changes.partition(_.changeType == RoadLinkChangeType.Remove)
+  override def filterChanges(typeId: Int, changes: Seq[RoadLinkChange]): Seq[RoadLinkChange] = {
+    val (remove, other) = super.filterChanges(typeId, changes).partition(_.changeType == RoadLinkChangeType.Remove)
     val linksOther = other.flatMap(_.newLinks.map(_.linkId)).toSet
     val filterChanges = if (linksOther.nonEmpty) {
       val links = roadLinkService.getExistingAndExpiredRoadLinksByLinkIds(linksOther,false)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdaterSpec.scala
@@ -88,6 +88,7 @@ class PavedRoadUpdaterSpec extends FunSuite with Matchers with UpdaterUtilsSuite
 
     runWithRollback {
       TestPavedRoadUpdater.updateByRoadLinks(PavedRoad.typeId, changes)
+      TestPavedRoadUpdater.updateByRoadLinks(PavedRoad.typeId, changes) // check that no overlapping assets are created even if the process is run twice
       val assetsAfter = dynamicLinearAssetService.getPersistedAssetsByLinkIds(PavedRoad.typeId, Seq(linkId15), false)
       assetsAfter.size should be(1)
       val sorted = assetsAfter.sortBy(_.endMeasure)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdaterSpec.scala
@@ -61,6 +61,7 @@ class RoadWidthUpdaterSpec extends FunSuite with BeforeAndAfter with Matchers wi
     
     runWithRollback {
       TestRoadWidthUpdaterNoRoadLinkMock.updateByRoadLinks(RoadWidth.typeId, changes)
+      TestRoadWidthUpdaterNoRoadLinkMock.updateByRoadLinks(RoadWidth.typeId, changes) // check that no overlapping assets are created even if the process is run twice
       val assetsAfter = roadWidthService.getPersistedAssetsByLinkIds(RoadWidth.typeId, Seq("624df3a8-b403-4b42-a032-41d4b59e1840:1"), false)
       assetsAfter.size should be(1)
       val sorted = assetsAfter.sortBy(_.endMeasure)

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdaterSpec.scala
@@ -149,6 +149,7 @@ class SpeedLimitUpdaterSpec extends FunSuite with Matchers with UpdaterUtilsSuit
       val newLink = "624df3a8-b403-4b42-a032-41d4b59e1840:1"
       when(mockRoadLinkService.fetchRoadlinksByIds(any[Set[String]])).thenReturn(Seq.empty[RoadLinkFetched])
       TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(SpeedLimitAsset.typeId, changes)
+      TestLinearAssetUpdaterNoRoadLinkMock.updateByRoadLinks(SpeedLimitAsset.typeId, changes) // check that no overlapping assets are created even if the process is run twice
       val unknown =  speedLimitService.getUnknownByLinkIds(Set(newLink),newTransaction = false)
       unknown.size should be(1)
     }


### PR DESCRIPTION
Lisätty lineaaristen samuutukseen filtteri, joka poistaa Add-muutossanomista sellaiset, joissa uudella linkillä jostain syystä on jo generoitu tietolaji. Testataan testeissä ajamalla samuutus useampaan kertaan.