### PR TITLE
Droth 3918 manoeuvre work list bug

### DIFF
--- a/UI/src/view/linear_asset/manoeuvreForm.js
+++ b/UI/src/view/linear_asset/manoeuvreForm.js
@@ -624,8 +624,8 @@
       };
 
       eventbus.on('layer:selected', function(layer) {
-        $('ul[class=information-content]').empty();
         if(layer === 'manoeuvre') {
+          $('ul[class=information-content]').empty();
           renderInaccurateWorkList(layer);
           renderSamuutusWorkList();
         }

--- a/UI/src/view/linear_asset/manoeuvreForm.js
+++ b/UI/src/view/linear_asset/manoeuvreForm.js
@@ -624,6 +624,7 @@
       };
 
       eventbus.on('layer:selected', function(layer) {
+        $('ul[class=information-content]').empty();
         if(layer === 'manoeuvre') {
           renderInaccurateWorkList(layer);
           renderSamuutusWorkList();


### PR DESCRIPTION
Formista puuttuu elementin tyhjennys, jolloin edellisen assetin työlistat jäävät näkymään. Lisätty tyhjennys. Laitoin nyt varmuuden vuoksi tonne if:n alle, kun oli muillakin formeilla, vaikka en havainnut sivuvaikutuksia ennen if:iä.