### PR TITLE
 DROTH-3906 Undo splitting, as original problem was not caused by Jetty limit

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -50,7 +50,6 @@ case class RoadAddressForLink(id: Long, roadNumber: Long, roadPartNumber: Long, 
 class RoadAddressService(viiteClient: SearchViiteClient ) {
   val roadAddressTempDAO = new RoadAddressTempDAO
   val logger = LoggerFactory.getLogger(getClass)
-  val BATCH_SIZE_LIMIT = 1000 // limit determined by Jetty for DOS protection
 
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
@@ -130,21 +129,12 @@ class RoadAddressService(viiteClient: SearchViiteClient ) {
   def getAllByLinkIds(linkIds: Seq[String]): Seq[RoadAddressForLink] = {
     (linkIds.nonEmpty) match {
       case true =>
-        linkIds.grouped(BATCH_SIZE_LIMIT).flatMap(processLinkIdBatch(_)).toSeq
-      case false =>
-        Seq.empty[RoadAddressForLink]
-    }
-  }
-
-  def processLinkIdBatch(linkIds: Seq[String]): Seq[RoadAddressForLink] = {
-    (linkIds.nonEmpty) match {
-      case true =>
-      val linksString2 = s"[${linkIds.map(id => s""""$id"""").mkString(",")}]"
-      ClientUtils.retry(5, logger, commentForFailing = s"JSON payload for failing: $linksString2") {
-        LogUtils.time(logger, "TEST LOG Retrieve road address by links") {
-          viiteClient.fetchAllByLinkIds(linkIds)
+        val linksString2 = s"[${linkIds.map(id => s""""$id"""").mkString(",")}]"
+        ClientUtils.retry(5, logger, commentForFailing = s"JSON payload for failing: $linksString2") {
+          LogUtils.time(logger, "TEST LOG Retrieve road address by links") {
+            viiteClient.fetchAllByLinkIds(linkIds)
+          }
         }
-      }
       case false =>
         Seq.empty[RoadAddressForLink]
     }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadAddressServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/RoadAddressServiceSpec.scala
@@ -2,16 +2,10 @@ package fi.liikennevirasto.digiroad2.service
 
 import fi.liikennevirasto.digiroad2.Track
 import fi.liikennevirasto.digiroad2.asset.SideCode
-import fi.liikennevirasto.digiroad2.client.viite.SearchViiteClient
 import fi.liikennevirasto.digiroad2.util.LinkIdGenerator
-import org.mockito.ArgumentMatchers.any
 import org.scalatest.{FunSuite, Matchers}
-import org.mockito.Mockito._
-import org.scalatest.mockito.MockitoSugar
 
 class RoadAddressServiceSpec extends FunSuite with Matchers{
-  val mockViiteClient = MockitoSugar.mock[SearchViiteClient]
-  val testRoadAddressService = new RoadAddressService(mockViiteClient)
 
   test("LRM calculation on Road Address") {
     val linkId = LinkIdGenerator.generateRandom()
@@ -27,13 +21,5 @@ class RoadAddressServiceSpec extends FunSuite with Matchers{
     towards.addressMValueToLRM(111L) should be (None)
     against.addressMValueToLRM(99L)  should be (None)
     against.addressMValueToLRM(111L) should be (None)
-  }
-
-  test("When fetching RoadAddress info with more than 1000 linkIds, then returned batches should be combined into one sequence") {
-    val mockRoadAddresses: Seq[RoadAddressForLink] = List.fill(1000)(RoadAddressForLink(1L, 1L, 1L, Track.RightSide, 100, 110, None, None, LinkIdGenerator.generateRandom(), 1.5, 11.4, SideCode.TowardsDigitizing, Seq(), false, None, None, None))
-    val linkIds: Seq[String] = List.fill(2000)(LinkIdGenerator.generateRandom())
-    when(mockViiteClient.fetchAllByLinkIds(any[Seq[String]])).thenReturn(mockRoadAddresses)
-    val roadAddressCollection = testRoadAddressService.getAllByLinkIds(linkIds)
-    roadAddressCollection.size should be(2000)
   }
 }


### PR DESCRIPTION
Pilkkominen tarpeeton lisäkuorma, poistetaan käytöstä