### PR TITLE
DROTH-4010 fix pedestrian crossings mixing with traffic signs

### DIFF
--- a/UI/src/controller/trafficSignsCollection.js
+++ b/UI/src/controller/trafficSignsCollection.js
@@ -116,7 +116,7 @@
     };
 
     this.fetch = function(boundingBox, center) {
-      return backend.getPointAssetsWithComplementary(boundingBox, specs.layerName)
+      return backend.getTrafficSignsWithComplementary(boundingBox)
         .then(function(assets) {
           eventbus.trigger('pointAssets:fetched');
           me.allowComplementaryIsActive(specs.allowComplementaryLinks);

--- a/UI/src/controller/trafficSignsReadOnlyCollection.js
+++ b/UI/src/controller/trafficSignsReadOnlyCollection.js
@@ -83,7 +83,7 @@
     };
 
     this.fetch = function(boundingBox) {
-      return backend.getPointAssetsWithComplementary(boundingBox, layerName)
+      return backend.getTrafficSignsWithComplementary(boundingBox)
         .then(function(assets) {
           eventbus.trigger('pointAssets:fetched');
           me.allowComplementaryIsActive(allowComplementary);

--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -237,6 +237,12 @@
       });
     });
 
+    this.getTrafficSignsWithComplementary = latestResponseRequestor(function(boundingBox) {
+      return validateBoundingBox(boundingBox,{
+        url: 'api/trafficSigns?bbox=' + boundingBox
+      });
+    });
+
     this.getPointAssetById = latestResponseRequestor(function(id, endPointName) {
       return {
         url: 'api/'+ endPointName + '/' + id


### PR DESCRIPTION
Suojatie-tietolajin kanssa on mahdollisuus näyttää liikennemerkit. Kun näitä haetaan samanaikaisesti, dynaamisesti muodostettu endpoint saattaa vaihtua liikennemerkkeihin ennen kuin suojatiet on haettu backendiltä. Tällöin haetaan suojateiden sijasta liikennemerkit, jotka piirretään suojateinä.

Siirsin liikennemerkkien haun omaan backend funktioon, jotta nämä eivät mene sekaisin. Testasin loggaamalla suojatiehaun endpointin, eikä tämän jälkeen tullut enää liikennemerkkien endpointia suojatiehaussa. Muutenkin tuntui toimivan.