### PR TITLE
DROTH-3666 Fix boolean logic in link type change handling

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/lane/LaneService.scala
@@ -1262,7 +1262,9 @@ trait LaneOperations {
       val linkId = linkPropertyChange.roadLinkFetched.linkId
       val newValue = linkPropertyChange.linkProperty.linkType.value
       val oldValue = linkPropertyChange.optionalExistingValue.getOrElse(99)
-      val twoWayLaneLinkTypeChange = twoWayLanes.map(_.value).contains(newValue) || twoWayLanes.map(_.value).contains(oldValue)
+      val newValueIsTwoWayLane = twoWayLanes.map(_.value).contains(newValue)
+      val oldValueIsTwoWayLane =  twoWayLanes.map(_.value).contains(oldValue)
+      val twoWayLaneLinkTypeChange = newValueIsTwoWayLane ^ oldValueIsTwoWayLane
       if (oldValue == TractorRoad.value && newValue != TractorRoad.value) {
         MainLanePopulationProcess.createMainLanesForRoadLinks(roadLink)
       }


### PR DESCRIPTION
Korjattu huomattu virhe boolean logiikassa, tielinkin tyypin muutos vaikuttaa kaistoihin vain jos pelkästään toinen uudesta ja vanhasta linkin tyypistä kuuluu twoWayLanes joukkoon