### PR TITLE
 DROTH-3977 try to improve memory used

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -689,7 +689,8 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   private def adjustAndAdditionalOperations(typeId: Int, onlyNeededNewRoadLinks: Seq[RoadLink],
                                             assets: OperationStep, changes: Seq[RoadLinkChange]): OperationStep = {
     val adjusted = adjustAssets(typeId, onlyNeededNewRoadLinks, assets)
-    val additionalSteps = additionalOperations(adjusted, changes)
+    // TODO additionalOperations need logic to just return changes assets which will be inserted into OperationStep
+    val additionalSteps = additionalOperations(adjusted, changes) 
     if (additionalSteps.isDefined) additionalSteps.get else adjusted
   }
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdater.scala
@@ -689,7 +689,8 @@ class LinearAssetUpdater(service: LinearAssetOperations) {
   private def adjustAndAdditionalOperations(typeId: Int, onlyNeededNewRoadLinks: Seq[RoadLink],
                                             assets: OperationStep, changes: Seq[RoadLinkChange]): OperationStep = {
     val adjusted = adjustAssets(typeId, onlyNeededNewRoadLinks, assets)
-    // TODO additionalOperations need logic to just return changes assets which will be inserted into OperationStep
+    // TODO additionalOperations need logic to just return changes assets which will be inserted into OperationStep or return OperationStep,
+   // If no additionalLogis return inputed OperationStep otherwise update OperationStep and return it.
     val additionalSteps = additionalOperations(adjusted, changes) 
     if (additionalSteps.isDefined) additionalSteps.get else adjusted
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/PavedRoadUpdater.scala
@@ -16,7 +16,7 @@ import org.joda.time.DateTime
 class PavedRoadUpdater(service: PavedRoadService) extends DynamicLinearAssetUpdater(service) {
 
   override def assetFiller: AssetFiller = PavedRoadFiller
-  override def operationForNewLink(change: RoadLinkChange, assetsAll: Seq[PersistedLinearAsset], onlyNeededNewRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
+  override def operationForNewLink(change: RoadLinkChange, onlyNeededNewRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
     val newLinkInfo = change.newLinks.head
     val roadLinkFound = onlyNeededNewRoadLinks.exists(_.linkId == newLinkInfo.linkId)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadWidthUpdater.scala
@@ -13,7 +13,7 @@ sealed case class RoadWidthMap(linkId: String, adminClass: AdministrativeClass, 
 
 class RoadWidthUpdater(service: RoadWidthService) extends DynamicLinearAssetUpdater(service) {
   
-  override def operationForNewLink(change: RoadLinkChange, assetsAll: Seq[PersistedLinearAsset], onlyNeededNewRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
+  override def operationForNewLink(change: RoadLinkChange, onlyNeededNewRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
     val newLinkInfo = change.newLinks.head
     val roadWidth = MTKClassWidth(newLinkInfo.roadClass)
     val roadLink = onlyNeededNewRoadLinks.find(_.linkId == newLinkInfo.linkId)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/SpeedLimitUpdater.scala
@@ -15,7 +15,7 @@ class SpeedLimitUpdater(service: SpeedLimitService) extends DynamicLinearAssetUp
 
   override def assetFiller: AssetFiller = SpeedLimitFiller
   
-  override def operationForNewLink(change: RoadLinkChange, assetsAll: Seq[PersistedLinearAsset], onlyNeededNewRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
+  override def operationForNewLink(change: RoadLinkChange, onlyNeededNewRoadLinks: Seq[RoadLink], changeSets: ChangeSet): Option[OperationStep] = {
     val newLinkInfo = change.newLinks.head
     val filteredLinks = onlyNeededNewRoadLinks.filterNot(link => Seq(HardShoulder, CycleOrPedestrianPath, TractorRoad).contains(link.linkType))
     val roadLinkFound = filteredLinks.exists(_.linkId == newLinkInfo.linkId)


### PR DESCRIPTION
Yritetään pitää muistissa vain kaksi listaa, yksi after ja yksi before.

Max listojen määrä on 3. Joko assets after tai before on kaksi kertaa hetkellisesti.

Sen sijaan että kanniskellaan assetAll ja assetsGroupBy listaa välitetään vain assetsGroupBy.
Yhdistämisessä assetsBefore saa arvon assetsGroupBy muuttujasta.
AssetAll listasta välitetään  vain listan koko tieto. 

Siirretty poisuneiden assets reporting osaksi muuta reporting ja se hyödyntää operationSteps assetsBefore listaa.

Perustuu ajatukseen pitää jokainen konteksi mahdollisimman pienenä. Ei pidetä kiinni muuttujista jo sama tieto saadaan toisesta muuttujasta. Jos tarvitaan jokin tieto listasta, haetaan se mahdollisimman ylhäällä ja välitetään vastaus vain.

Mustin hallinnan kannalta additionalOperations ei pitäisi palauttaa Operation Steps uuteen muuttujaan. Ketju tyylisestti vastaus pitää välitää heti eteenpäin.
