### PR TITLE
Droth 3906 split link query when jetty limit reached

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -131,21 +131,9 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
   def getAllByLinkIds(linkIds: Seq[String]): Seq[RoadAddressForLink] = {
     (linkIds.nonEmpty) match {
       case true =>
-        processLinkIdBatches(linkIds, Seq.empty[RoadAddressForLink])
+        linkIds.grouped(BATCH_SIZE_LIMIT).flatMap(processLinkIdBatch(_)).toSeq
       case false =>
         Seq.empty[RoadAddressForLink]
-    }
-  }
-
-  @tailrec
-  private def processLinkIdBatches(linkIds: Seq[String], roadAddressCollection: Seq[RoadAddressForLink]): Seq[RoadAddressForLink] = {
-    (linkIds.nonEmpty) match {
-      case true =>
-        val (linkIdBatch, remainingIds) = linkIds.splitAt(BATCH_SIZE_LIMIT)
-        val batchResult = processLinkIdBatch(linkIdBatch)
-        processLinkIdBatches(remainingIds, roadAddressCollection ++ batchResult)
-      case false =>
-        roadAddressCollection
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -14,7 +14,6 @@ import org.apache.http.conn.HttpHostConnectException
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
 
-import scala.annotation.tailrec
 import scala.compat.Platform.EOL
 
 case class RoadAddressForLink(id: Long, roadNumber: Long, roadPartNumber: Long, track: Track, startAddrMValue: Long, endAddrMValue: Long, startDate: Option[DateTime] = None,

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadAddressServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadAddressServiceSpec.scala
@@ -2,10 +2,17 @@ package fi.liikennevirasto.digiroad2.service
 
 import fi.liikennevirasto.digiroad2.Track
 import fi.liikennevirasto.digiroad2.asset.SideCode
-import fi.liikennevirasto.digiroad2.util.{LinkIdGenerator}
+import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
+import fi.liikennevirasto.digiroad2.util.LinkIdGenerator
+import org.mockito.ArgumentMatchers.any
 import org.scalatest.{FunSuite, Matchers}
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
 
 class RoadAddressServiceSpec extends FunSuite with Matchers{
+  val mockViiteClient = MockitoSugar.mock[SearchViiteClient]
+  val testRoadAddressService = new RoadAddressService(mockViiteClient)
+
   test("LRM calculation on Road Address") {
     val linkId = LinkIdGenerator.generateRandom()
     val towards = RoadAddressForLink(1L, 1L, 1L, Track.RightSide, 100, 110, None, None, linkId, 1.5, 11.4, SideCode.TowardsDigitizing, Seq(), false, None, None, None)
@@ -20,5 +27,13 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
     towards.addressMValueToLRM(111L) should be (None)
     against.addressMValueToLRM(99L)  should be (None)
     against.addressMValueToLRM(111L) should be (None)
+  }
+
+  test("When fetching RoadAddress info with more than 1000 linkIds, returned batches should be combined into one sequence") {
+    val mockRoadAddresses: Seq[RoadAddressForLink] = List.fill(1000)(RoadAddressForLink(1L, 1L, 1L, Track.RightSide, 100, 110, None, None, LinkIdGenerator.generateRandom(), 1.5, 11.4, SideCode.TowardsDigitizing, Seq(), false, None, None, None))
+    val linkIds: Seq[String] = List.fill(2000)(LinkIdGenerator.generateRandom())
+    when(mockViiteClient.fetchAllByLinkIds(any[Seq[String]])).thenReturn(mockRoadAddresses)
+    val roadAddressCollection = testRoadAddressService.getAllByLinkIds(linkIds)
+    roadAddressCollection.size should be(2000)
   }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadAddressServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadAddressServiceSpec.scala
@@ -29,7 +29,7 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
     against.addressMValueToLRM(111L) should be (None)
   }
 
-  test("When fetching RoadAddress info with more than 1000 linkIds, returned batches should be combined into one sequence") {
+  test("When fetching RoadAddress info with more than 1000 linkIds, then returned batches should be combined into one sequence") {
     val mockRoadAddresses: Seq[RoadAddressForLink] = List.fill(1000)(RoadAddressForLink(1L, 1L, 1L, Track.RightSide, 100, 110, None, None, LinkIdGenerator.generateRandom(), 1.5, 11.4, SideCode.TowardsDigitizing, Seq(), false, None, None, None))
     val linkIds: Seq[String] = List.fill(2000)(LinkIdGenerator.generateRandom())
     when(mockViiteClient.fetchAllByLinkIds(any[Seq[String]])).thenReturn(mockRoadAddresses)


### PR DESCRIPTION
Jettyn määrittelemä parametriraja johtaa hakujen eväämiseen suurissa tieosoitetietokyselyissä. Pilkotaan kyselyt 1000 linkId:n batcheihin, jotta rajaa ei ylitetä.