### PR TITLE
DROTH-3859 remove converting only speed limit always to both directions

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFiller.scala
@@ -709,9 +709,6 @@ class AssetFiller {
       }
     }
   }
-  
-  protected def adjustLopsidedLimit(roadLink: RoadLinkForFillTopology, assets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet):
-  (Seq[PieceWiseLinearAsset], ChangeSet) = (assets, changeSet)
 
   /**
     * Finally adjust asset length by snapping to links start and endpoint. <br> <pre> 
@@ -733,9 +730,7 @@ class AssetFiller {
       val (againstGeometrySegments, againstGeometryAdjustments) = adjustOneWaySegments(roadLink, linearAssets, SideCode.AgainstDigitizing)
       val (twoWayGeometrySegments, twoWayGeometryAdjustments) = adjustTwoWaySegments(roadLink, linearAssets)
       val mValueAdjustments = towardsGeometryAdjustments ++ againstGeometryAdjustments ++ twoWayGeometryAdjustments
-      val (asset,changeSetCopy)=(towardsGeometrySegments ++ againstGeometrySegments ++ twoWayGeometrySegments,
-        changeSet.copy(adjustedMValues = changeSet.adjustedMValues ++ mValueAdjustments))
-      adjustLopsidedLimit(roadLink,asset,changeSetCopy)
+      (towardsGeometrySegments ++ againstGeometrySegments ++ twoWayGeometrySegments, changeSet.copy(adjustedMValues = changeSet.adjustedMValues ++ mValueAdjustments))
     } else {
       linearAssets.foldLeft((Seq[PieceWiseLinearAsset](), changeSet)) {
         case ((resultAssets, change), linearAsset) =>

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimitFiller.scala
@@ -70,17 +70,6 @@ object SpeedLimitFiller extends AssetFiller {
     )
   }
 
-
-  override protected def adjustLopsidedLimit(roadLink: RoadLinkForFillTopology, assets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet): (Seq[PieceWiseLinearAsset], ChangeSet) = {
-    val onlyLimitOnLink = assets.length == 1 && assets.head.sideCode != SideCode.BothDirections
-    if (onlyLimitOnLink) {
-      val segment = assets.head
-      val sideCodeAdjustments = Seq(SideCodeAdjustment(segment.id, SideCode.BothDirections, SpeedLimitAsset.typeId))
-      (Seq(segment.copy(sideCode = SideCode.BothDirections)), changeSet.copy(adjustedSideCodes = changeSet.adjustedSideCodes ++ sideCodeAdjustments))
-    } else {
-      (assets, changeSet)
-    }
-  }
   override def dropShortSegments(roadLink: RoadLinkForFillTopology, assets: Seq[PieceWiseLinearAsset], changeSet: ChangeSet): (Seq[PieceWiseLinearAsset], ChangeSet) = {
     val limitsToDrop = assets.filter { limit =>
       GeometryUtils.geometryLength(limit.geometry) < MinAllowedLength && roadLink.length > MinAllowedLength


### PR DESCRIPTION
Poistetaan metodi, joka muuttaa nopeusrajoituksen sidecoden both directions aina, jos kyseessä on ainoa rajoitus tielinkillä. Asia tehdään myöhemmin adjustSegmentSidecodes-metodissa, jos tielinkin liikennöintisuunta on molempiin suuntiin. Sen sijaan yksisuuntaisten tielinkkien assettien kuuluu olla uuden logiikan mukaan yksisuuntaisia, joten tämä on vanhentunut.

Käytännössä tämä metodi ei taida tehdä enää mitään, koska uusi sidecodelogiikka ajetaan tämän jälkeen. Metodin poistaminen ei rikkonut testejä, enkä havainnut UI:lla mitään outoa.