### PR TITLE
DROTH-3902 safeguard for data fixture reset

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/PostGISDatabase.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/PostGISDatabase.scala
@@ -19,6 +19,10 @@ object PostGISDatabase {
     override def initialValue(): Boolean = { false }
   }
 
+  def isLocalDbConnection: Boolean = {
+    ds.getConnection.getMetaData.getURL == "jdbc:postgresql://localhost:5432/digiroad2" && ds.getConnection.getMetaData.getUserName == "digiroad2"
+  }
+
   def isTransactionOpen: Boolean = transactionOpen.get()
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2016,10 +2016,6 @@ object DataFixture {
     ))
   }
 
-  private def localDbConnection(dataSource: DataSource) = {
-    dataSource.getConnection.getMetaData.getURL == "jdbc:postgresql://localhost:5432/digiroad2" && dataSource.getConnection.getMetaData.getUserName == "digiroad2"
-  }
-
   def main(args:Array[String]) : Unit = {
     val batchMode = Digiroad2Properties.batchMode
     if (!batchMode) {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2032,7 +2032,7 @@ object DataFixture {
 
     args.headOption match {
       case Some("test") =>
-        if (!localDbConnection(PostGISDatabase.ds)) {
+        if (!PostGISDatabase.isLocalDbConnection) {
           throw new IllegalDatabaseConnectionException("not connected to local database, reset aborted")
         } else {
           logger.info("resetting database")


### PR DESCRIPTION
Tarkistetaan ennen datafixture resetiä urlin ja usernamen perusteella, että yhteys on lokaaliin kantaan. Jos ei ole, heitetään poikkeus.

Masterille viennin jälkeen cherry-pickaan commitin samuutus_codeen, kun sieltä branchataan myös.