### PR TITLE
DROTH-3884 bearing and validity direction fields when toggling between read only and edit

### DIFF
--- a/UI/src/view/point_asset/trafficSignForm.js
+++ b/UI/src/view/point_asset/trafficSignForm.js
@@ -536,4 +536,13 @@
         '    </div>';
     };
   };
+
+  eventbus.on('application:readOnly', function(readOnly) {
+    if(!readOnly) {
+      var assetIsOutsideRoadNetwork =  selectedAsset.get().validityDirection === validitydirections.outsideRoadNetwork;
+      rootElement.find('button#change-validity-direction').prop("disabled", assetIsOutsideRoadNetwork);
+      rootElement.find('.form-point-asset input#bearing').prop("disabled", !assetIsOutsideRoadNetwork);
+      rootElement.find('.form-point-asset input#bearing').prop("valueAsNumber", assetIsOutsideRoadNetwork ? selectedAsset.get().bearing : NaN);
+    }
+  });
 })(this);


### PR DESCRIPTION
Suuntiman ja vaihda suuntaa -kenttien lähtöarvojen asettaminen oikein myös tilanteessa, jossa merkki valitaan katselunäkymässä ja siirrytään katselunäkymästä muokkausnäkymään.