### PR TITLE
DROTH-3927 test no functional class or link type is transferred to hard shoulder

### DIFF
--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdaterSpec.scala
@@ -461,11 +461,10 @@ class RoadLinkPropertyUpdaterSpec extends FunSuite with Matchers{
   test("no link type or functional class should be transferred or generated when road class changes to hard shoulder") {
     val oldLinkId = "c51f721d-5c0b-4cd2-b6a5-6a0df207a8fe:1"
     val newLinkId = "ed66eaf4-c0b7-4356-86fb-10cf0624bf8a:1"
-    val change = RoadLinkChange(Replace,Some(RoadLinkInfo("c51f721d-5c0b-4cd2-b6a5-6a0df207a8fe:1",119.687,
+    val change = RoadLinkChange(Replace,Some(RoadLinkInfo(oldLinkId,119.687,
       List(Point(339271.771,6971427.195,153.038), Point(339265.3400000001,6971546.706,152.451)),12316,Unknown,5,BothDirections, SurfaceType.None)),
-      List(RoadLinkInfo("ed66eaf4-c0b7-4356-86fb-10cf0624bf8a:1",119.687,List(Point(339271.771,6971427.195,153.038), Point(339265.3400000001,6971546.706,152.451)),
-        12318,Unknown,5,BothDirections,SurfaceType.None)),List(ReplaceInfo(Some("c51f721d-5c0b-4cd2-b6a5-6a0df207a8fe:1"),
-        Some("ed66eaf4-c0b7-4356-86fb-10cf0624bf8a:1"),Some(0.0),Some(119.687),Some(0.0),Some(119.687),false)))
+      List(RoadLinkInfo(newLinkId,119.687,List(Point(339271.771,6971427.195,153.038), Point(339265.3400000001,6971546.706,152.451)),
+        12318,Unknown,5,BothDirections,SurfaceType.None)),List(ReplaceInfo(Some(oldLinkId), Some(newLinkId),Some(0.0),Some(119.687),Some(0.0),Some(119.687),false)))
     runWithRollback {
       RoadLinkOverrideDAO.insert(FunctionalClass, oldLinkId, Some("test"), 7)
       RoadLinkOverrideDAO.insert(LinkType, oldLinkId, Some("test"), 12)


### PR DESCRIPTION
Itse bugi on taidettu korjata jo aiemmin, mutta kirjoitin nyt varmuuden vuoksi testin siitä, ettei toiminnallisen luokan tai linkin tyypin tulisi siirtyä piennartielle.