### PR TITLE
Droth 4020 change api to handle missing history link

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
@@ -17,8 +17,6 @@ import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
 import org.joda.time.DateTime
 import slick.jdbc.StaticQuery.interpolation
 
-private val logger = LoggerFactory.getLogger(getClass)
-
 sealed trait FloatingReason {
   def value: Int
 }
@@ -96,6 +94,8 @@ trait LightGeometry {
 }
 
 trait  PointAssetOperations{
+  private val logger = LoggerFactory.getLogger(getClass)
+
   type IncomingAsset <: IncomingPointAsset
   type PersistedAsset <: PersistedPointAsset
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
@@ -144,10 +144,14 @@ trait  PointAssetOperations{
     }
 
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(assets.map(_.linkId).toSet)
-    val missingOrDeletedLinks = assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
+    val historyRoadLinks = fetchMissingLinksFromHistory(assets, roadLinks)
 
     mapPersistedAssetChanges(assets, roadLinks, historyRoadLinks)
+  }
+
+  protected def fetchMissingLinksFromHistory(assets: Seq[PersistedAsset], roadLinks: Seq[RoadLink]) = {
+    val missingOrDeletedLinks = assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet)
+    roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
   }
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/PointAssetOperations.scala
@@ -17,6 +17,8 @@ import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
 import org.joda.time.DateTime
 import slick.jdbc.StaticQuery.interpolation
 
+private val logger = LoggerFactory.getLogger(getClass)
+
 sealed trait FloatingReason {
   def value: Int
 }
@@ -142,7 +144,8 @@ trait  PointAssetOperations{
     }
 
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(assets.map(_.linkId).toSet)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val missingOrDeletedLinks = assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
 
     mapPersistedAssetChanges(assets, roadLinks, historyRoadLinks)
   }
