### PR TITLE
DROTH-3884 don't filter by car roads only when recalculating bearing

### DIFF
--- a/UI/src/view/point_asset/trafficSignForm.js
+++ b/UI/src/view/point_asset/trafficSignForm.js
@@ -194,7 +194,7 @@
           validityDirectionButton.prop("disabled", false);
           bearingElement.prop("disabled", true);
           bearingElement.val(null);
-          var nearestLine = geometrycalculator.findNearestLine(me.roadCollection.getRoadsForPointAssets(), selectedAsset.get().lon, selectedAsset.get().lat);
+          var nearestLine = geometrycalculator.findNearestLine(me.roadCollection.getRoadsForCarPedestrianCycling(), selectedAsset.get().lon, selectedAsset.get().lat);
           selectedAsset.set({validityDirection: validitydirections.sameDirection, bearing: geometrycalculator.getLineDirectionDegAngle(nearestLine)});
         }
       });


### PR DESCRIPTION
Aiempi metodi hakee liikennemerkeille vain autotiet, jolloin suuntima lasketaan virheellisesti lähimmän autotien perusteella, vaikka linkki olisi kävelytiellä. Filtteröidään linkit niin, että kävelytiet tulee mukaan.