### PR TITLE
 DROTH-3882 Updates for leaks that caused unnecessary incomplete links

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -129,11 +129,8 @@ class RoadLinkPropertyUpdater {
 
   def transferOrGenerateFunctionalClass(changeType: RoadLinkChangeType, optionalOldLink: Option[RoadLinkInfo], newLink: RoadLinkInfo): Option[FunctionalClassChange] = {
     val timeStamp = DateTime.now().toString()
-    val alreadyUpdatedFunctionalClass = FunctionalClassDao.getExistingValue(newLink.linkId)
-    (alreadyUpdatedFunctionalClass, optionalOldLink) match {
-      case (Some(_), _) =>
-        None
-      case (None, Some(oldLink)) =>
+    optionalOldLink match {
+      case Some(oldLink) =>
         transferFunctionalClass(changeType, oldLink, newLink, timeStamp) match {
           case Some(functionalClassChange) => Some(functionalClassChange)
           case _ =>
@@ -142,7 +139,7 @@ class RoadLinkPropertyUpdater {
               case _ => None
             }
         }
-      case (None, None) =>
+      case None =>
         generateFunctionalClass(changeType, newLink) match {
           case Some(generatedFunctionalClass) => Some(generatedFunctionalClass)
           case _ => None
@@ -173,6 +170,27 @@ class RoadLinkPropertyUpdater {
     }
   }
 
+  /***
+   * Filters out links that need no property update processing due to already having Admin Class or Link type,
+   * or having ignorable Feature Class
+   * @param newLink
+   * @return
+   */
+  def isProcessableLink(newLink: RoadLinkInfo): Boolean = {
+    val alreadyUpdatedFunctionalClass = FunctionalClassDao.getExistingValue(newLink.linkId)
+    val alreadyUpdatedLinkType = LinkTypeDao.getExistingValue(newLink.linkId)
+    if (alreadyUpdatedFunctionalClass.nonEmpty) {
+      logger.info(s"Functional Class already exists for new link ${newLink.linkId}")
+    }
+    if (alreadyUpdatedLinkType.nonEmpty) {
+      logger.info(s"Link Type already exists for new link ${newLink.linkId}")
+    }
+    val featureClass = KgvUtil.extractFeatureClass(newLink.roadClass)
+    val hasIgnoredFeatureClass = FeatureClass.featureClassesToIgnore.contains(featureClass)
+
+    alreadyUpdatedFunctionalClass.isEmpty && alreadyUpdatedLinkType.isEmpty && !hasIgnoredFeatureClass
+  }
+
   def transferOrGenerateFunctionalClassesAndLinkTypes(changes: Seq[RoadLinkChange]): Seq[ReportedChange] = {
     val incompleteLinks = new ListBuffer[IncompleteLink]()
     val createdProperties = new ListBuffer[Option[ReportedChange]]()
@@ -183,7 +201,7 @@ class RoadLinkPropertyUpdater {
         case Replace =>
           val newLink = change.newLinks.head
           val featureClass = KgvUtil.extractFeatureClass(newLink.roadClass)
-          if (!(iteratedNewLinks.contains(newLink)) && !FeatureClass.featureClassesToIgnore.contains(featureClass)) {
+          if ((!iteratedNewLinks.exists(_.linkId == newLink.linkId)) && !FeatureClass.featureClassesToIgnore.contains(featureClass)) {
             val relatedMerges = changes.filter(change => change.changeType == Replace && change.newLinks.head == newLink)
             val (created, failed) = transferFunctionalClassesAndLinkTypesForSingleReplace(relatedMerges, newLink, timeStamp)
             createdProperties ++= created
@@ -191,9 +209,8 @@ class RoadLinkPropertyUpdater {
             iteratedNewLinks += newLink
           }
         case _ =>
-          change.newLinks.foreach { newLink =>
-            val featureClass = KgvUtil.extractFeatureClass(newLink.roadClass)
-            if (!(iteratedNewLinks.contains(newLink)) && !FeatureClass.featureClassesToIgnore.contains(featureClass)) {
+          change.newLinks.filter(isProcessableLink).foreach { newLink =>
+            if (!iteratedNewLinks.exists(_.linkId == newLink.linkId)) {
               val functionalClassChange = transferOrGenerateFunctionalClass(change.changeType, change.oldLink, newLink)
               val linkTypeChange = transferOrGenerateLinkType(change.changeType, change.oldLink, newLink)
               if (functionalClassChange.isEmpty || linkTypeChange.isEmpty) {
@@ -201,6 +218,7 @@ class RoadLinkPropertyUpdater {
               }
               createdProperties += functionalClassChange
               createdProperties += linkTypeChange
+              iteratedNewLinks += newLink
             }
           }
       }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdaterSpec.scala
@@ -385,4 +385,76 @@ class RoadLinkPropertyUpdaterSpec extends FunSuite with Matchers{
       roadLinkService.getIncompleteLinks(None, false).size should be(0)
     }
   }
+
+  test("Given a new road link; When new admin class and link type are not created due to RoadClass value; Then an incomplete link should be generated") {
+    val newLinkId = "eea524dd-e371-47e3-9d58-44272ccf9db0:1"
+    val relevantChanges = Seq(
+      RoadLinkChange(Add, None,
+        List(RoadLinkInfo(newLinkId, 20.311, List(Point(238192.995, 6716501.977, 31.415), Point(238197.49, 6716521.779, 31.56)),
+          12121, State, 680, UnknownDirection)),
+        List(ReplaceInfo(None, Option(newLinkId), None, None, Option(0.0), Option(20.311), false)))
+    )
+    runWithRollback {
+      val createdProperties = roadLinkPropertyUpdater.transferOrGenerateFunctionalClassesAndLinkTypes(relevantChanges)
+      createdProperties.size should be(0)
+      val incompleteLinks = roadLinkService.getIncompleteLinks(None, false)
+      incompleteLinks.size should be(1)
+    }
+  }
+
+  test("Given a new road link; When new link already has admin class and link type; Then no properties or incomplete link should be generated") {
+    val newLinkId = "eea524dd-e371-47e3-9d58-44272ccf9db0:1"
+    val relevantChanges = Seq(
+      RoadLinkChange(Add, None,
+        List(RoadLinkInfo(newLinkId, 20.311, List(Point(238192.995, 6716501.977, 31.415), Point(238197.49, 6716521.779, 31.56)),
+          12121, State, 680, UnknownDirection)),
+        List(ReplaceInfo(None, Option(newLinkId), None, None, Option(0.0), Option(20.311), false)))
+    )
+    runWithRollback {
+      RoadLinkOverrideDAO.insert(FunctionalClass, newLinkId, Some("test"), 7)
+      RoadLinkOverrideDAO.insert(LinkType, newLinkId, Some("test"), 1)
+      val createdProperties = roadLinkPropertyUpdater.transferOrGenerateFunctionalClassesAndLinkTypes(relevantChanges)
+      createdProperties.size should be(0)
+      val incompleteLinks = roadLinkService.getIncompleteLinks(None, false)
+      incompleteLinks.size should be(0)
+    }
+  }
+
+  test("Given two splits with a shared new link; When old links are not missing information; Then no incomplete link should be generated") {
+    val newLinkId1 = "fba10b89-94f3-4857-95a9-ae8d3c1c276d:1"
+    val newLinkId2 = "cd4f0b7f-e916-4b6a-99ac-3c56516b691c:1"
+    val newLinkId3 = "b3539f88-88ac-4a92-8582-ef012cb0dbf3:1"
+    val oldLinkId1 = "a5eb0323-1b71-4a00-8c4c-9386d311fa30:1"
+    val oldLinkId2 = "cba1aef9-3c3d-4f50-aed2-f9eb0359b648:1"
+    val relevantChanges = Seq(
+      RoadLinkChange(
+        Split, Some(RoadLinkInfo(oldLinkId1, 137.767,
+        List(Point(477310.959, 7343262.118, 179.727), Point(477258.906, 7343389.476, 178.035)), 12132, Private, 698, UnknownDirection)),
+        List(RoadLinkInfo(newLinkId1, 196.95, List(Point(410580.098, 7524656.363, 186.118), Point(410803.855, 7525268.116, 186.353)),
+          12132, Private, 698, UnknownDirection),
+          RoadLinkInfo(newLinkId2, 82.995, List(Point(410580.098, 7524656.363, 186.118), Point(410803.855, 7525268.116, 186.353)),
+            12132, Private, 698, UnknownDirection)),
+        List(ReplaceInfo(Option(oldLinkId1), Option(newLinkId1), Option(0.0), Option(555.312), Option(0.0), Option(555.312), false),
+          ReplaceInfo(Option(oldLinkId1), Option(newLinkId2), Option(0.0), Option(555.312), Option(0.0), Option(555.312), false))),
+      RoadLinkChange(
+        Split, Some(RoadLinkInfo(oldLinkId2, 483.503,
+        List(Point(378461.027, 6674230.896, 1.993), Point(378521.11, 6674258.813, 6.9)), 12132, State, 698, UnknownDirection)),
+        List(RoadLinkInfo(newLinkId1, 196.95, List(Point(410580.098, 7524656.363, 186.118), Point(410803.855, 7525268.116, 186.353)),
+          12132, State, 698, UnknownDirection),
+          RoadLinkInfo(newLinkId3, 341.261, List(Point(410580.098, 7524656.363, 186.118), Point(410803.855, 7525268.116, 186.353)),
+            12132, State, 698, UnknownDirection)),
+        List(ReplaceInfo(Option(oldLinkId2), Option(newLinkId1), Option(0.0), Option(178.997), Option(555.312), Option(734.309), false),
+          ReplaceInfo(Option(oldLinkId2), Option(newLinkId3), Option(0.0), Option(178.997), Option(555.312), Option(734.309), false)))
+    )
+    runWithRollback {
+      RoadLinkOverrideDAO.insert(FunctionalClass, oldLinkId1, Some("test"), 7)
+      RoadLinkOverrideDAO.insert(FunctionalClass, oldLinkId2, Some("test"), 7)
+      RoadLinkOverrideDAO.insert(LinkType, oldLinkId1, Some("test"), 1)
+      RoadLinkOverrideDAO.insert(LinkType, oldLinkId2, Some("test"), 1)
+      val createdProperties = roadLinkPropertyUpdater.transferOrGenerateFunctionalClassesAndLinkTypes(relevantChanges)
+      createdProperties.size should be(6)
+      val incompleteLinks = roadLinkService.getIncompleteLinks(None, false)
+      incompleteLinks.size should be(0)
+    }
+  }
 }


### PR DESCRIPTION
Muutettu logiikkaa tiiviimmäksi, jotta korjattavaksi merkittyjä linkkejä ei synny seuraavissa tapauksissa:

- Linkki lisätty ennen 15.5.2022, annettu hallinnollinen luokka ja linkin tyyppi. Tieosoitetietohaun myötä tulee mukaan Add-muutossanomana. Nämä tapaukset ohitetaan mutta lokitetaan.
- Sama new link mukana kahdessa erillisessä Split-muutossanomassa. Minkään new linkin ei tule missään tapauksessa tulla käsitellyksi kuin yhden kerran, huolimatta monessako muutossanomassa se on mukana. 

Lisää testitapauksia.