### PR TITLE
DROTH-3994 fix lambda to combine replace infos with digitization change

### DIFF
--- a/lambda/road-link-change-handler/src/service/change-set.ts
+++ b/lambda/road-link-change-handler/src/service/change-set.ts
@@ -97,10 +97,10 @@ export class ChangeSet {
     private combineReplaceInfo(continuousParts: ReplaceInfo[], fromPartialAdd: boolean = false) {
         const oldId = continuousParts.map(p => p.oldLinkId).find(id => id != null) || undefined
         const newId = continuousParts.map(p => p.newLinkId).find(id => id != null) || undefined
-        const newFromM = _.min(continuousParts.map(p => p.newFromMValue))
-        const newToM = _.max(continuousParts.map(p => p.newToMValue))
-        const oldFromM = fromPartialAdd ? newFromM : _.min(continuousParts.map(p => p.oldFromMValue))
-        const oldToM = fromPartialAdd ? newToM : _.max(continuousParts.map(p => p.oldToMValue))
+        const newFromM = _.head(continuousParts)?.newFromMValue
+        const newToM = _.last(continuousParts)?.newToMValue
+        const oldFromM = fromPartialAdd ? newFromM : _.head(continuousParts)?.oldFromMValue
+        const oldToM = fromPartialAdd ? newToM : _.last(continuousParts)?.oldToMValue
         return new ReplaceInfo(
             oldId,
             newId,

--- a/lambda/road-link-change-handler/test/service/change-set_test.js
+++ b/lambda/road-link-change-handler/test/service/change-set_test.js
@@ -1017,4 +1017,56 @@ describe('Change Set', function () {
 
         assert.equal(changeSet.toJson(), "[]");
     })
+
+    it("Combine replace info with digitization change", () => {
+        const oldLinkId = "old:1";
+        const newLinkId = "new:1";
+        const oldLink = new KgvLink(oldLinkId, testLinkGeom1, 123, 3, 149, 36.877, 0, 12141);
+        const newLink = new KgvLink(newLinkId, testLinkGeom1, 123, 3, 149, 260.352, 0, 12141);
+        const change = new ReplaceInfo(oldLinkId, newLinkId, 0.0, 18.439, 260.352, 241.913);
+        const change2 = new ReplaceInfo(oldLinkId, newLinkId, 18.439, 36.877, 241.913, 223.475);
+        const changeSet = new ChangeSet([oldLink, newLink], [change, change2]);
+
+        const expected = [
+            {
+                "changeType": "replace",
+                "old": {
+                    "linkId": oldLinkId,
+                    "linkLength": 36.877,
+                    "geometry": testLinkGeom1,
+                    "roadClass": 12141,
+                    "adminClass": 3,
+                    "municipality": 149,
+                    "surfaceType": null,
+                    "trafficDirection": 0,
+                    "lifeCycleStatus": null
+                },
+                "new": [
+                    {
+                        "linkId": newLinkId,
+                        "linkLength": 260.352,
+                        "geometry": testLinkGeom1,
+                        "roadClass": 12141,
+                        "adminClass": 3,
+                        "municipality": 149,
+                        "surfaceType": null,
+                        "trafficDirection": 0,
+                        "lifeCycleStatus": null
+                    }
+                ],
+                "replaceInfo": [
+                    {
+                        "oldLinkId": oldLinkId,
+                        "newLinkId": newLinkId,
+                        "oldFromMValue": 0,
+                        "oldToMValue": 36.877,
+                        "newFromMValue": 260.352,
+                        "newToMValue": 223.475,
+                        "digitizationChange": true
+                    }
+                ]
+            }]
+        assert.equal(changeSet.changeEntries[0].changeType, "replace");
+        assert.equal(changeSet.toJson(), JSON.stringify(expected));
+    })
 });


### PR DESCRIPTION
Replace-infojen yhdistelyssä ollut min ja max ei sopinut tilanteeseen, jossa digitointisuunta kääntyy. Korvattu head ja last -arvoilla, koska yhdistelyssä käsitellään järjestettyä listaa. Testattu ongelmia aiheuttanut case.