### PR TITLE
Droth 3941 update docker base image

### DIFF
--- a/aws/buildspecs/development.yaml
+++ b/aws/buildspecs/development.yaml
@@ -40,7 +40,7 @@ phases:
       - grunt deploy
       - sbt clean
       - sbt assembly
-      - docker build -f aws/fargate/Dockerfile --build-arg image=475079312496.dkr.ecr.eu-west-1.amazonaws.com/openjdk_8u191-jre-alpine:latest  -t $ECR_REPOSITORY_NAME:latest .
+      - docker build -f aws/fargate/Dockerfile --build-arg image=public.ecr.aws/docker/library/amazoncorretto:8-alpine-jre  -t $ECR_REPOSITORY_NAME:latest .
       - echo Post-build started on `date`
       - docker tag $ECR_REPOSITORY_NAME:latest $ECR_REPOSITORY_URI:latest
       - docker tag $ECR_REPOSITORY_NAME:latest $ECR_REPOSITORY_URI:$CODEBUILD_BUILD_NUMBER

--- a/aws/cloud-formation/support-repository.yml
+++ b/aws/cloud-formation/support-repository.yml
@@ -21,9 +21,3 @@ Resources:
             Condition:
               Bool:
                 'aws:SecureTransport': false
-  ECRRepoForBuildOpenjdk:
-    Type: AWS::ECR::Repository
-    Properties:
-      RepositoryName: "openjdk_8u191-jre-alpine"
-      ImageScanningConfiguration:
-        ScanOnPush: "true"

--- a/aws/fargate/Dockerfile
+++ b/aws/fargate/Dockerfile
@@ -1,4 +1,4 @@
-ARG image="openjdk:8u191-jre-alpine"
+ARG image="amazoncorretto:8-alpine-jre"
 FROM ${image}
 ENV initialRamPercentage="-XX:InitialRAMPercentage=50.0"
 ENV maxRamPercentage="-XX:MaxRAMPercentage=95.0"


### PR DESCRIPTION
Päivitetty dev-build käyttämään uutta imagea public-repositorysta ja poistettu private-repon luominen. 