### PR TITLE
Master to development merge conflict fix

### DIFF
--- a/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/DEVbatchJobDefinition.json
@@ -18,11 +18,11 @@
     "resourceRequirements" : [
       {
         "type": "MEMORY",
-        "value": "40960"
+        "value": "30720"
       },
       {
         "type": "VCPU",
-        "value": "8"
+        "value": "4"
       }
     ],
     "executionRoleArn": "arn:aws:iam::475079312496:role/DEV-batchSystem-BatchTaskRole-VGL42N9TANTI",
@@ -30,7 +30,7 @@
     "environment": [
       {
         "name": "containerCPU",
-        "value": "-XX:ActiveProcessorCount=8"
+        "value": "-XX:ActiveProcessorCount=4"
       },
       {
         "name": "speedLimitProvider",
@@ -70,7 +70,7 @@
       },
       {
         "name": "kgv.endpoint",
-        "value": "https://api.testivaylapilvi.fi/paikkatiedot/ogc/features/collections/"
+        "value": "https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/"
       },
       {
         "name": "viiteRestApiEndPoint",

--- a/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/ProdBatchJobDefinition.json
@@ -67,7 +67,7 @@
       },
       {
         "name": "kgv.endpoint",
-        "value": "https://api.vaylapilvi.fi/paikkatiedot/ogc/features/collections/"
+        "value": "https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/"
       },
       {
         "name": "viiteRestApiEndPoint",

--- a/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
+++ b/aws/cloud-formation/batchSystem/QAbatchJobDefinition.json
@@ -67,7 +67,7 @@
       },
       {
         "name": "kgv.endpoint",
-        "value": "https://api.testivaylapilvi.fi/paikkatiedot/ogc/features/collections/"
+        "value": "https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/"
       },
       {
         "name": "viiteRestApiEndPoint",

--- a/aws/cloud-formation/taskdefinition/dev-create-taskdefinition.yaml
+++ b/aws/cloud-formation/taskdefinition/dev-create-taskdefinition.yaml
@@ -115,7 +115,7 @@ Resources:
             - Name: vvhRoadlink.frozen
               Value: 'false'
             - Name: kgv.endpoint
-              Value: 'https://api.testivaylapilvi.fi/paikkatiedot/ogc/features/collections/'
+              Value: 'https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/'
             - Name: viiteRestApiEndPoint
               Value: 'https://api.vaylapilvi.fi/viite/api/viite/'
             - Name: authenticationTestMode

--- a/aws/cloud-formation/taskdefinition/prod-create-taskdefinition.yaml
+++ b/aws/cloud-formation/taskdefinition/prod-create-taskdefinition.yaml
@@ -114,7 +114,7 @@ Resources:
             - Name: vvhRoadlink.frozen
               Value: 'false'
             - Name: kgv.endpoint
-              Value: 'https://api.vaylapilvi.fi/paikkatiedot/ogc/features/collections/'
+              Value: 'https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/'
             - Name: viiteRestApiEndPoint
               Value: 'https://api.vaylapilvi.fi/viite/api/viite/'
             - Name: authenticationTestMode

--- a/aws/cloud-formation/taskdefinition/qa-create-taskdefinition.yaml
+++ b/aws/cloud-formation/taskdefinition/qa-create-taskdefinition.yaml
@@ -116,7 +116,7 @@ Resources:
             - Name: vvhRoadlink.frozen
               Value: 'false'
             - Name: kgv.endpoint
-              Value: 'https://api.testivaylapilvi.fi/paikkatiedot/ogc/features/collections/'
+              Value: 'https://api.vaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/'
             - Name: viiteRestApiEndPoint
               Value: 'https://api.testivaylapilvi.fi/viite/api/viite/'
             - Name: authenticationTestMode

--- a/conf/env.properties
+++ b/conf/env.properties
@@ -16,7 +16,7 @@ vvhRestApiEndPoint=https://api.vayla.fi/vvhdata/
 vvhRoadlink.frozen=false
 vvhRest.username=svc_vvh_digiroad
 vvhRest.password=insertpassword
-kgv.endpoint=https://api.testivaylapilvi.fi/paikkatiedot/ogc/features/collections/
+kgv.endpoint=https://api.testivaylapilvi.fi/paikkatiedot/ogc/features/v1/collections/
 kgv.apikey=insertkey
 
 viiteRestApiEndPoint=https://api.testivaylapilvi.fi/viite/api/viite/


### PR DESCRIPTION
GitHub väittää, että master -> development mergessä olisi konflikteja. Tämä haara otettu developmentista, ja siihen mergetty master ilman konflikteja. Mergetään master deviin nyt tällä tavalla, kun ei suoraan anna.