### PR TITLE
DROTH-3855 fix dao statements

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISLinearAssetDao.scala
@@ -874,8 +874,7 @@ class PostGISLinearAssetDao() {
 
     if (verifiedBy.nonEmpty) ps.setString(8, verifiedBy.get)
     else ps.setNull(8, java.sql.Types.VARCHAR)
-
-    if (verifiedDateFromUpdate.nonEmpty) ps.setString(9, verifiedDateFromUpdate.toString)
+    if (verifiedDateFromUpdate.nonEmpty) ps.setString(9, verifiedDateFromUpdate.get.toString)
     else ps.setNull(9, java.sql.Types.VARCHAR)
 
     if (informationSource.nonEmpty) ps.setInt(10, informationSource.get)
@@ -984,7 +983,7 @@ class PostGISLinearAssetDao() {
     val (verifiedDateFromUpdateYes, verifiedDateFromUpdateNo) = fromUpdate.partition(_.asset.verifiedDateFromUpdate.isDefined)
     val verifiedStatementSql =
       s""" insert  into asset (id, asset_type_id, created_by, created_date, valid_to, modified_by, modified_date, verified_by, verified_date, information_source, geometry) 
-            values ((?), (?), (?),${timestamp},${timestamp},(?),${timestamp},(?),(?), (?), (?));
+            values ((?), (?), (?),${timestamp},${timestamp},(?),${timestamp},(?),${timestamp}, (?), (?));
             """.stripMargin
     
     if (verifiedDateFromUpdateYes.nonEmpty){

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdaterSpec.scala
@@ -1712,7 +1712,8 @@ class LinearAssetUpdaterSpec extends FunSuite with BeforeAndAfter with Matchers 
 
     runWithRollback {
       val oldRoadLink = roadLinkService.getExpiredRoadLinkByLinkId(linkId).get
-      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value, Measures(0, 18.081), "testuser", 0L, Some(oldRoadLink), false, None, None)
+      val id1 = service.createWithoutTransaction(HeightLimit.typeId, linkId, NumericValue(3), SideCode.TowardsDigitizing.value,
+        Measures(0, 18.081), "testuser", 0L, Some(oldRoadLink), false, None, None, verifiedBy = Some("testVerifier"))
 
       val assetsBefore = service.getPersistedAssetsByIds(HeightLimit.typeId, Set(id1), false)
       assetsBefore.size should be(1)


### PR DESCRIPTION
Lisätty yksi puuttuva get sekä verified_datelle timestamp-konversio. Muokattu yhtä testiä niin, että saadaan testicase myös datalle, josta löytyy verified-tiedot.