### PR TITLE
 DROTH-3997 added sorting

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
@@ -128,7 +128,7 @@ class AwsService {
     private def completeMultipartUpload(s3Bucket: String, id: String, uploadId: String, uploadedETags: Map[Int, String]): Unit = {
       val completedParts = uploadedETags.map {
         case (partNumber, eTag) => CompletedPart.builder().partNumber(partNumber).eTag(eTag).build()
-      }.toList.asJava
+      }.toList.sortBy(_.partNumber).asJava
 
       val completeRequest = CompleteMultipartUploadRequest.builder()
         .bucket(s3Bucket)


### PR DESCRIPTION
Lisätty järjestäminen partNumberin perusteella ennen uploadin päätöstä.

Testattu järjestämällä tarkoituksella väärin eTagin perusteella, mikä aiheutti alkuperäisen virheen mukaisen virheilmoituksen "The list of parts was not in ascending order. Parts must be ordered by part number".

partNumberilla järjestäminen tuotti onnistuneen uploadin.