### PR TITLE
DROTH-3855 fix overlapping adjustments

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -626,7 +626,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
       case _ => List(adjusting(typeId, changeSet, assetsByLink))
     }
     
-    val changeSetResult = result.map(_._2).foldLeft(LinearAssetFiller.useOrEmpty(changeSet)) { (a, b) =>
+    val changeSetResult = result.map(_._2).foldLeft(LinearAssetFiller.useOrEmpty(None)) { (a, b) =>
       LinearAssetFiller.combineChangeSets(a, b)
     }
     (result.flatMap(_._1), LinearAssetFiller.removeExpiredMValuesAdjustments(changeSetResult))


### PR DESCRIPTION
Päällekkäisten adjustmentien ongelma taitaa ainakin osittain johtua siitä, että foldLeftin lähtökohdaksi otetaan vanha ChangeSet, joka on jo AssetFillerissä käsitelty. Tällöin vanhat arvot tulevat mukaan. Aloitetaan yhdistely tyhjällä setillä, niin ainakaan testissä ei enää tule duplikaatteja tai limittäisiä adjustmenteja.