### PR TITLE
 DROTH-3934 revert jQuery back to 3.4.1 due incompatibility issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "backbone": "1.5.0",
     "chai-jquery": "2.1.0",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "jquery-migrate": "3.3.0",
     "jquery-ui-dist": "1.12.0",
     "jquery-validation": "^1.17.0",


### PR DESCRIPTION
jQuery v3.5.0 rikkoi vanhan self-closing tag syntaksin. Liian suuri työ alkaa korjaamaan UI-muutoksen kynnyksellä.