### PR TITLE
DROTH-3884 move read only toggle event

### DIFF
--- a/UI/src/view/point_asset/trafficSignForm.js
+++ b/UI/src/view/point_asset/trafficSignForm.js
@@ -201,6 +201,15 @@
         selectedAsset.set({bearing: parseInt($(this).val())});
       });
 
+      eventbus.on('application:readOnly', function(readOnly) {
+        if(!readOnly && selectedAsset.get()) {
+          var assetIsOutsideRoadNetwork = selectedAsset.get().validityDirection === validitydirections.outsideRoadNetwork;
+          rootElement.find('button#change-validity-direction').prop("disabled", assetIsOutsideRoadNetwork);
+          rootElement.find('.form-point-asset input#bearing').prop("disabled", !assetIsOutsideRoadNetwork);
+          rootElement.find('.form-point-asset input#bearing').prop("valueAsNumber", assetIsOutsideRoadNetwork ? selectedAsset.get().bearing : NaN);
+        }
+      });
+
       function bindPanelEvents(){
         rootElement.find('.remove-panel').on('click', function (event) {
           removeSingle(event);
@@ -537,12 +546,4 @@
     };
   };
 
-  eventbus.on('application:readOnly', function(readOnly) {
-    if(!readOnly) {
-      var assetIsOutsideRoadNetwork =  selectedAsset.get().validityDirection === validitydirections.outsideRoadNetwork;
-      rootElement.find('button#change-validity-direction').prop("disabled", assetIsOutsideRoadNetwork);
-      rootElement.find('.form-point-asset input#bearing').prop("disabled", !assetIsOutsideRoadNetwork);
-      rootElement.find('.form-point-asset input#bearing').prop("valueAsNumber", assetIsOutsideRoadNetwork ? selectedAsset.get().bearing : NaN);
-    }
-  });
 })(this);


### PR DESCRIPTION
Alkuperäinen muutos ei toiminut devillä, koska ei taida päästä käsiksi valittuun assettiin. Jostain syystä lokaalissa ympäristössä en huomannut tätä ongelmaa. Siirretään tapahtumakäsittelyä ja tarkennetaan sen verran, että logiikka toteutetaan vain, jos on olemassa valittu asset.