### PR TITLE
Droth 3885 csv import side code 0 fix from master

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -877,7 +877,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
           "typeOfDamage" -> Try(trafficSignService.getProperty(trafficSign, "type_of_damage").map(_.propertyValue.toInt).get).getOrElse(""),
           "urgencyOfRepair" -> Try(trafficSignService.getProperty(trafficSign, "urgency_of_repair").map(_.propertyValue.toInt).get).getOrElse(""),
           "lifespanLeft" -> Try(trafficSignService.getProperty(trafficSign, "lifespan_left").map(_.propertyDisplayValue.get.toInt).get).getOrElse(""),
-          "trafficDirection" -> SideCode.toTrafficDirection(SideCode(trafficSign.validityDirection)).value,
+          "trafficDirection" -> SideCode.toTrafficDirectionForTrafficSign(SideCode(trafficSign.validityDirection)),
           "additionalPanels" -> mapAdditionalPanels(trafficSignService.getAllProperties(trafficSign, "additional_panel").map(_.asInstanceOf[AdditionalPanel]))
      )}
   }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/TrafficSign.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/TrafficSign.scala
@@ -3164,7 +3164,7 @@ sealed trait LocationSpecifier {
   def description: String
 }
 object LocationSpecifier {
-  val values = Set(Unknown, RightSideOfRoad, LeftSideOfRoad, AboveLane, TrafficIslandOrTrafficDivider, LengthwiseRelativeToTrafficFlow, OnRoadOrStreetNetwork)
+  val values = Set(Unknown, RightSideOfRoad, LeftSideOfRoad, AboveLane, TrafficIslandOrTrafficDivider, LengthwiseRelativeToTrafficFlow, OutsideRoadOrStreetNetwork)
 
   def apply(intValue: Int):LocationSpecifier = {
     values.find(_.value == intValue).getOrElse(getDefault)
@@ -3179,7 +3179,7 @@ object LocationSpecifier {
   case object LengthwiseRelativeToTrafficFlow extends LocationSpecifier { def value = 5; def description = "Pitkittäin ajosuuntaan nähden" }
 
   /*English description: On road or street network, for example parking area or courtyard*/
-  case object OnRoadOrStreetNetwork extends LocationSpecifier { def value = 6; def description = "Tie tai katuverkon ulkopuolella, esimerkiksi parkkialueella tai piha-alueella" }
+  case object OutsideRoadOrStreetNetwork extends LocationSpecifier { def value = 6; def description = "Tie tai katuverkon ulkopuolella, esimerkiksi parkkialueella tai piha-alueella" }
   case object Unknown extends LocationSpecifier { def value = 99; def description = "Ei tiedossa" }
 }
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
@@ -262,7 +262,7 @@ object SideCode {
       case AgainstDigitizing => TrafficDirection.AgainstDigitizing.value
       case BothDirections => TrafficDirection.BothDirections.value
       case Unknown => TrafficDirection.UnknownDirection.value
-      case DoesNotAffectRoadLink => 0
+      case DoesNotAffectRoadLink => DoesNotAffectRoadLink.value
     }
   }
   

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
@@ -228,6 +228,7 @@ object PointAssetStructure {
   case object Unknown extends PointAssetStructure { def value = 99; def description = "Ei tiedossa" }
 }
 
+case class SideCodeException(msg:String) extends Exception(msg)
 sealed trait SideCode {
   def value: Int
 }
@@ -252,9 +253,20 @@ object SideCode {
       case AgainstDigitizing => TrafficDirection.AgainstDigitizing
       case BothDirections => TrafficDirection.BothDirections
       case Unknown => TrafficDirection.UnknownDirection
+      case DoesNotAffectRoadLink => throw SideCodeException("Cannot convert SideCode 0 into TrafficDirection")
     }
   }
-
+  def toTrafficDirectionForTrafficSign(sideCode: SideCode): Int = {
+    sideCode match {
+      case TowardsDigitizing => TrafficDirection.TowardsDigitizing.value
+      case AgainstDigitizing => TrafficDirection.AgainstDigitizing.value
+      case BothDirections => TrafficDirection.BothDirections.value
+      case Unknown => TrafficDirection.UnknownDirection.value
+      case DoesNotAffectRoadLink => 0
+    }
+  }
+  
+  case object DoesNotAffectRoadLink extends SideCode { def value = 0 }
   case object BothDirections extends SideCode { def value = 1 }
   case object TowardsDigitizing extends SideCode { def value = 2 }
   case object AgainstDigitizing extends SideCode { def value = 3 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -2,6 +2,7 @@ package fi.liikennevirasto.digiroad2.csvDataImporter
 
 import java.io.{InputStream, InputStreamReader}
 import com.github.tototoshi.csv.{CSVReader, DefaultCSVFormat}
+import fi.liikennevirasto.digiroad2.LocationSpecifier.OutsideRoadOrStreetNetwork
 import fi.liikennevirasto.digiroad2.TrafficSignTypeGroup.AdditionalPanels
 import fi.liikennevirasto.digiroad2._
 import fi.liikennevirasto.digiroad2.asset.SideCode.DoesNotAffectRoadLink
@@ -537,7 +538,7 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
       val (sideCode, propsToUse, bearingToUse) = if (linksWithValidBearing.isEmpty) {
         val validityDirection = DoesNotAffectRoadLink.value
         val propsIndexToUpdate = props.indexWhere(_.columnName == "locationSpecifier")
-        val updatedAssetProperty = props(propsIndexToUpdate).copy(value = 6)
+        val updatedAssetProperty = props(propsIndexToUpdate).copy(value = OutsideRoadOrStreetNetwork.value)
         val updatedProps = props.updated(propsIndexToUpdate, updatedAssetProperty)
         (validityDirection, updatedProps, optBearing)
       }
@@ -545,7 +546,8 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
         (trafficSignService.getValidityDirection(point, roadLink, assetBearing, twoSided), props, assetBearing)
       } else (assetValidityDirection.get, props, assetBearing)
 
-      (propsToUse, CsvPointAsset(point.x, point.y, roadLink.linkId, generateBaseProperties(propsToUse), sideCode, bearingToUse, mValue, roadLink, (linksWithValidBearing.isEmpty || linksWithValidBearing.size > 1) && assetBearing.isEmpty))
+      val isFloating = (linksWithValidBearing.isEmpty || linksWithValidBearing.size > 1) && assetBearing.isEmpty
+      (propsToUse, CsvPointAsset(point.x, point.y, roadLink.linkId, generateBaseProperties(propsToUse), sideCode, bearingToUse, mValue, roadLink, isFloating))
     }
 
     var notImportedDataExceptions: List[NotImportedData] = List()


### PR DESCRIPTION
Jos ei löydy tielinkkiä, jonka suuntima on 25 asteen toleranssin sisällä tuotavan assetin suuntimasta, annetaan sijainti tarkenne 6 ja sideCode 0 ja käytetään alkuperäistä assetin suuntimaa luonnissa.. Tehty samalla valtion tie filter korjaus liittyen tikettiin DROTH-2935