### PR TITLE
DROTH-3884 ui handling for traffic signs outside roads

### DIFF
--- a/UI/src/utils/validity-directions.js
+++ b/UI/src/utils/validity-directions.js
@@ -1,5 +1,6 @@
 (function() {
   window.validitydirections = {
+    outsideRoadNetwork: 0,
     bothDirections: 1,
     sameDirection: 2,
     oppositeDirection: 3,

--- a/UI/src/view/point_asset/pointAssetForm.js
+++ b/UI/src/view/point_asset/pointAssetForm.js
@@ -56,6 +56,11 @@ root.PointAssetForm = function() {
       rootElement.find('.form-controls button').prop('disabled', !(selectedAsset.isDirty() && me.saveCondition(selectedAsset, authorizationPolicy)));
       rootElement.find('button#cancel-button').prop('disabled', !(selectedAsset.isDirty()));
       rootElement.find('button#save-button').prop('disabled', !(selectedAsset.isDirty() && me.saveCondition(selectedAsset, authorizationPolicy)));
+      if (layerName === 'trafficSigns') {
+        var bearingElement = rootElement.find('.form-point-asset input#bearing');
+        rootElement.find('button#save-button').prop('disabled', bearingElement.prop('disabled') === false &&
+            (bearingElement.val() < 0 || bearingElement.val() > 360 || _.isEmpty(bearingElement.val())));
+      }
     });
 
     eventbus.on(layerName + ':unselected ' + layerName + ':creationCancelled', function() {
@@ -383,7 +388,7 @@ root.PointAssetForm = function() {
   };
 
   me.renderValidityDirection = function (selectedAsset) {
-    if(selectedAsset.validityDirection){
+    if(!_.isUndefined(selectedAsset.validityDirection)){
       return '' +
           '    <div class="form-group editable form-directional-traffic-sign edit-only">' +
           '      <label class="control-label">Vaikutussuunta</label>' +


### PR DESCRIPTION
Peruslogiikka:

Merkki tieverkon ulkopuolelle (locationSpecifier = 6) -> sidecode 0, vaihda suuntaa disabled, validi suuntima annettava manuaalisesti

Takaisin tieverkolle -> sidecode 2, vaihda suuntaa enabled, suuntima-kenttä disabled ja suuntima lasketaan uudelleen linkin perusteella (samalla tavoin kuin assettia siirrettäessä)

(Branchatty alunperin samuutus_codesta. Pitää cherry-pick, jos viedään eteenpäin.)