### PR TITLE
 DROTH-3952 change how failure is handdled, report error

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
@@ -153,7 +153,7 @@ object ApiUtils {
             Future {
               s3Service.saveFileToS3(s3Bucket, workId, responseString, responseType)
             }.onComplete {
-              case Failure(e) => saveErrror(workId, queryId, e)
+              case Failure(e) => saveError(workId, queryId, e)
               case Success(t) => ""
             }
             redirectToUrl(path, queryId, Some(1))
@@ -162,7 +162,7 @@ object ApiUtils {
     } catch {
       case _: TimeoutException =>
           ret.onComplete {
-            case Failure(e) => saveErrror(workId, queryId, e)
+            case Failure(e) => saveError(workId, queryId, e)
             case Success(t) => 
               val responseBody = formatResponse(t, responseType, queryId)
               s3Service.saveFileToS3(s3Bucket, workId, responseBody, responseType)
@@ -171,7 +171,7 @@ object ApiUtils {
     }
   }
 
-  private def saveErrror[T](workId: String, queryId: String, e: Throwable): Unit = {
+  private def saveError[T](workId: String, queryId: String, e: Throwable): Unit = {
     logger.error(s"API LOG $queryId: error with message ${e.getMessage}, stacktrace: ", e);
     // Save the error message to S3, so that the caller gets the error feedback from there,
     // and does not stay stuck waiting forever in the case of a failure.

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
@@ -3,22 +3,44 @@ package fi.liikennevirasto.digiroad2
 import fi.liikennevirasto.digiroad2.Digiroad2Context.awsService
 import fi.liikennevirasto.digiroad2.util.{Digiroad2Properties, LogUtils}
 import org.joda.time.DateTime
+import org.json4s.DefaultFormats
+import org.json4s.native.Json
+import org.scalatra._
+import org.slf4j.{Logger, LoggerFactory}
 
 import java.util.concurrent.TimeUnit
 import javax.servlet.http.HttpServletRequest
-import org.json4s.DefaultFormats
-import org.json4s.native.Json
-import org.scalatra.{ActionResult, BadRequest, Found, InternalServerError, Params}
-import org.slf4j.{Logger, LoggerFactory}
-
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.compat.Platform.EOL
-import scala.concurrent.{Await, Future, TimeoutException}
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
+import scala.concurrent.{Await, Future, TimeoutException}
 import scala.util.{Failure, Random, Success}
+sealed trait HttpStatusCodeError {
+  def value: Int
+}
 
+object HttpStatusCodeError {
+
+  // --- 4xx Client Error ---
+  case object BAD_REQUEST extends HttpStatusCodeError { val value = 400 }
+  case object UNAUTHORIZED extends HttpStatusCodeError { val value = 401 }
+  case object FORBIDDEN extends HttpStatusCodeError { val value = 403 }
+  case object NOT_FOUND extends HttpStatusCodeError { val value = 404 }
+  case object METHOD_NOT_ALLOWED extends HttpStatusCodeError { val value = 405 }
+  case object NOT_ACCEPTABLE extends HttpStatusCodeError { val value = 406 }
+  case object REQUEST_TIMEOUT extends HttpStatusCodeError { val value = 408 }
+  case object REQUEST_TOO_LONG extends HttpStatusCodeError { val value = 413 }
+  case object THROTTLING extends HttpStatusCodeError { val value = 429 }
+
+  // --- 5xx Server Error ---
+  case object INTERNAL_SERVER_ERROR extends HttpStatusCodeError { val value = 500 }
+  case object BAD_GATEWAY extends HttpStatusCodeError { val value = 502 }
+  case object SERVICE_UNAVAILABLE extends HttpStatusCodeError { val value = 503 }
+  case object GATEWAY_TIMEOUT extends HttpStatusCodeError { val value = 504 }
+}
+
+case class DigiroadApiError(httpCode:HttpStatusCodeError, msg:String) extends Throwable(msg)
 object ApiUtils {
   val logger: Logger = LoggerFactory.getLogger(getClass)
   val s3Service: awsService.S3.type = awsService.S3
@@ -33,9 +55,10 @@ object ApiUtils {
   val MAX_RESPONSE_SIZE_BYTES: Long = 1024 * 1024 * 10 // 10Mb in bytes
   val MAX_RETRIES: Int = 540 // 3 hours / 20sec per retry
 
-  /**
+ /**
    * Avoid API Gateway restrictions
    * When using avoidRestrictions, do not hide errors but delegate these to avoidRestrictions method.
+   * For error handling throw exception [[DigiroadApiError]].
    * API Gateway timeouts if response is not received in 30 sec
    *  -> Return redirect to same url with retry param if query is not finished within maxWaitTime
    *  -> Save response to S3 when its ready (access with pre-signed url)
@@ -67,9 +90,10 @@ object ApiUtils {
       case (None, false) =>
         try {
           newQuery(workId, queryId, path, f, params, responseType)
-        } catch {
-          case e: Throwable =>
-            logger.error(s"API LOG $queryId: error with message ${e.getMessage} and stacktrace: ",e);
+        } catch { // handle imminent error
+          case e: DigiroadApiError => handleError(queryId, e)
+          case e: Throwable => 
+            logger.error(s"API LOG $queryId: error with message ${e.getMessage} and stacktrace: ", e);
             InternalServerError(s"Request with id $queryId failed.")
         }
       case (Some(retry: String), false) =>
@@ -83,6 +107,25 @@ object ApiUtils {
     }
   }
 
+  private def handleError[T](queryId: String, e: DigiroadApiError): ActionResult = {
+    logger.error(s"API LOG $queryId: error with message ${e.msg} and stacktrace: ", e);
+
+    e.httpCode match {
+      case HttpStatusCodeError.BAD_REQUEST => BadRequest(e.msg)
+      case HttpStatusCodeError.UNAUTHORIZED => Unauthorized(e.msg)
+      case HttpStatusCodeError.FORBIDDEN => Forbidden(e.msg)
+      case HttpStatusCodeError.NOT_FOUND => NotFound(e.msg)
+      case HttpStatusCodeError.METHOD_NOT_ALLOWED => MethodNotAllowed(e.msg)
+      case HttpStatusCodeError.NOT_ACCEPTABLE => NotAcceptable(e.msg)
+      case HttpStatusCodeError.REQUEST_TIMEOUT => RequestTimeout(e.msg)
+      case HttpStatusCodeError.REQUEST_TOO_LONG => RequestEntityTooLarge(e.msg)
+      case HttpStatusCodeError.THROTTLING => TooManyRequests(e.msg)
+      case HttpStatusCodeError.INTERNAL_SERVER_ERROR => InternalServerError(e.msg)
+      case HttpStatusCodeError.BAD_GATEWAY => BadGateway(e.msg)
+      case HttpStatusCodeError.SERVICE_UNAVAILABLE => ServiceUnavailable(e.msg)
+      case HttpStatusCodeError.GATEWAY_TIMEOUT => GatewayTimeout(e.msg)
+    }
+  }
   /** Work id formed of request id (i.e. "integration") and query params */
   def getWorkId(requestId: String, params: Params, contentType: String): String = {
     val sortedParams = params.toSeq.filterNot(param => param._1 == "retry" || param._1 == "queryId").sortBy(_._1)
@@ -110,10 +153,8 @@ object ApiUtils {
             Future {
               s3Service.saveFileToS3(s3Bucket, workId, responseString, responseType)
             }.onComplete {
-              case Failure(e) => 
-                logger.error(s"API LOG $queryId: failed to save S3, stacktrace: ",e);
+              case Failure(e) => saveErrror(workId, queryId, e)
               case Success(t) => ""
-                
             }
             redirectToUrl(path, queryId, Some(1))
           }
@@ -121,7 +162,7 @@ object ApiUtils {
     } catch {
       case _: TimeoutException =>
           ret.onComplete {
-            case Failure(e) =>  logger.error(s"API LOG $queryId: error with message ${e.getMessage}, stacktrace: ",e);
+            case Failure(e) => saveErrror(workId, queryId, e)
             case Success(t) => 
               val responseBody = formatResponse(t, responseType, queryId)
               s3Service.saveFileToS3(s3Bucket, workId, responseBody, responseType)
@@ -129,8 +170,14 @@ object ApiUtils {
         redirectToUrl(path, queryId, Some(1))
     }
   }
-  
-  def formatResponse(content: Any, responseType: String,queryId: String): String = {
+
+  private def saveErrror[T](workId: String, queryId: String, e: Throwable): Unit = {
+    logger.error(s"API LOG $queryId: error with message ${e.getMessage}, stacktrace: ", e);
+    // Save the error message to S3, so that the caller gets the error feedback from there,
+    // and does not stay stuck waiting forever in the case of a failure.
+    s3Service.saveFileToS3(s3Bucket, workId, s"Request with id $queryId failed.", "text/plain")
+  }
+  def formatResponse(content: Any, responseType: String, queryId: String): String = {
     (content, responseType) match {
       case (response: Seq[_], "json") =>
         timer(s"API LOG $queryId: convert to json"){

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
@@ -97,8 +97,9 @@ object RequestMiddleware {
     val (path: String, id: String) = prepare(request)
     logger.info(s"$title $id: Received query $path at ${DateTime.now}")
     try {
-      f(params)
+      val r = f(params)
       logger.info(s"$title $id: Completed the query at ${DateTime.now}")
+      r
     } catch { // handle imminent error
       case e: DigiroadApiError => ReturnResponse.error(id, e, logger)
       case e: Throwable =>

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ApiUtils.scala
@@ -58,7 +58,7 @@ object ApiUtils {
  /**
    * Avoid API Gateway restrictions
    * When using avoidRestrictions, do not hide errors but delegate these to avoidRestrictions method.
-   * For error handling throw exception [[DigiroadApiError]].
+   * For handling validation exception throw [[DigiroadApiError]].
    * API Gateway timeouts if response is not received in 30 sec
    *  -> Return redirect to same url with retry param if query is not finished within maxWaitTime
    *  -> Save response to S3 when its ready (access with pre-signed url)

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -68,8 +68,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
   get("/:assetType", operation(getChangesOfAssetsByType)) {
     contentType = formats("json")
     ApiUtils.avoidRestrictions(apiId, request, params) { params =>
-      val since = DateTime.parse(params.get("since").getOrElse(halt(BadRequest("Missing mandatory 'since' parameter"))))
-      val until = DateTime.parse(params.get("until").getOrElse(halt(BadRequest("Missing mandatory 'until' parameter"))))
+      val since = DateTime.parse(params.get("since").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'since' parameter")))
+      val until = DateTime.parse(params.get("until").getOrElse( throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'until' parameter")))
       val token = params.get("token").map(_.toString)
 
       val withAdjust = params.get("withAdjust") match {
@@ -105,8 +105,8 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
   get("/mass_transit_stops", operation(getMassTransitStopsPrintedAtValluXML)) {
     contentType = formats("json")
     ApiUtils.avoidRestrictions(apiId + "_mass_transit_stops", request, params) { params =>
-      val since = DateTime.parse(params.get("since").getOrElse(halt(BadRequest("Missing mandatory 'since' parameter"))))
-      val until = DateTime.parse(params.get("until").getOrElse(halt(BadRequest("Missing mandatory 'until' parameter"))))
+      val since = DateTime.parse(params.get("since").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'since' parameter")))
+      val until = DateTime.parse(params.get("until").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'until' parameter")))
       val token = params.get("token").map(_.toString)
 
       massTransitStopsToGeoJson(since, massTransitStopService.getPublishedOnXml(since, until, token))

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ChangeApi.scala
@@ -19,6 +19,7 @@ import org.scalatra.swagger.{Swagger, SwaggerSupport}
 import org.scalatra.{BadRequest, ScalatraServlet}
 
 import scala.collection.mutable
+import scala.util.Try
 
 class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSupport with SwaggerSupport {
   protected val applicationDescription = "Change API "
@@ -63,14 +64,15 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
       authorizations "Contact your service provider for more information"
       description "Example URL: api/changes/mass_transit_stops?since=2019-03-15T09:19:27.424Z&until=2019-03-22T23:55:27.429Z"
       )
-
-
+ 
   get("/:assetType", operation(getChangesOfAssetsByType)) {
     contentType = formats("json")
     ApiUtils.avoidRestrictions(apiId, request, params) { params =>
-      val since = DateTime.parse(params.get("since").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'since' parameter")))
-      val until = DateTime.parse(params.get("until").getOrElse( throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'until' parameter")))
-      val token = params.get("token").map(_.toString)
+     val since = Try(DateTime.parse(params.get("since").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Missing mandatory 'since' parameter"))))
+                 .getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Cannot convert to date"))
+     val until = Try(DateTime.parse(params.get("until").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Missing mandatory 'until' parameter"))))
+                 .getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Cannot convert to date"))
+     val token = params.get("token").map(_.toString)
 
       val withAdjust = params.get("withAdjust") match {
         case Some(value) => true
@@ -98,6 +100,7 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
         case "warning_signs_group" => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(trafficSignService.getTrafficSignTypeByGroup(TrafficSignTypeGroup.GeneralWarningSigns), since, until, token), pointAssetWarningSignsGroupProperties)
         case "stop_sign" => pointAssetsToGeoJson(since, trafficSignService.getChangedByType(Set(Stop.OTHvalue), since, until, token), pointAssetStopSignProperties)
         case "lane_information" => laneChangesToGeoJson(laneService.getChanged(since, until, withAdjust, token), withGeometry)
+        case _ => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid asset type")
       }
     }
   }
@@ -105,8 +108,10 @@ class ChangeApi(val swagger: Swagger) extends ScalatraServlet with JacksonJsonSu
   get("/mass_transit_stops", operation(getMassTransitStopsPrintedAtValluXML)) {
     contentType = formats("json")
     ApiUtils.avoidRestrictions(apiId + "_mass_transit_stops", request, params) { params =>
-      val since = DateTime.parse(params.get("since").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'since' parameter")))
-      val until = DateTime.parse(params.get("until").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'until' parameter")))
+     val since = Try(DateTime.parse(params.get("since").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Missing mandatory 'since' parameter"))))
+       .getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Cannot convert to date"))
+     val until = Try(DateTime.parse(params.get("until").getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Missing mandatory 'until' parameter"))))
+       .getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST, "Cannot convert to date"))
       val token = params.get("token").map(_.toString)
 
       massTransitStopsToGeoJson(since, massTransitStopService.getPublishedOnXml(since, until, token))

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -972,10 +972,10 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
           case "road_works_asset" => roadWorksToApi(municipalityNumber)
           case "parking_prohibitions" => parkingProhibitionsToApi(municipalityNumber)
           case "cycling_and_walking" => linearAssetsToApi(CyclingAndWalking.typeId, municipalityNumber)
-          case _ => BadRequest("Invalid asset type")
+          case _ => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid asset type")
         }
       } getOrElse {
-        BadRequest("Missing mandatory 'municipality' parameter")
+        throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'municipality' parameter")
       }
     }
   }
@@ -986,11 +986,11 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
       params.get("municipality").map { municipality =>
         val groupName = getTrafficSignGroup(params("group_name"))
         groupName match {
-          case TrafficSignTypeGroup.Unknown => BadRequest("Invalid group type")
+          case TrafficSignTypeGroup.Unknown => DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid group type")
           case _ => trafficSignsToApi(trafficSignService.getByMunicipalityAndGroup(municipality.toInt, groupName))
         }
       } getOrElse {
-        BadRequest("Missing mandatory 'municipality' parameter")
+      throw  DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mandatory 'municipality' parameter")
       }
     }
   }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -986,7 +986,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
       params.get("municipality").map { municipality =>
         val groupName = getTrafficSignGroup(params("group_name"))
         groupName match {
-          case TrafficSignTypeGroup.Unknown => DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid group type")
+          case TrafficSignTypeGroup.Unknown => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid group type")
           case _ => trafficSignsToApi(trafficSignService.getByMunicipalityAndGroup(municipality.toInt, groupName))
         }
       } getOrElse {

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -927,7 +927,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
     contentType = formats("json")+ "; charset=utf-8"
     ApiUtils.avoidRestrictions(apiId, request, params){ params =>
       params.get("municipality").map { municipality =>
-        val municipalityNumber = municipality.toInt
+        val municipalityNumber = Try(municipality.toInt).getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Municipality parameter is not in number format"))
         val assetType = params("assetType")
         assetType match {
           case "mass_transit_stops" => toGeoJSON(getMassTransitStopsByMunicipality(municipalityNumber) ++ servicePointStopService.transformToPersistedMassTransitStop(servicePointStopService.getByMunicipality(municipalityNumber)))

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -98,7 +98,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
       }
       catch {
         case invalidRoadNumberException: InvalidRoadAddressRangeParamaterException => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,invalidRoadNumberException.getMessage)
-        case _: NumberFormatException => halt(BadRequest("Invalid parameters"))
+        case _: NumberFormatException => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid parameters")
       }
 
       lanesInRoadAddressRangeToApi(parameters)
@@ -110,14 +110,14 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     ApiUtils.avoidRestrictions(apiId + "_municipality", request, params) { params =>
       try {
         val municipalityParameter = params.get("municipality")
-        if (municipalityParameter.isEmpty) halt(BadRequest("Missing municipality parameter"))
+        if (municipalityParameter.isEmpty)  throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing municipality parameter")
         else {
           val municipalityNumber = municipalityParameter.get.toInt
           lanesInMunicipalityToApi(municipalityNumber)
         }
       }
       catch {
-        case _: NumberFormatException => halt(BadRequest("Missing or invalid municipality parameter"))
+        case _: NumberFormatException =>  throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing or invalid municipality parameter")
       }
     }
   }
@@ -177,7 +177,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
     val (lanesWithRoadAddress, roadLinksGrouped) = try {
       laneService.getLanesInRoadAddressRange(roadAddressRange)
     } catch {
-      case rae: RoadAddressException => halt(BadRequest("Could not fetch lanes for given road address range, check that given road address range is valid"))
+      case rae: RoadAddressException =>  throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Could not fetch lanes for given road address range, check that given road address range is valid")
     }
     val twoDigitLanes = pwLanesTwoDigitLaneCode(lanesWithRoadAddress)
     val homogenousLanes = homogenizeTwoDigitLanes(twoDigitLanes, roadLinksGrouped)

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/LaneApi.scala
@@ -80,12 +80,12 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
   get("/lanes_in_range", operation(getLanesInRoadAddressRange)) {
     contentType = formats("json") + "; charset=utf-8"
     ApiUtils.avoidRestrictions(apiId + "_range", request, params) { params =>
-      val roadNumber = params.getOrElse("road_number", halt(BadRequest("Missing parameters")))
+      val roadNumber = params.getOrElse("road_number",throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing parameters"))
       val track = params.get("track")
-      val startRoadPartNumber = params.getOrElse("start_part", halt(BadRequest("Missing parameters")))
-      val startAddrM = params.getOrElse("start_addrm", halt(BadRequest("Missing parameters")))
-      val endRoadPartNumber = params.getOrElse("end_part", halt(BadRequest("Missing parameters")))
-      val endAddrM = params.getOrElse("end_addrm", halt(BadRequest("Missing parameters")))
+      val startRoadPartNumber = params.getOrElse("start_part", throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing parameters"))
+      val startAddrM = params.getOrElse("start_addrm", throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing parameters"))
+      val endRoadPartNumber = params.getOrElse("end_part", throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing parameters"))
+      val endAddrM = params.getOrElse("end_addrm", throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing parameters"))
 
       val parameters = try {
         val trackParam = if(track.isDefined) Some(Track(track.get.toInt))
@@ -97,7 +97,7 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
         params
       }
       catch {
-        case invalidRoadNumberException: InvalidRoadAddressRangeParamaterException => halt(BadRequest(invalidRoadNumberException.getMessage))
+        case invalidRoadNumberException: InvalidRoadAddressRangeParamaterException => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,invalidRoadNumberException.getMessage)
         case _: NumberFormatException => halt(BadRequest("Invalid parameters"))
       }
 
@@ -128,8 +128,8 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
       try {
         val linkIdParam = params.get("linkId")
         val mValueParam = params.get("mValue")
-        if (linkIdParam.isEmpty) halt(BadRequest("Missing linkId parameter"))
-        if (mValueParam.isEmpty) halt(BadRequest("Missing mValue parameter"))
+        if (linkIdParam.isEmpty) throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing linkId parameter")
+        if (mValueParam.isEmpty) throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Missing mValue parameter")
         else {
           val linkId = linkIdParam.get
           val mValue = mValueParam.get.toDouble
@@ -137,9 +137,9 @@ class LaneApi(val swagger: Swagger, val roadLinkService: RoadLinkService, val ro
         }
       }
       catch {
-        case _: NoSuchElementException => halt(BadRequest("No road link found on given linkID"))
-        case _: NumberFormatException => halt(BadRequest("Invalid mValue parameter"))
-        case _: Exception => halt(BadRequest("Something went wrong"))
+        case _: NoSuchElementException => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"No road link found on given linkID")
+        case _: NumberFormatException => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Invalid mValue parameter")
+        case _: Exception => throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Something went wrong")
       }
     }
   }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ServiceRoadAPI.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ServiceRoadAPI.scala
@@ -69,7 +69,7 @@ class ServiceRoadAPI(val maintenanceService: MaintenanceService, val roadLinkSer
   get("/huoltotiet", operation(getServiceRoadByBoundingBox)){
     contentType = formats("json")
     ApiUtils.avoidRestrictions(apiId, request, params) { params =>
-      val bbox = params.get("boundingBox").map(constructBoundingRectangle).getOrElse(halt(BadRequest("Bounding box was missing")))
+      val bbox = params.get("boundingBox").map(constructBoundingRectangle).getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Bounding box was missing"))
       validateBoundingBox(bbox)
       createGeoJson(maintenanceService.getAllByBoundingBox(bbox))
     }
@@ -176,7 +176,7 @@ class ServiceRoadAPI(val maintenanceService: MaintenanceService, val roadLinkSer
     val width = Math.abs(rightTop.x - leftBottom.x).toLong
     val height = Math.abs(rightTop.y - leftBottom.y).toLong
     if ((width * height) > MAX_BOUNDING_BOX) {
-      halt(BadRequest("Bounding box was too big: " + bbox))
+      throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"Bounding box was too big: " + bbox)
     }
   }
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ServiceRoadAPI.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/ServiceRoadAPI.scala
@@ -10,6 +10,7 @@ import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.{BadRequest, ScalatraServlet}
 import org.scalatra.json.JacksonJsonSupport
 import org.scalatra.swagger.{Swagger, SwaggerSupport}
+import scala.util.Try
 
 case class serviceRoadApiResponseOnGetExample(`type`: String, geometry: geometryFields, properties: propertiesFields)
 case class geometryFields(`type`: String, coordinates: Seq[Seq[(Double, Double, Double)]])
@@ -95,7 +96,8 @@ class ServiceRoadAPI(val maintenanceService: MaintenanceService, val roadLinkSer
     contentType = formats("json")
     ApiUtils.avoidRestrictions(apiId, request, params) { params =>
       val areaId = params("areaId")
-      val maintenanceAssets = maintenanceService.getActiveMaintenanceRoadByPolygon(areaId.toInt)
+      val maintenanceAssets = maintenanceService.getActiveMaintenanceRoadByPolygon(Try(areaId.toInt)
+        .getOrElse(throw DigiroadApiError(HttpStatusCodeError.BAD_REQUEST,"areaId parameter is not in number format")))
       val linkIdMap = maintenanceAssets.groupBy(_.linkId).mapValues(_.map(_.id))
       val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(linkIdMap.keySet)
 


### PR DESCRIPTION
Keskitetty virheiden käsittely. Luotu erillinen metodi virheen käsittelylle, jotta avoidRestrictions pysyisi siistinä.
avoidRestrictions käyttää samaa virheen käsittely systeemiä jos oli sitten AWS yhteys päällä tai ei.

Korjattu infinity loop kun törmätään virheeseen.

Pientä virheen käsittelyn parantelua.