### PR TITLE
DROTH-3902 allow aws test connection to reset unit test db

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/PostGISDatabase.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/postgis/PostGISDatabase.scala
@@ -23,6 +23,11 @@ object PostGISDatabase {
     ds.getConnection.getMetaData.getURL == "jdbc:postgresql://localhost:5432/digiroad2" && ds.getConnection.getMetaData.getUserName == "digiroad2"
   }
 
+  def isAwsUnitTestConnection: Boolean = {
+    ds.getConnection.getMetaData.getURL == "jdbc:postgresql://ddw6gldo8fiqt4.c8sq5c8rj3gu.eu-west-1.rds.amazonaws.com:5432/digiroad2" &&
+      ds.getConnection.getMetaData.getUserName == "digiroaduserfortest"
+  }
+
   def isTransactionOpen: Boolean = transactionOpen.get()
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2069,7 +2069,7 @@ object DataFixture {
 
     args.headOption match {
       case Some("test") =>
-        if (!PostGISDatabase.isLocalDbConnection) {
+        if (!(PostGISDatabase.isLocalDbConnection || PostGISDatabase.isAwsUnitTestConnection)) {
           throw new IllegalDatabaseConnectionException("not connected to local database, reset aborted")
         } else {
           logger.info("resetting database")


### PR DESCRIPTION
Hyväksytään resetissä yhteys myös buildin unit-test kantaan, jotta build ei kaadu.