### PR TITLE
DROTH-3929 round length values in validation

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ValidatorDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ValidatorDao.scala
@@ -153,7 +153,7 @@ object ValidatorLinearDao extends ValidatorDao{
       )
       SELECT DISTINCT id, link_id,side_code, start_measure, end_measure
       FROM result_set
-      WHERE assets_total_lenght != geometrylength"""
+      WHERE ROUND(assets_total_lenght) != ROUND(geometrylength)"""
     StaticQuery.queryNA[LinearReferenceAsset](sql)(getResult).iterator.toSeq
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ValidatorDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ValidatorDao.scala
@@ -102,6 +102,10 @@ object ValidatorLinearDao extends ValidatorDao{
     StaticQuery.queryNA[LinearReferenceAsset](sql)(getResult).iterator.toSeq
   }
 
+  /**
+  * get assets with total lengths differing from the link length by more than 0.1, which is also the generally allowed
+   * mValue error in topology corrections
+   */
   def assetDoesNotFillLink(assetType: Int, links: Set[String]): Seq[LinearReferenceAsset] = {
     val assetTypeFilter = s"a.asset_type_id = ${assetType}"
     val sql =

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ValidatorDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ValidatorDao.scala
@@ -153,7 +153,7 @@ object ValidatorLinearDao extends ValidatorDao{
       )
       SELECT DISTINCT id, link_id,side_code, start_measure, end_measure
       FROM result_set
-      WHERE ROUND(assets_total_lenght) != ROUND(geometrylength)"""
+      WHERE ABS(assets_total_lenght - geometrylength) > 0.1"""
     StaticQuery.queryNA[LinearReferenceAsset](sql)(getResult).iterator.toSeq
   }
 


### PR DESCRIPTION
Kattelin, et kokonaisluvun tarkkuus varmaan suodattaa suurimman osan turhista riveistä pois. Toki tuossa on pieni mahdollisuus, että assettien ja linkin pituus on just puolikkaan eri puolilla, mutta se ei taida olla kovin vaarallista.

Muutan tarkkuuden, jos on joku näkökulma, mitä en tajunnut.