### PR TITLE
Droth 3883 location specifier in traffic sign sidecode update

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdateProcess.scala
@@ -37,10 +37,12 @@ object PointAssetUpdateProcess {
   private val logger: Logger = LoggerFactory.getLogger(getClass)
 
   private def getAssetUpdater(typeId: Int): PointAssetUpdater = {
-    val directionalPointAssets = List(DirectionalTrafficSigns.typeId, TrafficSigns.typeId, TrafficLights.typeId)
+    val directionalPointAssets = List(DirectionalTrafficSigns.typeId, TrafficLights.typeId)
     typeId match {
       case id if id == MassTransitStopAsset.typeId =>
         new MassTransitStopUpdater(massTransitStopService)
+      case id if id == TrafficSigns.typeId =>
+        new TrafficSignUpdater(getPointAssetService(typeId))
       case id if directionalPointAssets.contains(id) =>
         new DirectionalPointAssetUpdater(getPointAssetService(typeId))
       case _ =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/PointAssetUpdater.scala
@@ -146,7 +146,7 @@ class PointAssetUpdater(service: PointAssetOperations) {
     }
   }
 
-  private def snapAssetToNewLink(asset: PersistedPointAsset, newLink: RoadLinkInfo, oldLink: RoadLinkInfo,
+  protected def snapAssetToNewLink(asset: PersistedPointAsset, newLink: RoadLinkInfo, oldLink: RoadLinkInfo,
                                  digitizationChange: Boolean): AssetUpdate = {
     if (isVersionChange(asset.linkId, newLink.linkId) && newLink.linkLength == oldLink.linkLength) {
       toAssetUpdate(asset.id, Point(asset.lon, asset.lat), newLink.linkId, asset.mValue,
@@ -166,17 +166,17 @@ class PointAssetUpdater(service: PointAssetOperations) {
     }
   }
 
-  private def isVersionChange(oldId: String, newId: String): Boolean = {
+  protected def isVersionChange(oldId: String, newId: String): Boolean = {
     def linkIdWithoutVersion(id: String): String = id.split(":").head
     linkIdWithoutVersion(oldId) == linkIdWithoutVersion(newId)
   }
 
-  private def setAssetAsFloating(asset: PersistedPointAsset, floatingReason: Option[FloatingReason]): AssetUpdate = {
+  protected def setAssetAsFloating(asset: PersistedPointAsset, floatingReason: Option[FloatingReason]): AssetUpdate = {
     toAssetUpdate(asset.id, Point(asset.lon, asset.lat), asset.linkId, asset.mValue, asset.getValidityDirection,
                   asset.getBearing, floating = true, floatingReason)
   }
 
-  private def toAssetUpdate(assetId: Long, point: Point, linkId: String, mValue: Double,
+  protected def toAssetUpdate(assetId: Long, point: Point, linkId: String, mValue: Double,
                             validityDirection: Option[Int], bearing: Option[Int],
                             floating: Boolean = false, floatingReason: Option[FloatingReason] = None): AssetUpdate = {
     AssetUpdate(assetId, point.x, point.y, linkId, mValue, validityDirection, bearing, DateTime.now().getMillis,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/TrafficSignUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/TrafficSignUpdater.scala
@@ -39,4 +39,10 @@ class TrafficSignUpdater(service: PointAssetOperations) extends DirectionalPoint
         false
     }
   }
+
+  override protected def setAssetAsFloating(asset: PersistedPointAsset, floatingReason: Option[FloatingReason]): AssetUpdate = {
+    val fixedValidityDirection = if (isOutsideRoadNetwork(asset)) Some(DoesNotAffectRoadLink.value) else asset.getValidityDirection
+    toAssetUpdate(asset.id, Point(asset.lon, asset.lat), asset.linkId, asset.mValue, fixedValidityDirection,
+      asset.getBearing, floating = true, floatingReason)
+  }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/TrafficSignUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/TrafficSignUpdater.scala
@@ -1,0 +1,42 @@
+package fi.liikennevirasto.digiroad2.util.assetUpdater.pointasset
+
+import fi.liikennevirasto.digiroad2.LocationSpecifier.OnRoadOrStreetNetwork
+import fi.liikennevirasto.digiroad2.asset.PropertyValue
+import fi.liikennevirasto.digiroad2.asset.SideCode.DoesNotAffectRoadLink
+import fi.liikennevirasto.digiroad2.client.RoadLinkInfo
+import fi.liikennevirasto.digiroad2.{AssetUpdate, FloatingReason, GeometryUtils, PersistedPointAsset, Point, PointAssetOperations}
+
+import scala.util.Try
+
+class TrafficSignUpdater(service: PointAssetOperations) extends DirectionalPointAssetUpdater(service: PointAssetOperations) {
+
+  override protected def snapAssetToNewLink(asset: PersistedPointAsset, newLink: RoadLinkInfo, oldLink: RoadLinkInfo,
+                                 digitizationChange: Boolean): AssetUpdate = {
+    if (isVersionChange(asset.linkId, newLink.linkId) && newLink.linkLength == oldLink.linkLength) {
+      val fixedValidityDirection = if (isOutsideRoadNetwork(asset)) Some(DoesNotAffectRoadLink.value) else asset.getValidityDirection
+      toAssetUpdate(asset.id, Point(asset.lon, asset.lat), newLink.linkId, asset.mValue,
+        fixedValidityDirection, asset.getBearing)
+    } else {
+      val oldLocation = Point(asset.lon, asset.lat)
+      val newMValue = GeometryUtils.calculateLinearReferenceFromPoint(oldLocation, newLink.geometry)
+      val newPoint = GeometryUtils.calculatePointFromLinearReference(newLink.geometry, newMValue)
+      newPoint match {
+        case Some(point) if point.distance2DTo(oldLocation) <= MaxDistanceDiffAllowed =>
+          val calculatedBearing = if (isOutsideRoadNetwork(asset)) asset.getBearing else calculateBearing(point, newLink.geometry)
+          val fixedValidityDirection = if (isOutsideRoadNetwork(asset)) Some(DoesNotAffectRoadLink.value) else adjustValidityDirection(asset.getValidityDirection, digitizationChange)
+          toAssetUpdate(asset.id, point, newLink.linkId, newMValue, fixedValidityDirection, calculatedBearing)
+        case _ =>
+          setAssetAsFloating(asset, Some(FloatingReason.DistanceToRoad))
+      }
+    }
+  }
+
+  private def isOutsideRoadNetwork(asset: PersistedPointAsset): Boolean = {
+    Try(service.getProperty(asset.propertyData, "location_specifier")).getOrElse(None) match {
+      case Some(value: PropertyValue) =>
+        Try(value.propertyValue.toInt).getOrElse(None) == OnRoadOrStreetNetwork.value
+      case _ =>
+        false
+    }
+  }
+}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/TrafficSignUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/pointasset/TrafficSignUpdaterSpec.scala
@@ -1,0 +1,79 @@
+package fi.liikennevirasto.digiroad2.util.assetUpdater.pointasset
+
+import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.NormalLinkInterface
+import fi.liikennevirasto.digiroad2.asset._
+import fi.liikennevirasto.digiroad2.client.{RoadLinkChange, RoadLinkChangeClient}
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
+import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.service.pointasset.TrafficSignService
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, PersistedPointAsset}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
+
+class TrafficSignUpdaterSpec extends FunSuite with Matchers {
+
+  case class testTrafficSign(id: Long, lon: Double, lat: Double, municipalityCode: Int, linkId: String,
+                                       mValue: Double, floating: Boolean, timeStamp: Long, validityDirection: Int,
+                                       bearing: Option[Int], linkSource: LinkGeomSource,
+                                       propertyData: Seq[Property] = Seq()) extends PersistedPointAsset {
+    override def getValidityDirection: Option[Int] = Some(validityDirection)
+
+    override def getBearing: Option[Int] = bearing
+  }
+
+  val roadLinkChangeClient = new RoadLinkChangeClient
+  val source: scala.io.BufferedSource = scala.io.Source.fromFile("digiroad2-oracle/src/test/resources/smallChangeSet.json")
+  val changes: Seq[RoadLinkChange] = roadLinkChangeClient.convertToRoadLinkChange(source.mkString)
+
+  val mockEventBus: DigiroadEventBus = MockitoSugar.mock[DigiroadEventBus]
+  val mockRoadLinkService: RoadLinkService = MockitoSugar.mock[RoadLinkService]
+
+  val trafficSignService: TrafficSignService = new TrafficSignService(mockRoadLinkService, mockEventBus) {
+    override def withDynTransaction[T](f: => T): T = f
+
+    override def withDynSession[T](f: => T): T = f
+  }
+
+  val updater: TrafficSignUpdater = new TrafficSignUpdater(trafficSignService) {
+    override lazy val roadLinkService: RoadLinkService = mockRoadLinkService
+  }
+
+  test("Traffic sign outside the road network: validity direction should be set to zero and bearing remain the same") {
+    val oldLinkId = "291f7e18-a48a-4afc-a84b-8485164288b2:1"
+    val newLinkId = "eca24369-a77b-4e6f-875e-57dc85176003:1"
+    val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
+
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.TowardsDigitizing,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(1)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getExistingOrExpiredRoadLinkByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
+    val asset = testTrafficSign(1, 391936.8899081593, 6672840.334351871, 91, oldLinkId,
+      4.773532861864595, false, 0, SideCode.AgainstDigitizing.value, Some(23), NormalLinkInterface,
+      Seq(Property(1, "location_specifier", "single_choice", false, Seq(PropertyValue("6", Some("Tie tai katuverkon ulkopuolella, esimerkiksi parkkialueella tai piha-alueella"))))))
+    val corrected = updater.correctPersistedAsset(asset, change)
+
+    corrected.validityDirection should be(Some(SideCode.DoesNotAffectRoadLink.value))
+    corrected.bearing should be(asset.getBearing)
+  }
+
+  test("Traffic sign within the road network: validity direction and bearing should be processed like other directional point assets") {
+    val oldLinkId = "291f7e18-a48a-4afc-a84b-8485164288b2:1"
+    val newLinkId = "eca24369-a77b-4e6f-875e-57dc85176003:1"
+    val change = changes.find(change => change.oldLink.nonEmpty && change.oldLink.get.linkId == oldLinkId).get
+
+    val newLinkInfo = change.newLinks.find(_.linkId == newLinkId).get
+    val newLink = RoadLink(newLinkId, newLinkInfo.geometry, newLinkInfo.linkLength, Municipality, 1, TrafficDirection.TowardsDigitizing,
+      Motorway, None, None, Map("MUNICIPALITYCODE" -> BigInt(1)), ConstructionType.InUse, LinkGeomSource.NormalLinkInterface)
+    when(mockRoadLinkService.getExistingOrExpiredRoadLinkByLinkId(newLinkId, false)).thenReturn(Some(newLink))
+
+    val asset = testTrafficSign(1, 391936.8899081593, 6672840.334351871, 91, oldLinkId,
+      4.773532861864595, false, 0, SideCode.AgainstDigitizing.value, Some(23), NormalLinkInterface,
+      Seq(Property(1, "location_specifier", "single_choice", false, Seq(PropertyValue("1", Some("Väylän oikea puoli"))))))
+    val corrected = updater.correctPersistedAsset(asset, change)
+
+    corrected.validityDirection should be(Some(SideCode.TowardsDigitizing.value))
+    corrected.bearing should not be(asset.bearing) // the validity direction has changed, so bearing should change as well
+  }
+}


### PR DESCRIPTION
Päivitetään liikennemerkin sidecode/validitydirection nollaksi samuutuksessa, eikä muokata bearingia, jos merkki on tieverkon ulkopuolella (location_specifier = 6).