### PR TITLE
DROTH-3939 set dragged point asset mValue to null

### DIFF
--- a/UI/src/view/point_asset/pointAssetLayer.js
+++ b/UI/src/view/point_asset/pointAssetLayer.js
@@ -116,7 +116,7 @@
                 });
               }
 
-              selectedAsset.set({lon: newPosition.x, lat: newPosition.y, linkId: nearestLine.linkId, geometry: feature.features.getArray()[0].getGeometry(), floating: false, bearing: newBearing});
+              selectedAsset.set({lon: newPosition.x, lat: newPosition.y, mValue: null, linkId: nearestLine.linkId, geometry: feature.features.getArray()[0].getGeometry(), floating: false, bearing: newBearing});
             }
           }
         }


### PR DESCRIPTION
Ongelma johtuu aiemman ongelman korjaamisesta https://github.com/finnishtransportagency/digiroad2/pull/2772. Huomasin, että frontilla mArvoa ei päivitetä, jos kohdetta siirretään. Kun frontilta tulee tallennuksen yhteydessä vanha mArvo, pistemäisen koordinaatit lasketaan sen perusteella, jolloin kohde siirtyy tallennuksessa samaan kohtaan samalla linkillä, tai vanhaa mArvoa vastaavaan kohtaan uudella linkillä.

Homma hoituisi varmaan myös backend-koodia muokkaamalla, mutta minusta helpointa olisi asettaa frontilla mArvoksi null, jos kohde liikkuu. Tällöin mArvo lasketaan koordinaattien perusteella uudelleen backendilla.