### PR TITLE
DROTH-3854 remove incorrect comma from csv report

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
@@ -287,7 +287,7 @@ object ChangeReporter {
       if (changedAsset.after.isEmpty) {
         val emptyAfterFields =  Seq("", "", "", "", "", "", "","", "", "")
         if(withGeometry) Seq(metaFields ++ beforeFields ++ emptyAfterFields)
-        else Seq(metaFields ++ beforeFieldsWithoutGeometry ++ emptyAfterFields)
+        else Seq(metaFields ++ beforeFieldsWithoutGeometry ++ emptyAfterFields.dropRight(1))
       } else {
         changedAsset.after.map { after =>
           val linearReference = after.linearReference.get


### PR DESCRIPTION
Ilman geometriaa olevaan tyhjään after-riviin tulee tällä hetkellä yksi pilkku liikaa, kun ei huomioida otsikkorivin puuttuvaa geometriasaraketta. Excel ei tästä välitä, mutta jollain muulla (esim. pandas) avaaminen ei välttämättä onnistu. Eli poistetaan ylimääräinen pilkku.