### PR TITLE
Droth 3977 optimize linear asset samuutus

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/DynamicLinearAssetDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/DynamicLinearAssetDao.scala
@@ -2,7 +2,6 @@ package fi.liikennevirasto.digiroad2.dao
 
 import java.nio.charset.StandardCharsets
 import java.util.Base64
-
 import fi.liikennevirasto.digiroad2.asset.PropertyTypes._
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.dao.Queries._
@@ -16,6 +15,7 @@ import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.asset.DateParser.DatePropertyFormat
+import fi.liikennevirasto.digiroad2.util.LogUtils
 
 
 case class DynamicAssetRow(id: Long, linkId: String, sideCode: Int, value: DynamicPropertyRow,
@@ -27,11 +27,12 @@ class DynamicLinearAssetDao {
   val logger: Logger = LoggerFactory.getLogger(getClass)
 
   def fetchDynamicLinearAssetsByLinkIds(assetTypeId: Int, linkIds: Seq[String], includeExpired: Boolean = false, includeFloating: Boolean = false): Seq[PersistedLinearAsset] = {
-    val filterFloating = if (includeFloating) "" else " and a.floating = '0'"
-    val filterExpired = if (includeExpired) "" else " and (a.valid_to > current_timestamp or a.valid_to is null)"
-    val filter = filterFloating + filterExpired
-    val assets = MassQuery.withStringIds(linkIds.toSet) { idTableName =>
-      sql"""
+    LogUtils.time(logger, s"Fetch dynamic linear assets on ${linkIds.size} links, assetType: $assetTypeId") {
+      val filterFloating = if (includeFloating) "" else " and a.floating = '0'"
+      val filterExpired = if (includeExpired) "" else " and (a.valid_to > current_timestamp or a.valid_to is null)"
+      val filter = filterFloating + filterExpired
+      val assets = MassQuery.withStringIds(linkIds.toSet) { idTableName =>
+        sql"""
         select a.id, pos.link_id, pos.side_code, pos.start_measure, pos.end_measure, p.public_id, p.property_type, p.required,
          case
                when tp.value_fi is not null then tp.value_fi
@@ -56,15 +57,16 @@ class DynamicLinearAssetDao {
           left join enumerated_value e on mc.enumerated_value_id = e.id or s.enumerated_value_id = e.id
           where a.asset_type_id = $assetTypeId
           #$filter""".as[DynamicAssetRow](getDynamicAssetRow).list
-    }
-    assets.groupBy(_.id).map { case (id, assetRows) =>
-      val row = assetRows.head
-      val value: DynamicAssetValue = DynamicAssetValue(assetRowToProperty(assetRows))
+      }
+      assets.groupBy(_.id).map { case (id, assetRows) =>
+        val row = assetRows.head
+        val value: DynamicAssetValue = DynamicAssetValue(assetRowToProperty(assetRows))
 
-      id -> PersistedLinearAsset(id = row.id, linkId = row.linkId, sideCode = row.sideCode, value = Some(DynamicValue(value)), startMeasure = row.startMeasure, endMeasure = row.endMeasure, createdBy = row.createdBy,
-        createdDateTime = row.createdDate, modifiedBy = row.modifiedBy, modifiedDateTime = row.modifiedDate, expired = row.expired, typeId = row.typeId,  timeStamp = row.timeStamp,
-        geomModifiedDate = row.geomModifiedDate, linkSource = LinkGeomSource.apply(row.linkSource), verifiedBy = row.verifiedBy, verifiedDate = row.verifiedDate, informationSource = row.informationSource.map(info => InformationSource.apply(info)))
-    }.values.toSeq
+        id -> PersistedLinearAsset(id = row.id, linkId = row.linkId, sideCode = row.sideCode, value = Some(DynamicValue(value)), startMeasure = row.startMeasure, endMeasure = row.endMeasure, createdBy = row.createdBy,
+          createdDateTime = row.createdDate, modifiedBy = row.modifiedBy, modifiedDateTime = row.modifiedDate, expired = row.expired, typeId = row.typeId, timeStamp = row.timeStamp,
+          geomModifiedDate = row.geomModifiedDate, linkSource = LinkGeomSource.apply(row.linkSource), verifiedBy = row.verifiedBy, verifiedDate = row.verifiedDate, informationSource = row.informationSource.map(info => InformationSource.apply(info)))
+      }.values.toSeq
+    }
   }
 
   def fetchDynamicLinearAssetsByIds(ids: Set[Long]): Seq[PersistedLinearAsset] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -458,7 +458,7 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   def filterChanges(typeId: Int, changes: Seq[RoadLinkChange]): Seq[RoadLinkChange] = {
     val newLinkIds = changes.flatMap(_.newLinks.map(_.linkId))
     val linkIdsWithExistingAsset = service.fetchExistingAssetsByLinksIdsString(typeId, newLinkIds.toSet, Set(), newTransaction = false).map(_.linkId)
-    if (linkIdsWithExistingAsset.nonEmpty) logger.info(s"found already created assets on new links ${linkIdsWithExistingAsset}")
+    if (linkIdsWithExistingAsset.nonEmpty) logger.info(s"found already created assets on new links ${linkIdsWithExistingAsset.mkString(",")}")
     changes.filterNot(c => c.changeType == Add && linkIdsWithExistingAsset.contains(c.newLinks.head.linkId))
   }
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -576,10 +576,13 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
 
       val initStep = OperationStep(Seq(), Some(changeSet))
       new Parallel().operation(changesGrouped, level) { tasks =>
-        tasks.flatMap { changes =>
-          changes.map(change => {
-            goThroughChanges(assetsGroup, assetsAll, onlyNeededNewRoadLinks, changeSet, initStep, change, OperationStepSplit(Seq(), Some(changeSet)))
-          })
+        tasks.flatMap {
+          changesPerThread =>
+            LogUtils.time(logger, s"Processing ${changesPerThread.size} changes in a single thread") {
+              changesPerThread.map(change => {
+                goThroughChanges(assetsGroup, assetsAll, onlyNeededNewRoadLinks, changeSet, initStep, change, OperationStepSplit(Seq(), Some(changeSet)))
+              })
+            }
         }
       }.seq.toSeq
     }


### PR DESCRIPTION
- Poistettu viallinen parallel progress lokitus
- Palautettu vanha mergerOperations, uusi toteutus aiheutti hitautta lokien perusteella