### PR TITLE
Droth 4016 remove xz and openssl

### DIFF
--- a/aws/fargate/Dockerfile
+++ b/aws/fargate/Dockerfile
@@ -7,6 +7,8 @@ ENV otherParameter="-Djava.security.egd=file:/dev/./urandom -Duser.timezone=Euro
 ENV containerCPU=""
 ENV javaParameter="${initialRam} ${maxRamPercentage} ${containerCPU} ${otherParameter}"
 ENV batchMode="false"
+RUN apk update && \
+    apk del xz openssl
 RUN apk --no-cache add curl
 RUN mkdir /src
 RUN mkdir /src/main


### PR DESCRIPTION
Poistetaan xz ja openssl, jotka tulee base imagen mukana. Testataan eka devillä, että ei aiheuta ongelmia.