### PR TITLE
Droth 3774 allow railway crossings to new types

### DIFF
--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -1193,7 +1193,7 @@
         form: ObstacleForm,
         saveCondition: saveConditionWithSuggested,
         hasMunicipalityValidation: true,
-        roadCollection: ObstaclesRoadCollection,
+        roadCollection: ObstaclesAndRailwayCrossingsRoadCollection,
         showRoadLinkInfo: true,
         isSuggestedAsset: true,
         label: new SuggestionLabel()
@@ -1228,7 +1228,8 @@
         isSuggestedAsset: true,
         hasMunicipalityValidation: true,
         label: new SuggestionLabel(),
-        showRoadLinkInfo: true
+        showRoadLinkInfo: true,
+        roadCollection: ObstaclesAndRailwayCrossingsRoadCollection
       },
       {
         typeId: assetType.directionalTrafficSigns,

--- a/UI/src/controller/obstaclesRoadCollection.js
+++ b/UI/src/controller/obstaclesRoadCollection.js
@@ -1,5 +1,5 @@
 (function(root) {
-  root.ObstaclesRoadCollection = function(backend) {
+  root.ObstaclesAndRailwayCrossingsRoadCollection = function (backend) {
     RoadCollection.call(this, backend);
     var me = this;
 

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -57,7 +57,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
 
   val updateOnlyStartDatesFalse: UpdateOnlyStartDates = UpdateOnlyStartDates(false)
 
-  when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+  when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
   when(mockRoadLinkService.enrichFetchedRoadLinks(any[Seq[RoadLinkFetched]], any[Boolean])).thenReturn(roadLink)
 
   def runWithRollback(test: => Unit): Unit = sTestTransactions.runWithRollback()(test)
@@ -344,7 +344,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     val assetFields = Map("koordinaatti x" -> 1, "koordinaatti y" -> 1, "liikennemerkin tyyppi" -> "F37", "suuntima" -> "40")
     val invalidCsv = csvToInputStream(createCsvForTrafficSigns(assetFields))
     val defaultValues = trafficSignCsvImporter.mappings.keys.toList.map { key => key -> "" }.toMap
-    when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(Seq())
+    when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(Seq())
 
     trafficSignCsvImporter.processing(invalidCsv, Set(), testUser) should equal(trafficSignCsvImporter.ImportResultPointAsset(
       notImportedData = List(trafficSignCsvImporter.NotImportedData(
@@ -359,7 +359,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     val validCsv = csvToInputStream(createCsvForTrafficSigns(assetFields))
 
     runWithRollback {
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
       when(mockRoadLinkService.filterRoadLinkByBearing(any[Option[Int]], any[Option[Int]], any[Point], any[Seq[RoadLink]])).thenReturn(roadLink)
 
       val result = trafficSignCsvImporter.processing(validCsv, Set(), testUser)
@@ -382,7 +382,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     val validCsv = csvToInputStream(createCsvForTrafficSigns(assetFields))
 
     runWithRollback {
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
       when(mockRoadLinkService.filterRoadLinkByBearing(any[Option[Int]], any[Option[Int]], any[Point], any[Seq[RoadLink]])).thenReturn(roadLink)
 
       val result = trafficSignCsvImporter.processing(validCsv, Set(), testUser)
@@ -405,7 +405,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     val validCsv = csvToInputStream(createCsvForTrafficSigns(assetFields))
 
     runWithRollback {
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
       when(mockRoadLinkService.filterRoadLinkByBearing(any[Option[Int]], any[Option[Int]], any[Point], any[Seq[RoadLink]])).thenReturn(roadLink)
 
       val result = trafficSignCsvImporter.processing(validCsv, Set(), testUser)
@@ -428,7 +428,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     val validCsv = csvToInputStream(createCsvForTrafficSigns(assetFields))
 
     runWithRollback {
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
       when(mockRoadLinkService.filterRoadLinkByBearing(any[Option[Int]], any[Option[Int]], any[Point], any[Seq[RoadLink]])).thenReturn(roadLink)
 
       val result = trafficSignCsvImporter.processing(validCsv, Set(), testUser)
@@ -450,7 +450,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     val validCsv = csvToInputStream(createCsvForTrafficSigns(assetFields))
 
     runWithRollback {
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
       when(mockRoadLinkService.filterRoadLinkByBearing(any[Option[Int]], any[Option[Int]], any[Point], any[Seq[RoadLink]])).thenReturn(roadLink)
 
       val result = trafficSignCsvImporter.processing(validCsv, Set(), testUser)

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -52,7 +52,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
     override val geometryTransform: GeometryTransform = mockGeometryTransform
   }
 
-  when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(roadLink)
+  when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(roadLink)
   when(mockRoadLinkService.enrichFetchedRoadLinks(any[Seq[RoadLinkFetched]], any[Boolean])).thenReturn(roadLink)
 
   def runWithRollback(test: => Unit): Unit = sTestTransactions.runWithRollback()(test)
@@ -470,7 +470,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       val yCoord = 4
       val municipalityCode = Map("MUNICIPALITYCODE" -> BigInt(837))
       val pedestrianRoadLink = Seq(RoadLink(linkId2, Seq(Point(2, 2), Point(4, 4), Point(6, 6)), 6, Municipality, 1, TrafficDirection.BothDirections, CycleOrPedestrianPath, None, None, municipalityCode))
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(pedestrianRoadLink)
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(pedestrianRoadLink)
 
       val assetFields = Map("koordinaatti x" -> xCoord, "koordinaatti y" -> yCoord, "pysäkin tyyppi" -> "1", "tietojen ylläpitäjä" -> "1")
       val csv = massTransitStopImporterCreate.csvRead(assetFields)
@@ -496,7 +496,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
     runWithRollback {
       val xCoord = 2
       val yCoord = 2
-      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(Seq.empty[RoadLink])
+      when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(Seq.empty[RoadLink])
 
       val assetFields = Map("koordinaatti x" -> xCoord, "koordinaatti y" -> yCoord, "pysäkin tyyppi" -> "2", "tietojen ylläpitäjä" -> "1")
       val csv = massTransitStopImporterCreate.csvRead(assetFields)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -79,7 +79,7 @@ class KgvMunicipalityBorderClient(collection: Option[KgvCollection], linkGeomSou
     match {
       case Right(features) => features.get.features.map {feature =>
         val polygonFeature = feature.asInstanceOf[PolygonFeature]
-        MunicipalityBorders(polygonFeature.properties("kuntanumer").toString.toInt, polygonFeature.polygonGeometry) }
+        MunicipalityBorders(polygonFeature.properties("natcode").toString.toInt, polygonFeature.polygonGeometry) }
       case Left(error) => throw new ClientException(error.toString)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
@@ -45,7 +45,7 @@ object KgvCollection {
   case object UnFrozen extends KgvCollection { def value = "keskilinjavarasto:road_links" }
   case object LinkVersios extends KgvCollection { def value = "keskilinjavarasto:road_links_versions" }
   case object LinkCorreponceTable extends KgvCollection { def value = "keskilinjavarasto:frozenlinks_vastintaulu" }
-  case object MunicipalityBorders extends KgvCollection { def value = "paikkatiedot:kuntarajat"}
+  case object MunicipalityBorders extends KgvCollection { def value = "paikkatiedot:kuntarajat_10k"}
 }
 
 object FilterOgc extends Filter {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -367,8 +367,9 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
     * @param municipalities
     * @return RoadLinkFetched
     */
-  def fetchRoadLinksByBoundsAndMunicipalities(bounds: BoundingRectangle, municipalities: Set[Int] = Set()): Seq[RoadLinkFetched] = {
-    withDbConnection{roadLinkDAO.fetchByMunicipalitiesAndBounds(bounds, municipalities)}
+  def fetchRoadLinksByBoundsAndMunicipalities(bounds: BoundingRectangle, municipalities: Set[Int] = Set(), includeComplementaries: Boolean = false): Seq[RoadLinkFetched] = {
+    if (includeComplementaries) withDbConnection{roadLinkDAO.fetchByMunicipalitiesAndBounds(bounds, municipalities) ++ complementaryLinkDAO.fetchByMunicipalitiesAndBounds(bounds, municipalities)}
+    else withDbConnection{roadLinkDAO.fetchByMunicipalitiesAndBounds(bounds, municipalities)}
   }
 
   /**
@@ -888,12 +889,12 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
     else Some(roadLinks.minBy(roadLink => minimumDistance(point, roadLink.geometry)))
   }
 
-  def getClosestRoadlinkForCarTraffic(user: User, point: Point, forCarTraffic: Boolean = true): Seq[RoadLink] = {
+  def getClosestRoadlinkForCarTraffic(user: User, point: Point, forCarTraffic: Boolean = true, includeComplementaries: Boolean = false): Seq[RoadLink] = {
     val diagonal = Vector3d(10, 10, 0)
 
     val roadLinks =
-      if (user.isOperator()) fetchRoadLinksByBoundsAndMunicipalities(BoundingRectangle(point - diagonal, point + diagonal))
-      else fetchRoadLinksByBoundsAndMunicipalities(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities)
+      if (user.isOperator()) fetchRoadLinksByBoundsAndMunicipalities(BoundingRectangle(point - diagonal, point + diagonal), includeComplementaries = includeComplementaries)
+      else fetchRoadLinksByBoundsAndMunicipalities(BoundingRectangle(point - diagonal, point + diagonal), user.configuration.authorizedMunicipalities, includeComplementaries)
 
     val closestRoadLinks =
       if (roadLinks.isEmpty) Seq.empty[RoadLink]

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignServiceSpec.scala
@@ -53,7 +53,7 @@ class TrafficSignServiceSpec extends FunSuite with Matchers with BeforeAndAfter 
   val fetchedRoadlink2 = Seq(RoadLinkFetched(testLinkId2, 235, Seq(Point(2, 2), Point(4, 4)), Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers))
   when(mockRoadLinkService.getRoadLinksByBoundsAndMunicipalities(any[BoundingRectangle], any[Set[Int]],any[Boolean])).thenReturn(fetchedRoadlink1.map(toRoadLink))
   when(mockRoadLinkService.getRoadLinkByLinkId(any[String], any[Boolean])).thenReturn(fetchedRoadlink1.map(toRoadLink).headOption)
-  when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean])).thenReturn(fetchedRoadlink2.map(toRoadLink))
+  when(mockRoadLinkService.getClosestRoadlinkForCarTraffic(any[User], any[Point], any[Boolean], any[Boolean])).thenReturn(fetchedRoadlink2.map(toRoadLink))
   when(mockRoadLinkService.enrichFetchedRoadLinks(fetchedRoadlink2)).thenReturn(fetchedRoadlink2.map(toRoadLink))
   when(mockRoadLinkService.getRoadLinkByLinkId(randomLinkId2)).thenReturn(Seq(
     RoadLinkFetched(randomLinkId2, 235, Seq(Point(373500.349, 6677657.152), Point(373494.182, 6677669.918)), Private,


### PR DESCRIPTION
Tarkoituksena sallia tasoristeysten lisääminen UI:lla ja csv:llä käpyväylille, ajopoluille, täydentävälle geometrialle ja hallinnolliselle luokalle 99. Tällä hetkellä onnistuu vähän vaihtelevasti.

Rajapinta, josta kuntien rajat haetaan, oli muuttunut.