### PR TITLE
Droth 3937 work list for missing replacements

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_38__alter_road_link_replacement_table.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_38__alter_road_link_replacement_table.sql
@@ -1,0 +1,6 @@
+ALTER TABLE road_link_replacement_work_list
+ADD removed_geometry                   geometry,
+ADD    added_geometry                  geometry,
+ADD hausdorff_similarity_measure       NUMERIC(1000, 3),
+ADD area_similarity_measure            NUMERIC(1000, 3),
+ADD created_date                       timestamp

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkReplacementWorkListDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkReplacementWorkListDAO.scala
@@ -1,5 +1,6 @@
 package fi.liikennevirasto.digiroad2.dao
 
+import fi.liikennevirasto.digiroad2.GeometryUtils
 import fi.liikennevirasto.digiroad2.postgis.MassQuery
 import fi.liikennevirasto.digiroad2.util.MatchedRoadLinks
 import slick.driver.JdbcDriver.backend.Database.dynamicSession
@@ -27,14 +28,22 @@ class RoadLinkReplacementWorkListDAO {
     }
 
     val insertMatchedLinks =
-      s"""insert into road_link_replacement_work_list (id, removed_link_id, added_link_id) values ((?), (?), (?))""".stripMargin
+      s"""insert into road_link_replacement_work_list (id, removed_link_id, added_link_id, removed_geometry,
+         | added_geometry, hausdorff_similarity_measure, area_similarity_measure, created_date)
+         |  values ((?), (?), (?), ST_GeomFromText((?)), ST_GeomFromText((?)), (?), (?), current_timestamp)""".stripMargin
 
     MassQuery.executeBatch(insertMatchedLinks) { statement =>
       matchedRoadLinksWithIds.foreach { mlWithId =>
         val (matchedLinks, id) = mlWithId
+        val removedGeometryWKT = GeometryUtils.toWktLineString(matchedLinks.removedRoadLink.geometry).string
+        val addedGeometryWKT = GeometryUtils.toWktLineString(matchedLinks.addedRoadLink.geometry).string
         statement.setLong(1, id)
-        statement.setString(2, matchedLinks.removedLinkId)
-        statement.setString(3, matchedLinks.addedLinkId)
+        statement.setString(2, matchedLinks.removedRoadLink.linkId)
+        statement.setString(3, matchedLinks.addedRoadLink.linkId)
+        statement.setString(4, removedGeometryWKT)
+        statement.setString(5, addedGeometryWKT)
+        statement.setDouble(6, matchedLinks.hausdorffSimilarityMeasure)
+        statement.setDouble(7, matchedLinks.areaSimilarityMeasure)
         statement.addBatch()
       }
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RoadLinkReplacementFinder.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RoadLinkReplacementFinder.scala
@@ -15,7 +15,7 @@ object RoadLinkReplacementFinder {
 
   lazy val roadLinkChangeClient: RoadLinkChangeClient = new RoadLinkChangeClient
   lazy val roadLinkReplacementTypeId = 1
-  lazy val replacementSearchRadius: Double = 200.0 // Radius in meters for searching nearby links
+  lazy val replacementSearchRadius: Double = 10.0 // Radius in meters for searching nearby links
   lazy val hausdorffMeasureThreshold: Double = 0.6 // Threshold value for matching links by Hausdorff measure (0-1)
   lazy val areaMeasureBuffer: Double = 5 // Buffer size in meters for comparing geometries with area measure
   lazy val areaMeasureThreshold: Double = 0.6 // Threshold value for matching links by area measure (0-1)
@@ -72,9 +72,9 @@ object RoadLinkReplacementFinder {
     val matchedLinks = addedRoadLinks.zipWithIndex.flatMap(addedLinkAndIndex => {
       val (addedLink, index) = addedLinkAndIndex
       percentageProcessed = LogUtils.logArrayProgress(logger, "Find matches for added road links", addedRoadLinks.size, index, percentageProcessed)
-      val addedLinkCentroid = GeometryUtils.calculateCentroid(addedLink.geometry)
       val nearbyRemovedLinks = removedRoadLinks.filter(removedRoadLink => {
-        GeometryUtils.isAnyPointInsideRadius(addedLinkCentroid, replacementSearchRadius, removedRoadLink.geometry)
+        GeometryUtils.isAnyPointInsideRadius(addedLink.geometry.head, replacementSearchRadius, removedRoadLink.geometry) ||
+          GeometryUtils.isAnyPointInsideRadius(addedLink.geometry.last, replacementSearchRadius, removedRoadLink.geometry)
       })
       findMatchesWithSimilarity(addedLink, nearbyRemovedLinks)
     })

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RoadLinkReplacementFinder.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/RoadLinkReplacementFinder.scala
@@ -1,13 +1,14 @@
 package fi.liikennevirasto.digiroad2.util
 
-import fi.liikennevirasto.digiroad2.GeometryUtils
 import fi.liikennevirasto.digiroad2.client._
 import fi.liikennevirasto.digiroad2.dao.Queries
+import fi.liikennevirasto.digiroad2.linearasset.RoadLink
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import fi.liikennevirasto.digiroad2.service.RoadLinkReplacementWorkListService
+import fi.liikennevirasto.digiroad2.service.{RoadLinkReplacementWorkListService, RoadLinkService}
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, DummyEventBus, DummySerializer, GeometryUtils}
 import org.slf4j.{Logger, LoggerFactory}
 
-case class MatchedRoadLinks(removedLinkId: String, addedLinkId: String)
+case class MatchedRoadLinks(removedRoadLink: RoadLink, addedRoadLink: RoadLink, hausdorffSimilarityMeasure: Double, areaSimilarityMeasure: Double)
 
 object RoadLinkReplacementFinder {
   private val logger: Logger = LoggerFactory.getLogger(getClass)
@@ -16,23 +17,29 @@ object RoadLinkReplacementFinder {
   lazy val roadLinkReplacementTypeId = 1
   lazy val replacementSearchRadius: Double = 200.0 // Radius in meters for searching nearby links
   lazy val hausdorffMeasureThreshold: Double = 0.6 // Threshold value for matching links by Hausdorff measure (0-1)
+  lazy val areaMeasureBuffer: Double = 5 // Buffer size in meters for comparing geometries with area measure
   lazy val areaMeasureThreshold: Double = 0.6 // Threshold value for matching links by area measure (0-1)
   lazy val missingReplacementService: RoadLinkReplacementWorkListService = new RoadLinkReplacementWorkListService
+  lazy val eventBus: DigiroadEventBus = new DummyEventBus
+  lazy val roadLinkClient: RoadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
+  lazy val roadLinkService: RoadLinkService = new RoadLinkService(roadLinkClient, eventBus, new DummySerializer)
 
-  def findMatchesWithSimilarity(addedLink: ReplaceInfoWithGeometry, removedLinks: Seq[ReplaceInfoWithGeometry]): Seq[ReplaceInfoWithGeometry] = {
-    removedLinks.filter(removedLink => {
-      val addedLinkCentroid = GeometryUtils.calculateCentroid(addedLink.newGeometry)
-      val addedLinkCentered = GeometryUtils.centerGeometry(addedLink.newGeometry, addedLinkCentroid)
+  def findMatchesWithSimilarity(addedLink: RoadLink, removedLinks: Seq[RoadLink]): Seq[MatchedRoadLinks] = {
+    removedLinks.flatMap(removedLink => {
+      val addedLinkCentroid = GeometryUtils.calculateCentroid(addedLink.geometry)
+      val addedLinkCentered = GeometryUtils.centerGeometry(addedLink.geometry, addedLinkCentroid)
       val addedLineStringCentered = GeometryUtils.pointsToLineString(addedLinkCentered)
 
-      val removedLinkCentroid = GeometryUtils.calculateCentroid(removedLink.oldGeometry)
-      val removedLinkCentered = GeometryUtils.centerGeometry(removedLink.oldGeometry, removedLinkCentroid)
+      val removedLinkCentroid = GeometryUtils.calculateCentroid(removedLink.geometry)
+      val removedLinkCentered = GeometryUtils.centerGeometry(removedLink.geometry, removedLinkCentroid)
       val removedLineStringCentered = GeometryUtils.pointsToLineString(removedLinkCentered)
 
       val hausdorffSimilarityMeasure = GeometryUtils.getHausdorffSimilarityMeasure(addedLineStringCentered, removedLineStringCentered)
-      val areaSimilarityMeasure = GeometryUtils.getAreaSimilarityMeasure(addedLineStringCentered, removedLineStringCentered)
+      val areaSimilarityMeasure = GeometryUtils.getAreaSimilarityMeasure(addedLineStringCentered.buffer(areaMeasureBuffer), removedLineStringCentered.buffer(areaMeasureBuffer))
 
-      hausdorffSimilarityMeasure >= hausdorffMeasureThreshold || areaSimilarityMeasure >= areaMeasureThreshold
+      if(hausdorffSimilarityMeasure >= hausdorffMeasureThreshold || areaSimilarityMeasure >= areaMeasureThreshold) {
+        Some(MatchedRoadLinks(removedLink, addedLink, hausdorffSimilarityMeasure, areaSimilarityMeasure))
+      } else None
     })
   }
 
@@ -51,31 +58,28 @@ object RoadLinkReplacementFinder {
   }
 
   def findMissingReplacements(changes: Seq[RoadLinkChange]): Seq[MatchedRoadLinks] = {
-    val replaceInfos = changes.flatMap(_.replaceInfo)
-    val replaceInfosWithoutReplacement = replaceInfos.filter(ri => ri.newLinkId.isEmpty || ri.oldLinkId.isEmpty)
-    val replaceInfosWithGeometry = roadLinkChangeClient.withLinkGeometry(replaceInfosWithoutReplacement, changes)
-    val matchedLinks = matchRemovesAndAdds(replaceInfosWithGeometry)
+    val addedLinkIds = changes.filter(_.changeType == RoadLinkChangeType.Add).flatMap(change => change.newLinks.map(_.linkId))
+    val removedLinkIds = changes.filter(_.changeType == RoadLinkChangeType.Remove).flatMap(change => change.oldLink.map(_.linkId))
+    val addedRoadLinks = roadLinkService.getRoadLinksByLinkIds(addedLinkIds.toSet)
+    val removedRoadLinks = roadLinkService.getExistingAndExpiredRoadLinksByLinkIds(removedLinkIds.toSet)
+    val matchedLinks = matchRemovesAndAdds(addedRoadLinks, removedRoadLinks)
     matchedLinks
   }
 
-  def matchRemovesAndAdds(replaceInfosWithGeometry: Seq[ReplaceInfoWithGeometry]): Seq[MatchedRoadLinks] = {
-    val (removed, added) = replaceInfosWithGeometry.partition(_.newLinkId.isEmpty)
+  def matchRemovesAndAdds(addedRoadLinks: Seq[RoadLink], removedRoadLinks: Seq[RoadLink]): Seq[MatchedRoadLinks] = {
 
     var percentageProcessed = 0
-    val matchedLinks = added.zipWithIndex.map(addedLinkAndIndex => {
+    val matchedLinks = addedRoadLinks.zipWithIndex.flatMap(addedLinkAndIndex => {
       val (addedLink, index) = addedLinkAndIndex
-      percentageProcessed = LogUtils.logArrayProgress(logger, "Find matches for added road links", added.size, index, percentageProcessed)
-      val addedLinkCentroid = GeometryUtils.calculateCentroid(addedLink.newGeometry)
-      val nearbyRemovedLinks = removed.filter(removedRoadLink => {
-        GeometryUtils.isAnyPointInsideRadius(addedLinkCentroid, replacementSearchRadius, removedRoadLink.oldGeometry)
+      percentageProcessed = LogUtils.logArrayProgress(logger, "Find matches for added road links", addedRoadLinks.size, index, percentageProcessed)
+      val addedLinkCentroid = GeometryUtils.calculateCentroid(addedLink.geometry)
+      val nearbyRemovedLinks = removedRoadLinks.filter(removedRoadLink => {
+        GeometryUtils.isAnyPointInsideRadius(addedLinkCentroid, replacementSearchRadius, removedRoadLink.geometry)
       })
-      (findMatchesWithSimilarity(addedLink, nearbyRemovedLinks), addedLink)
+      findMatchesWithSimilarity(addedLink, nearbyRemovedLinks)
     })
 
-    matchedLinks.flatMap(removedLinksMatchedWithAdded => {
-      val (removed, added) = removedLinksMatchedWithAdded
-      removed.map(removedLink => MatchedRoadLinks(removedLink.oldLinkId.get, added.newLinkId.get))
-    })
+    matchedLinks
   }
 
 

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RoadLinkReplacementFinderSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/RoadLinkReplacementFinderSpec.scala
@@ -1,22 +1,31 @@
 package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.client.{RoadLinkChange, RoadLinkChangeClient}
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+import fi.liikennevirasto.digiroad2.service.RoadLinkReplacementWorkListService
 import org.scalatest.{FunSuite, Matchers}
 
 import scala.io.Source
 
 class RoadLinkReplacementFinderSpec extends FunSuite with Matchers {
   val roadLinkChangeClient = new RoadLinkChangeClient
+  val missingReplacementService: RoadLinkReplacementWorkListService = new RoadLinkReplacementWorkListService
   val filePath: String = getClass.getClassLoader.getResource("smallChangeSet.json").getPath
   val jsonFile: String = Source.fromFile(filePath).mkString
   val testChanges: Seq[RoadLinkChange] = roadLinkChangeClient.convertToRoadLinkChange(jsonFile)
+  def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback(PostGISDatabase.ds)(test)
 
 
   test("Link is removed, other replacing link is added as new. Find match") {
-    val matchedRoadLinks = RoadLinkReplacementFinder.findMissingReplacements(testChanges)
-    matchedRoadLinks.size should equal(1)
-    matchedRoadLinks.head.addedLinkId should equal ("2b99971a-b8c8-42ad-bbb4-b3985e2c312b:1")
-    matchedRoadLinks.head.removedLinkId should equal ("91ac78c9-7a6d-44b3-aefe-7f76cc345f5d:1")
+    runWithRollback {
+      val matchedRoadLinks = RoadLinkReplacementFinder.findMissingReplacements(testChanges)
+      matchedRoadLinks.size should equal(1)
+      matchedRoadLinks.head.addedRoadLink.linkId should equal ("2b99971a-b8c8-42ad-bbb4-b3985e2c312b:1")
+      matchedRoadLinks.head.removedRoadLink.linkId should equal ("91ac78c9-7a6d-44b3-aefe-7f76cc345f5d:1")
+      missingReplacementService.insertMatchedLinksToWorkList(matchedRoadLinks, false)
+      val items = missingReplacementService.getMatchedLinksWorkList(false)
+      items.size should equal(1)
+    }
   }
 
 }


### PR DESCRIPTION
- Käytetään lisättyjä / poistettuja linkkejä käsittelyssä replaceInfon sijaan
- lisätty kenttiä tauluun
- Muutettu viereisten linkkien etsintä käyttämään lisätyn linkin alku- ja loppu pisteitä geometrisen painopisteen sijaan
