### PR TITLE
DROTH-3855 alter illogical empty check

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
@@ -987,7 +987,7 @@ class PostGISLinearAssetDao() {
             values ((?), (?), (?),${timestamp},${timestamp},(?),${timestamp},(?),(?), (?), (?));
             """.stripMargin
     
-    if (verifiedDateFromUpdateNo.nonEmpty){
+    if (verifiedDateFromUpdateYes.nonEmpty){
       MassQuery.executeBatch(verifiedStatementSql) { ps => 
         verifiedDateFromUpdateYes.foreach(a => verifiedStatement(ps, a.asset.typeId, a.asset.createdByFromUpdate, a.asset.createdDateTimeFromUpdate, 
             a.asset.modifiedDateTimeFromUpdate, a.asset.verifiedBy, a.asset.verifiedDateFromUpdate, a.asset.informationSource, a.id,


### PR DESCRIPTION
Huomasin tuossa logituksia lisäillessä, että yksi tallennusoperaation empty-check testaa eri listaa, mitä tallennetaan. Tuon vuoksi voi jotain jäädä tallentamatta, jolloin asset ei ole taulussa silloin, kun propertya tallennetaan.

Voisin ajella tämän ensiksi ja lisätä logit vasta sen jälkeen, jos tarpeen.