### PR TITLE
DROTH-3668 Fix nested transaction, use different method to get road l…

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DamagedByThawService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DamagedByThawService.scala
@@ -3,7 +3,6 @@ package fi.liikennevirasto.digiroad2.service.linearasset
 import fi.liikennevirasto.digiroad2.DigiroadEventBus
 import fi.liikennevirasto.digiroad2.linearasset._
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
-import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
 
 class DamagedByThawService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends DynamicLinearAssetService(roadLinkServiceImpl, eventBusImpl) {
 
@@ -18,13 +17,15 @@ class DamagedByThawService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: D
   }
 
   override def getAssetsByMunicipality(typeId: Int, municipality: Int, newTransaction: Boolean = true): Seq[PersistedLinearAsset] = {
-    val (roadLinks, changes) = roadLinkService.getRoadLinksWithComplementaryAndChanges(municipality)
-    val linkIds = roadLinks.map(_.linkId)
-    val mappedChanges = LinearAssetUtils.getMappedChanges(changes)
-    val removedLinkIds = LinearAssetUtils.deletedRoadLinkIds(mappedChanges, roadLinks.map(_.linkId).toSet)
     if(newTransaction) withDynTransaction {
-      dynamicLinearAssetDao.fetchDynamicLinearAssetsByLinkIds(typeId, linkIds ++ removedLinkIds)
-    } else dynamicLinearAssetDao.fetchDynamicLinearAssetsByLinkIds(typeId, linkIds ++ removedLinkIds)
+      val roadLinks= roadLinkService.getRoadLinksByMunicipality(municipality, newTransaction = false)
+      val linkIds = roadLinks.map(_.linkId)
+      dynamicLinearAssetDao.fetchDynamicLinearAssetsByLinkIds(typeId, linkIds)
+    } else {
+      val roadLinks= roadLinkService.getRoadLinksByMunicipality(municipality, newTransaction = false)
+      val linkIds = roadLinks.map(_.linkId)
+      dynamicLinearAssetDao.fetchDynamicLinearAssetsByLinkIds(typeId, linkIds)
+    }
   }
 
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/DamagedByThawRepeaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/DamagedByThawRepeaterSpec.scala
@@ -69,8 +69,8 @@ class DamagedByThawRepeaterSpec extends FunSuite with Matchers {
     )
   val topology = Seq(RoadLink(linkId, Seq(Point(0.0, 0.0), Point(10.0, 0.0)), 10.0, Municipality, 1, TrafficDirection.TowardsDigitizing, Motorway, None, None))
 
-  when(damagedByThawRepeaterMockServices.damagedByThawService.roadLinkService.getRoadLinksWithComplementaryAndChanges(testMunicipalityCode))
-    .thenReturn((Seq(testRoadLink), Seq()))
+  when(damagedByThawRepeaterMockServices.damagedByThawService.roadLinkService.getRoadLinksByMunicipality(testMunicipalityCode, newTransaction = false))
+    .thenReturn(Seq(testRoadLink))
 
   test("ongoing period is not updated") {
     runWithRollback {


### PR DESCRIPTION
Oli jäänyt nested transaction, vaihdettu käyttämään simppelimpää metodia tielinkkien hakuun overridetyssä getAssetsByMunicipality metodissa.