### PR TITLE
Droth 3563 cicd to use secrets manager

### DIFF
--- a/aws/cloud-formation/cicd/dev/DEV-cicd-parameter.json
+++ b/aws/cloud-formation/cicd/dev/DEV-cicd-parameter.json
@@ -41,7 +41,7 @@
   },
   {
     "ParameterKey": "GitHubWebhookSecret",
-    "UsePreviousValue": true
+    "ParameterValue": "arn:aws:secretsmanager:eu-west-1:475079312496:secret:GITHUB_PAT-CqR1N2"
   },
   {
     "ParameterKey": "VpcIDOfSystem",

--- a/aws/cloud-formation/cicd/dev/cicd-github.yaml
+++ b/aws/cloud-formation/cicd/dev/cicd-github.yaml
@@ -81,7 +81,8 @@ Resources:
     Properties:
       Authentication: GITHUB_HMAC
       AuthenticationConfiguration:
-        SecretToken: !Ref GitHubWebhookSecret
+        SecretToken:
+          Fn::Sub: "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
       Filters:
         - JsonPath: $.ref
           MatchEquals: 'refs/heads/{Branch}'
@@ -114,7 +115,8 @@ Resources:
                 Owner: !Ref GitHubOwner
                 Repo: !Ref GitRepositoryName
                 Branch: !Ref GitBranchName
-                OAuthToken: !Ref GitHubWebhookSecret
+                OAuthToken:
+                  Fn::Sub: "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
                 PollForSourceChanges: false
               RunOrder: 1
         - Name: Build
@@ -187,6 +189,11 @@ Resources:
                   - 'cloudformation:*'
                   - 'ecs:*'
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'secretsmanager:DescribeSecret'
+                  - 'secretsmanager:GetSecretValue'
+                Resource: !Ref GitHubWebhookSecret
   CodeBuildSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:

--- a/aws/cloud-formation/cicd/dev/cicd-github.yaml
+++ b/aws/cloud-formation/cicd/dev/cicd-github.yaml
@@ -81,8 +81,7 @@ Resources:
     Properties:
       Authentication: GITHUB_HMAC
       AuthenticationConfiguration:
-        SecretToken:
-          Fn::Sub: "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
+        SecretToken: !Sub "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
       Filters:
         - JsonPath: $.ref
           MatchEquals: 'refs/heads/{Branch}'
@@ -115,8 +114,7 @@ Resources:
                 Owner: !Ref GitHubOwner
                 Repo: !Ref GitRepositoryName
                 Branch: !Ref GitBranchName
-                OAuthToken:
-                  Fn::Sub: "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
+                OAuthToken: !Sub "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
                 PollForSourceChanges: false
               RunOrder: 1
         - Name: Build

--- a/aws/cloud-formation/cicd/qa/QA-cicd-parameter.json
+++ b/aws/cloud-formation/cicd/qa/QA-cicd-parameter.json
@@ -29,7 +29,7 @@
   },
   {
     "ParameterKey": "GitHubWebhookSecret",
-    "UsePreviousValue": true
+    "ParameterValue": "arn:aws:secretsmanager:eu-west-1:475079312496:secret:GITHUB_PAT-CqR1N2"
   },
   {
     "ParameterKey": "GitRepositoryName",

--- a/aws/cloud-formation/cicd/qa/cicd-qa.yaml
+++ b/aws/cloud-formation/cicd/qa/cicd-qa.yaml
@@ -74,7 +74,7 @@ Resources:
     Properties:
       Authentication: GITHUB_HMAC
       AuthenticationConfiguration:
-        SecretToken: !Ref GitHubWebhookSecret
+        SecretToken: !Sub "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
       Filters:
         - JsonPath: $.ref
           MatchEquals: 'refs/heads/{Branch}'
@@ -107,7 +107,7 @@ Resources:
               Owner: !Ref GitHubOwner
               Repo: !Ref GitRepositoryName
               Branch: !Ref GitBranchName
-              OAuthToken: !Ref GitHubWebhookSecret
+              OAuthToken: !Sub "{{resolve:secretsmanager:${GitHubWebhookSecret}:SecretString:::}}"
               PollForSourceChanges: false
             RunOrder: 1
         - Name: Build
@@ -189,7 +189,11 @@ Resources:
                   - "ecr:BatchGetImage"
                   - "ecr:ListTagsForResource"
                   - "ecr:DescribeImageScanFindings"
-      
+              - Effect: Allow
+                Action:
+                  - 'secretsmanager:DescribeSecret'
+                  - 'secretsmanager:GetSecretValue'
+                Resource: !Ref GitHubWebhookSecret
   
   CodeBuildSecurityGroup:
     Type: AWS::EC2::SecurityGroup


### PR DESCRIPTION
Token secretsmanagerin kautta dev- ja qa-pipelineen. Muut pipelinet taitaa olla omissa brancheissaan vielä.