### PR TITLE
 DROTH-3976 Moved saveMultipart decision from ChangeReporter to AwsService

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/ChangeReporter.scala
@@ -158,8 +158,6 @@ object ChangeReporter {
   implicit lazy val serializationFormats: Formats = DefaultFormats
   def directLink: String = Digiroad2Properties.feedbackAssetsEndPoint
   val localReportDirectoryName = "samuutus-reports-local-test"
-  val SINGLE_UPLOAD_MAX_SIZE = 100 * 1024 * 1024 // files greater than 100MB should be uploaded using MultipartUpload
-
 
 
   private def getCSVRowForRoadLinkPropertyChanges(linkId: String, changeType: Int, changes: Seq[ReportedChange]) = {
@@ -397,16 +395,6 @@ object ChangeReporter {
     (stringWriter.toString, contentRows)
   }
 
-  def requiresMultipartUpload(body: String): Boolean = {
-    if (body.length > SINGLE_UPLOAD_MAX_SIZE) {
-      true
-    } else {
-      // double check, as body size might still exceed the limit due to multi-byte characters
-      val sizeInBytes = body.getBytes("UTF-8").length
-      sizeInBytes > SINGLE_UPLOAD_MAX_SIZE
-    }
-  }
-
   def saveReportToS3(assetName: String, changesProcessedUntil: DateTime, body: String, contentRowCount: Int,
                      hasGeometry: Boolean = false): Unit = {
     val date = DateTime.now().toString("YYYY-MM-dd")
@@ -414,10 +402,7 @@ object ChangeReporter {
     val withGeometry = if (hasGeometry) "_withGeometry" else ""
     val path = s"$date/${assetName}_${untilDate}_${contentRowCount}content_rows$withGeometry.csv"
     logger.info(s"Saving ${path} to S3")
-    requiresMultipartUpload(body) match {
-      case true => s3Service.saveFileToS3Multipart(s3Bucket, path, body, "csv")
-      case false => s3Service.saveFileToS3(s3Bucket, path, body, "csv")
-    }
+    s3Service.saveFileToS3(s3Bucket, path, body, "csv")
   }
 
   // Used for testing CSV report. Saves file locally to directory 'samuutus-reports-local-test' created in project root directory


### PR DESCRIPTION
Siirretty päätös multipartin käytöstä ChangeReporterilta AwsServicelle. 

AwsServiceen määritellyn CHUNK_SIZEn koko tällä hetkellä sama kuin SINGLE_UPLOAD_MAX_SIZE, mutta kokoja voidaan arvioida uudestaan mikäli käyttötapauksissa ilmenee tarvetta.