### PR TITLE
DROTH-3935 exclude illegal targets for unknown speed limits

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -17,7 +17,8 @@ class SpeedLimitUpdater(service: SpeedLimitService) extends DynamicLinearAssetUp
   
   override def operationForNewLink(change: RoadLinkChange, assetsAll: Seq[PersistedLinearAsset], newRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
     val newLinkInfo = change.newLinks.head
-    val roadLinkFound = newRoadLinks.exists(_.linkId == newLinkInfo.linkId)
+    val filteredLinks = newRoadLinks.filterNot(link => Seq(HardShoulder, CycleOrPedestrianPath, TractorRoad).contains(link.linkType))
+    val roadLinkFound = filteredLinks.exists(_.linkId == newLinkInfo.linkId)
     if(roadLinkFound) {
       service.persistUnknown(Seq(UnknownSpeedLimit(newLinkInfo.linkId, newLinkInfo.municipality, newLinkInfo.adminClass)),newTransaction = false)
       None


### PR DESCRIPTION
Filtteröidään käpyväylä, ajopolku ja piennar pois tuntemattomien nopeusrajoitusten generoinnista link typen perusteella. Talvitiellä ei ole link typeä, joten sitä ei voi tässä filtterissä käyttää, mutta talvitiet filtteröidään pois jo linkkejä haettaessa kaikissa samuutuksissa (piennartiellä taitaa olla sama juttu, mutta laitoin nyt filtteriin joka tapauksessa).