@@ -158,7 +161,6 @@ trait  PointAssetOperations{
                                filteredRoadLinks: Seq[RoadLink],
                                historyRoadLinks: Seq[RoadLink],
                                excludedRoadLinks: Seq[RoadLink] = Seq.empty[RoadLink]): Seq[ChangedPointAsset] = {
-    val logger = LoggerFactory.getLogger(getClass)
     assets.flatMap { asset =>
       val roadLinkFetched = filteredRoadLinks
         .find(_.linkId == asset.linkId)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
@@ -257,10 +257,10 @@ class DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusIm
       dynamicLinearAssetDao.getDynamicLinearAssetsChangedSince(typeId, since, until, withAutoAdjust, token)
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(persistedLinearAssets.map(_.linkId).toSet)
-    val roadLinksWithoutWalkways = roadLinks.filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
+    val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
     val historyRoadLinks = roadLinkService.getHistoryDataLinks(persistedLinearAssets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
 
-    mapPersistedAssetChanges(persistedLinearAssets, roadLinksWithoutWalkways, historyRoadLinks)
+    mapPersistedAssetChanges(persistedLinearAssets, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }
 
   override def getInaccurateRecords(typeId: Int, municipalities: Set[Int] = Set(), adminClass: Set[AdministrativeClass] = Set()): Map[String, Map[String, Any]] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/DynamicLinearAssetService.scala
@@ -258,7 +258,7 @@ class DynamicLinearAssetService(roadLinkServiceImpl: RoadLinkService, eventBusIm
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(persistedLinearAssets.map(_.linkId).toSet)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(persistedLinearAssets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val historyRoadLinks = fetchMissingLinksFromHistory(persistedLinearAssets, roadLinksWithoutWalkways)
 
     mapPersistedAssetChanges(persistedLinearAssets, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -338,6 +338,11 @@ trait LinearAssetOperations {
       dao.fetchLinearAssetsByLinkIds(typeId, linkIds, LinearAssetTypes.getValuePropertyId(typeId))
   }
 
+  protected def fetchMissingLinksFromHistory(assets: Seq[PersistedLinearAsset], roadLinks: Seq[RoadLink]) = {
+    val missingOrDeletedLinks = assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet)
+    roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
+  }
+
   /**
     * This method returns linear assets that have been changed in OTH between given date values. It is used by TN-ITS ChangeApi.
     *
@@ -353,8 +358,7 @@ trait LinearAssetOperations {
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(persistedLinearAssets.map(_.linkId).toSet).filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val missingOrDeletedLinks = persistedLinearAssets.map(_.linkId).toSet.diff(roadLinksWithoutWalkways.map(_.linkId).toSet)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
+    val historyRoadLinks = fetchMissingLinksFromHistory(persistedLinearAssets, roadLinksWithoutWalkways)
     mapPersistedAssetChanges(persistedLinearAssets, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/LinearAssetService.scala
@@ -353,7 +353,8 @@ trait LinearAssetOperations {
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(persistedLinearAssets.map(_.linkId).toSet).filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(persistedLinearAssets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val missingOrDeletedLinks = persistedLinearAssets.map(_.linkId).toSet.diff(roadLinksWithoutWalkways.map(_.linkId).toSet)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
     mapPersistedAssetChanges(persistedLinearAssets, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -209,8 +209,9 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
       dao.getProhibitionsChangedSince(typeId, since, until, excludedTypes, withAutoAdjust, token)
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(prohibitions.map(_.linkId).toSet).filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
-    mapPersistedAssetChanges(prohibitions, roadLinks)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(prohibitions.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
 
+    mapPersistedAssetChanges(prohibitions, roadLinks, historyRoadLinks)
   }
 
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -210,8 +210,7 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(prohibitions.map(_.linkId).toSet).filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val missingOrDeletedLinks = prohibitions.map(_.linkId).toSet.diff(roadLinksWithoutWalkways.map(_.linkId).toSet)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
+    val historyRoadLinks = fetchMissingLinksFromHistory(prohibitions, roadLinksWithoutWalkways)
 
     mapPersistedAssetChanges(prohibitions, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -209,9 +209,10 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
       dao.getProhibitionsChangedSince(typeId, since, until, excludedTypes, withAutoAdjust, token)
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(prohibitions.map(_.linkId).toSet).filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
+    val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
     val historyRoadLinks = roadLinkService.getHistoryDataLinks(prohibitions.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
 
-    mapPersistedAssetChanges(prohibitions, roadLinks, historyRoadLinks)
+    mapPersistedAssetChanges(prohibitions, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }
 
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/ProhibitionService.scala
@@ -210,7 +210,8 @@ class ProhibitionService(roadLinkServiceImpl: RoadLinkService, eventBusImpl: Dig
     }
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(prohibitions.map(_.linkId).toSet).filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(prohibitions.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val missingOrDeletedLinks = prohibitions.map(_.linkId).toSet.diff(roadLinksWithoutWalkways.map(_.linkId).toSet)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
 
     mapPersistedAssetChanges(prohibitions, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -113,20 +113,9 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
     }
     val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(persistedSpeedLimits.map(_.linkId).toSet)
     val roadLinksWithoutWalkways = roadLinks.filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(persistedSpeedLimits.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
 
-    persistedSpeedLimits.map { persisted =>
-      val roadLinkFetched = roadLinksWithoutWalkways.find(_.linkId == persisted.linkId) match {
-        case Some(roadLink) => roadLink
-        case _ => roadLinkService.getHistoryDataLink(persisted.linkId)
-          .getOrElse(throw new IllegalStateException(s"Road link no longer available ${persisted.linkId}"))
-      }
-      ChangedLinearAsset(
-        PieceWiseLinearAsset(persisted.id, persisted.linkId, SideCode(persisted.sideCode), persisted.value, GeometryUtils.truncateGeometry3D(roadLinkFetched.geometry, persisted.startMeasure, persisted.endMeasure), persisted.expired,
-          persisted.startMeasure, persisted.endMeasure, Set(Point(0.0, 0.0)), persisted.modifiedBy, persisted.modifiedDateTime, persisted.createdBy, persisted.createdDateTime,
-          persisted.typeId, SideCode.toTrafficDirection(SideCode(persisted.sideCode)), persisted.timeStamp, persisted.geomModifiedDate,
-          roadLinkFetched.linkSource, roadLinkFetched.administrativeClass, Map(), persisted.verifiedBy, persisted.verifiedDate, persisted.informationSource),
-        roadLinkFetched)
-    }
+    mapPersistedAssetChanges(persistedSpeedLimits, roadLinksWithoutWalkways, historyRoadLinks)
   }
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -113,8 +113,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
     }
     val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(persistedSpeedLimits.map(_.linkId).toSet)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val missingOrDeletedLinks = persistedSpeedLimits.map(_.linkId).toSet.diff(roadLinksWithoutWalkways.map(_.linkId).toSet)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
+    val historyRoadLinks = fetchMissingLinksFromHistory(persistedSpeedLimits, roadLinksWithoutWalkways)
 
     mapPersistedAssetChanges(persistedSpeedLimits, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -112,10 +112,10 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       speedLimitDao.getSpeedLimitsChangedSince(sinceDate, untilDate, withAdjust, token)
     }
     val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(persistedSpeedLimits.map(_.linkId).toSet)
-    val roadLinksWithoutWalkways = roadLinks.filterNot(_.linkType == CycleOrPedestrianPath).filterNot(_.linkType == TractorRoad)
+    val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
     val historyRoadLinks = roadLinkService.getHistoryDataLinks(persistedSpeedLimits.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
 
-    mapPersistedAssetChanges(persistedSpeedLimits, roadLinksWithoutWalkways, historyRoadLinks)
+    mapPersistedAssetChanges(persistedSpeedLimits, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }
 
   /**

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -113,7 +113,8 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
     }
     val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(persistedSpeedLimits.map(_.linkId).toSet)
     val (walkWays, roadLinksWithoutWalkways) = roadLinks.partition(link => link.linkType == CycleOrPedestrianPath || link.linkType == TractorRoad)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(persistedSpeedLimits.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val missingOrDeletedLinks = persistedSpeedLimits.map(_.linkId).toSet.diff(roadLinksWithoutWalkways.map(_.linkId).toSet)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
 
     mapPersistedAssetChanges(persistedSpeedLimits, roadLinksWithoutWalkways, historyRoadLinks, walkWays)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
@@ -140,8 +140,7 @@ class TrafficSignService(val roadLinkService: RoadLinkService, eventBusImpl: Dig
     }
 
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(assets.map(_.linkId).toSet)
-    val missingOrDeletedLinks = assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet)
-    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
+    val historyRoadLinks = fetchMissingLinksFromHistory(assets, roadLinks)
 
     mapPersistedAssetChanges(assets, roadLinks, historyRoadLinks)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
@@ -140,9 +140,10 @@ class TrafficSignService(val roadLinkService: RoadLinkService, eventBusImpl: Dig
     }
 
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(assets.map(_.linkId).toSet)
-    val historicRoadLinks = roadLinkService.getHistoryDataLinks(assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val missingOrDeletedLinks = assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet)
+    val historyRoadLinks = roadLinkService.getHistoryDataLinks(missingOrDeletedLinks)
 
-    mapPersistedAssetChanges(assets, roadLinks, historicRoadLinks)
+    mapPersistedAssetChanges(assets, roadLinks, historyRoadLinks)
   }
 
   def updateWithoutTransaction(id: Long, updatedAsset: IncomingTrafficSign, roadLink: RoadLink, username: String, mValue: Option[Double], timeStamp: Option[Long]): Long = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/TrafficSignService.scala
@@ -140,17 +140,9 @@ class TrafficSignService(val roadLinkService: RoadLinkService, eventBusImpl: Dig
     }
 
     val roadLinks = roadLinkService.getRoadLinksByLinkIds(assets.map(_.linkId).toSet)
-    val historicRoadLink = roadLinkService.getHistoryDataLinks(assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
+    val historicRoadLinks = roadLinkService.getHistoryDataLinks(assets.map(_.linkId).toSet.diff(roadLinks.map(_.linkId).toSet))
 
-    assets.map { asset =>
-      ChangedPointAsset(asset,
-        roadLinks.find(_.linkId == asset.linkId) match {
-          case Some(roadLink) => roadLink
-          case _ =>
-            historicRoadLink.filter(_.linkId == asset.linkId).sortBy(_.timeStamp)(Ordering.Long.reverse).headOption
-            .getOrElse(throw new IllegalStateException(s"Road link no longer available ${asset.linkId}"))
-        })
-    }
+    mapPersistedAssetChanges(assets, roadLinks, historicRoadLinks)
   }
 
   def updateWithoutTransaction(id: Long, updatedAsset: IncomingTrafficSign, roadLink: RoadLink, username: String, mValue: Option[Double], timeStamp: Option[Long]): Long = {


### PR DESCRIPTION
Muutettu muutosapin hyödyntämiä servicejä niin, että ne hakevat poistuneen assetin linkkiä kgv:n historia-taulusta mikäli linkkiä ei löydy enää Digiroadin kannasta.

Operaattorin toiveesta lisätty logiikka, jonka myötä käsittelystä jätetään pois sellaiset assetit, joille ei löydy linkkiä myöskään kgv:n taulusta. Nämä tapaukset merkitään lokiin varoituksina.

Lisäksi yhdenmukaistettu assetien ja linkkien mappausta eri getChanged overrideissä niin, että ne kaikki kutsuvat tyypilleen sopivaa mapPersistedAssetChanges-metodia.

Testattu dev-kantaa vasten.