### PR TITLE
Droth 3976 traffic sign samuutus report saving failed

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
@@ -402,7 +402,9 @@ object ChangeReporter {
     val untilDate = changesProcessedUntil.toString("YYYY-MM-dd")
     val withGeometry = if (hasGeometry) "_withGeometry" else ""
     val path = s"$date/${assetName}_${untilDate}_${contentRowCount}content_rows$withGeometry.csv"
+    logger.info(s"Saving ${assetName}-report to S3")
     s3Service.saveFileToS3(s3Bucket, path, body, "csv")
+    logger.info(s"${assetName}-report saved successfully")
   }
 
   // Used for testing CSV report. Saves file locally to directory 'samuutus-reports-local-test' created in project root directory


### PR DESCRIPTION
Muutettu samuutusraporttien tallennusta niin, että yli 100MB raportit tallennetaan hyödyntäen S3MultipartUploadia. 

Rinnakkainen tallennus tehdään 100MB chunkeissa asynkroonisesti. Testattu lokaalisti 1GB:n bodyilla, joiden tallennus vei alusta loppuun keskimäärin 15-20 sekunttia.

ChangeReporter tarkistaa bodyn koon ennen tallennuskutsua selvittääkseen parhaan tallennustavan.

Tallennuksen testaukseen käytetty bucket: https://s3.console.aws.amazon.com/s3/buckets/droth-3976-multipart-upload-test-bucket?region=eu-west-1&bucketType=general&tab=objects
Bucket poistetaan pull requestin mergeämisen jälkeen.