### PR TITLE
DROTH-3882_unnecessary_incomplete_links_produced

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -191,7 +191,7 @@ class RoadLinkPropertyUpdater {
           }
         case _ =>
           change.newLinks.foreach { newLink =>
-            if (KgvUtil.extractFeatureClass(newLink.roadClass) != WinterRoads) {
+            if (!(iteratedNewLinks.contains(newLink)) && KgvUtil.extractFeatureClass(newLink.roadClass) != WinterRoads) {
               val functionalClassChange = transferOrGenerateFunctionalClass(change.changeType, change.oldLink, newLink)
               val linkTypeChange = transferOrGenerateLinkType(change.changeType, change.oldLink, newLink)
               if (functionalClassChange.isEmpty || linkTypeChange.isEmpty) {


### PR DESCRIPTION
Jokainen uusi linkki käsitellään päivityksessä vain kerran, vaikka olisikin osa useampaa eri muutossanomaa. Ominaisuudet peritään ensimmäisestä käsitellystä muutossanomasta, jossa linkki on mukana.

esim:

- Linkki a jakaantuu kahdeksi uudeksi linkiksi: x ja y
- Uusi linkki x korvaa myöhemmin linkin z
- x on jo perinyt ominaisuudet a:lta jakaantumisen yhteydessä, joten uutta perintäprosessia ei suoriteta.

