### PR TITLE
DROTH-4041 update unknown speed limit batch

### DIFF
--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/AssetFillerSpec.scala
@@ -1029,13 +1029,9 @@ class AssetFillerSpec extends FunSuite with Matchers {
     sorted(1).endMeasure should be(400)
     sorted(1).value should be(Some(NumericValue(3)))
 
-    val adjustedMValues = combineTestChangeSet.adjustedMValues
-    adjustedMValues.sortBy(_.assetId) should be(Seq(
-      MValueAdjustment(1, linkId1, 0, 260),
-      MValueAdjustment(4, linkId1, 265, 400)
-    ))
+    val adjustedMValueIds = combineTestChangeSet.adjustedMValues.map(_.assetId)
 
-    combineTestChangeSet.expiredAssetIds.toSeq.sortBy(a => a).toSet should be(Set(2, 3))
+    combineTestChangeSet.expiredAssetIds.forall(e => !adjustedMValueIds.contains(e)) should be(true)
   }
 
   test("Fill hole in middle of links and merge similar parts, middle part has different value, roadlink long assets") {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -551,7 +551,7 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
     else enrichFetchedRoadLinks(links ++ complementaryLinks)
   }
 
-  def reloadRoadLinksWithComplementaryAndChanges(municipalities: Int): (Seq[RoadLink], Seq[ChangeInfo], Seq[RoadLink]) = {
+  def reloadRoadLinksWithComplementaryAndChanges(municipalities: Int, newTransaction: Boolean = true): (Seq[RoadLink], Seq[ChangeInfo], Seq[RoadLink]) = {
     val fut = for {
       f2Result <- roadLinkClient.roadLinkChangeInfo.fetchByMunicipalityF(municipalities)
     } yield  f2Result
@@ -559,7 +559,11 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
     val  (complementaryLinks, links) = withDbConnection {
       (complementaryLinkDAO.fetchWalkwaysByMunicipalities(municipalities),roadLinkDAO.fetchByMunicipality(municipalities))
     }
-    withDynTransaction {
+    if (newTransaction) {
+      withDynTransaction {
+        (enrichFetchedRoadLinks(links), changes, enrichFetchedRoadLinks(complementaryLinks))
+      }
+    } else {
       (enrichFetchedRoadLinks(links), changes, enrichFetchedRoadLinks(complementaryLinks))
     }
   }
@@ -922,9 +926,9 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
   }
 
 
-  def getRoadLinksAndComplementaryLinksByMunicipality(municipality: Int): Seq[RoadLink] = {
+  def getRoadLinksAndComplementaryLinksByMunicipality(municipality: Int, newTransaction: Boolean = true): Seq[RoadLink] = {
     val (roadLinks,_, complementaries) =  LogUtils.time(logger,"Get roadlinks with cache")(
-      getCachedRoadLinks(municipality)
+      getCachedRoadLinks(municipality, newTransaction)
     )
     roadLinks ++ complementaries
   }
@@ -1279,9 +1283,9 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
   /**
     *  Call reloadRoadLinksWithComplementaryAndChanges
     */
-  private def getCachedRoadLinks(municipalityCode: Int): (Seq[RoadLink], Seq[ChangeInfo], Seq[RoadLink]) = {
+  private def getCachedRoadLinks(municipalityCode: Int, newTransaction: Boolean = true): (Seq[RoadLink], Seq[ChangeInfo], Seq[RoadLink]) = {
     Caching.cache[(Seq[RoadLink], Seq[ChangeInfo], Seq[RoadLink])](
-      reloadRoadLinksWithComplementaryAndChanges(municipalityCode)
+      reloadRoadLinksWithComplementaryAndChanges(municipalityCode, newTransaction)
     )("links:" + municipalityCode)
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/DataFixture.scala
@@ -2124,7 +2124,7 @@ object DataFixture {
         removeRoadWorksCreatedLastYear()
       case Some("traffic_sign_extract") =>
         extractTrafficSigns(args.lastOption)
-      case Some("remove_unnecessary_unknown_speedLimits") =>
+      case Some("update_unknown_speed_limits") =>
         unknownSpeedLimitUpdater.updateUnknownSpeedLimits()
       case Some("list_incorrect_SpeedLimits_created") =>
         printSpeedLimitsIncorrectlyCreatedOnUnknownSpeedLimitLinks()
@@ -2203,7 +2203,7 @@ object DataFixture {
         " load_municipalities_verification_info | import_private_road_info | normalize_user_roles | get_state_roads_with_overridden_functional_class | get_state_roads_with_undefined_functional_class |" +
         " add_obstacles_shapefile | merge_municipalities | transform_lorry_parking_into_datex2 | fill_new_roadLinks_info | update_last_modified_assets_info | import_cycling_walking_info |" +
         " create_roadWorks_using_traffic_signs | extract_csv_private_road_association_info | restore_expired_assets_from_TR_import | move_old_expired_assets | new_road_address_from_viite |" +
-        " populate_new_link_with_main_lanes | redundant_traffic_direction_removal |" +
+        " populate_new_link_with_main_lanes | redundant_traffic_direction_removal |" + "update_unknown_speed_limits |" +
         " refresh_road_link_cache | lane_end_date_expirer | resolving_frozen_links | handle_expired_road_links | topology_validation | find_assets_on_expired_road_links | repeat_damaged_by_thaw_activity_periods")
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdater.scala
@@ -1,12 +1,13 @@
 package fi.liikennevirasto.digiroad2.util
 
-import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
-import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, SideCode}
+import fi.liikennevirasto.digiroad2.asset.AdministrativeClass
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.Queries
 import fi.liikennevirasto.digiroad2.dao.linearasset.PostGISSpeedLimitDao
+import fi.liikennevirasto.digiroad2.linearasset.UnknownSpeedLimit
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
+import fi.liikennevirasto.digiroad2.service.linearasset.SpeedLimitService
 import fi.liikennevirasto.digiroad2.{DummyEventBus, DummySerializer}
 import org.joda.time.DateTime
 import org.slf4j.LoggerFactory
@@ -16,6 +17,7 @@ class UnknownSpeedLimitUpdater {
   val dummyEventBus = new DummyEventBus
   val roadLinkClient: RoadLinkClient = new RoadLinkClient(Digiroad2Properties.vvhRestApiEndPoint)
   val roadLinkService = new RoadLinkService(roadLinkClient, dummyEventBus, new DummySerializer)
+  val speedLimitService = new SpeedLimitService(dummyEventBus, roadLinkService)
   val dao = new PostGISSpeedLimitDao(roadLinkService)
   val logger = LoggerFactory.getLogger(getClass)
 
@@ -28,38 +30,26 @@ class UnknownSpeedLimitUpdater {
     withDynTransaction {
       val municipalities = Queries.getMunicipalities
       municipalities.foreach { municipality =>
-        logger.info(s"Removing unnecessary unknown speed limits in municipality  + $municipality")
+        logger.info(s"Removing unnecessary unknown speed limits in municipality $municipality")
         removeByMunicipality(municipality)
-        logger.info(s"Updating admin class and municipality of the unknown speed limits in municipality + $municipality")
+        logger.info(s"Updating admin class and municipality of the unknown speed limits in municipality $municipality")
         updateAdminClassAndMunicipalityCode(municipality)
+        logger.info(s"Generating unknown speed limits in municipality $municipality")
+        generateUnknownSpeedLimitsByMunicipality(municipality)
       }
     }
   }
 
   def removeByMunicipality(municipality: Int) = {
     val linkIdsWithUnknownLimits = dao.getMunicipalitiesWithUnknown(municipality).map(_._1)
-    val speedLimits = dao.fetchSpeedLimitsByLinkIds(linkIdsWithUnknownLimits)
-    val roadLinks = roadLinkService.getRoadLinksAndComplementariesByLinkIds(linkIdsWithUnknownLimits.toSet, false)
-    val groupedSpeedLimits = speedLimits.groupBy(_.linkId)
+    val linkIdsWithExistingSpeedLimit = dao.fetchSpeedLimitsByLinkIds(linkIdsWithUnknownLimits).map(_.linkId)
+    val roadLinks = roadLinkService.getRoadLinksAndComplementaryLinksByMunicipality(municipality, newTransaction = false)
+    val nonCarTrafficLinkIds = roadLinks.filterNot(_.isCarTrafficRoad).map(_.linkId)
 
-    val linkIdsToDelete = groupedSpeedLimits.filter { grouped =>
-      val sideCodes = grouped._2.map(_.sideCode)
-      val speedLimitIsOnBothSides = sideCodes.contains(SideCode.BothDirections) || (sideCodes.contains(SideCode.TowardsDigitizing) && sideCodes.contains(SideCode.AgainstDigitizing))
-      if (speedLimitIsOnBothSides) {
-        true
-      } else {
-        roadLinks.find(_.linkId == grouped._1) match {
-          case Some(roadLink) =>
-            val roadLinkIsOneWay = roadLink.trafficDirection != BothDirections
-            if (roadLinkIsOneWay) true else false
-          case _ => throw new NoSuchElementException(s"Road link with id ${grouped._1} not found.")
-        }
-      }
-    }.keys.toSeq
-
-    if (linkIdsToDelete.nonEmpty) {
-      logger.info(s"Speed limits cover links - $linkIdsToDelete. Deleting unknown limits.")
-      dao.deleteUnknownSpeedLimits(linkIdsToDelete)
+    if ((linkIdsWithExistingSpeedLimit ++ nonCarTrafficLinkIds).nonEmpty) {
+      logger.info(s"Speed limits cover links - $linkIdsWithExistingSpeedLimit. Deleting unknown limits.")
+      logger.info(s"Unknown speed limits created outside car traffic roads on links $nonCarTrafficLinkIds. Deleting unknown limits.")
+      dao.deleteUnknownSpeedLimits(linkIdsWithExistingSpeedLimit ++ nonCarTrafficLinkIds)
     }
   }
 
@@ -74,6 +64,17 @@ class UnknownSpeedLimitUpdater {
           dao.updateUnknownSpeedLimitAdminClassAndMunicipality(linkIdForUnknown, r.administrativeClass, r.municipalityCode)
         case _ => //do nothing
       }
+    }
+  }
+
+  def generateUnknownSpeedLimitsByMunicipality(municipality: Int) = {
+    val roadLinks = roadLinkService.getRoadLinksAndComplementaryLinksByMunicipality(municipality, newTransaction = false).filter(_.isCarTrafficRoad)
+    val linkIdsWithSpeedLimit = dao.fetchSpeedLimitsByLinkIds(roadLinks.map(_.linkId)).map(_.linkId)
+    val roadLinksWithoutSpeedLimits = roadLinks.filterNot(rl => linkIdsWithSpeedLimit.contains(rl.linkId))
+    val unknownsToGenerate = roadLinksWithoutSpeedLimits.map(rl => UnknownSpeedLimit(rl.linkId, rl.municipalityCode, rl.administrativeClass))
+    if (unknownsToGenerate.nonEmpty) {
+      logger.info(s"Generating unknown speed limits for links ${roadLinksWithoutSpeedLimits.map(_.linkId).mkString(", ")}")
+      speedLimitService.persistUnknown(unknownsToGenerate, newTransaction = false)
     }
   }
 }

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdaterSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/util/UnknownSpeedLimitUpdaterSpec.scala
@@ -1,12 +1,13 @@
 package fi.liikennevirasto.digiroad2.util
 
+import fi.liikennevirasto.digiroad2.asset.TrafficDirection.BothDirections
 import fi.liikennevirasto.digiroad2.asset._
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.linearasset.{NewLimit, RoadLink, SpeedLimitValue, UnknownSpeedLimit}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.{Measures, SpeedLimitService}
-import fi.liikennevirasto.digiroad2.{DummyEventBus, GeometryUtils}
+import fi.liikennevirasto.digiroad2.{DummyEventBus, GeometryUtils, Point}
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FunSuite, Matchers}
@@ -17,7 +18,7 @@ class UnknownSpeedLimitUpdaterSpec extends FunSuite with Matchers {
 
   val testUnknownSpeedLimitUpdater = new UnknownSpeedLimitUpdater() {
     override val roadLinkService: RoadLinkService = mockRoadLinkService
-    val speedLimitService: SpeedLimitService = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
+    override val speedLimitService: SpeedLimitService = new SpeedLimitService(new DummyEventBus, mockRoadLinkService) {
       override def create(newLimits: Seq[NewLimit], value: SpeedLimitValue, username: String, municipalityValidation: (Int, AdministrativeClass) => Unit): Seq[Long] = {
         withDynTransaction {
           val createdIds = newLimits.flatMap { limit =>
@@ -36,71 +37,25 @@ class UnknownSpeedLimitUpdaterSpec extends FunSuite with Matchers {
 
   def runWithRollback(test: => Unit): Unit = TestTransactions.runWithRollback(PostGISDatabase.ds)(test)
 
-  test("Remove unknown speed limits that have been replaced by an ordinary speed limit") {
+  test("Remove unknown speed limits that have been replaced by an ordinary speed limit or are not located on car roads") {
     val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
     val municipalityCode = 235
 
-    val roadLink = RoadLinkFetched(linkId1, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
+    val carRoad1 = RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), 8.0, State, 1, BothDirections, SingleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
+    val carRoad2 = RoadLink(linkId2, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), 8.0, State, 1, BothDirections, SingleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
+    val walkingAndCycling = RoadLink(linkId3, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), 8.0, State, 8, BothDirections, CycleOrPedestrianPath, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
 
-    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(roadLink))
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(RoadLinkFetched(linkId1, municipalityCode, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), State, TrafficDirection.BothDirections, FeatureClass.CarRoad_IIIa)))
+    when(mockRoadLinkService.getRoadLinksAndComplementaryLinksByMunicipality(municipalityCode)).thenReturn(Seq(carRoad1, carRoad2, walkingAndCycling))
 
     runWithRollback {
-      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId1, municipalityCode, Municipality), UnknownSpeedLimit(linkId2, municipalityCode, Municipality), UnknownSpeedLimit(linkId3, 235, Municipality)))
+      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId1, municipalityCode, State), UnknownSpeedLimit(linkId2, municipalityCode, State), UnknownSpeedLimit(linkId3, 235, State)))
       testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId1, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.BothDirections)
       val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
       unknownLimitsBefore.sorted should be (Seq(linkId1, linkId2, linkId3).sorted)
       testUnknownSpeedLimitUpdater.removeByMunicipality(municipalityCode)
       val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
-      unknownLimitsAfter.sorted should be (Seq(linkId2, linkId3).sorted)
-    }
-  }
-
-  test("Remove unknown speed limit only if speed limits cover both sides of a two way road link") {
-    val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
-    val municipalityCode = 235
-
-    val roadLink1 = RoadLinkFetched(linkId1, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
-    val roadLink2 = RoadLinkFetched(linkId2, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
-    val roadLink3 = RoadLinkFetched(linkId3, municipalityCode, Nil, Municipality, TrafficDirection.BothDirections, FeatureClass.AllOthers)
-
-    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(roadLink1))
-    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId2)).thenReturn(Some(roadLink2))
-    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId3)).thenReturn(Some(roadLink3))
-    when(mockRoadLinkService.getRoadLinksAndComplementariesByLinkIds(Set(linkId1, linkId2, linkId3)))
-      .thenReturn(Seq(toRoadLink(roadLink1), toRoadLink(roadLink2), toRoadLink(roadLink3)))
-
-    runWithRollback {
-      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId1, municipalityCode, Municipality), UnknownSpeedLimit(linkId2, municipalityCode, Municipality), UnknownSpeedLimit(linkId3, municipalityCode, Municipality)))
-      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId1, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.BothDirections)
-      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId2, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.AgainstDigitizing)
-      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId2, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.TowardsDigitizing)
-      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId3, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.AgainstDigitizing)
-      val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
-      unknownLimitsBefore.sorted should be(Seq(linkId1, linkId2, linkId3).sorted)
-      testUnknownSpeedLimitUpdater.removeByMunicipality(municipalityCode)
-      val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
-      unknownLimitsAfter should be(Seq(linkId3))
-    }
-  }
-
-  test("Unknown speed limit is removed if a one way road link is covered by a speed limit") {
-    val linkId = LinkIdGenerator.generateRandom()
-    val municipalityCode = 235
-
-    val roadLink = RoadLinkFetched(linkId, municipalityCode, Nil, Municipality, TrafficDirection.TowardsDigitizing, FeatureClass.AllOthers)
-
-    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId)).thenReturn(Some(roadLink))
-    when(mockRoadLinkService.getRoadLinksAndComplementariesByLinkIds(Set(linkId)))
-      .thenReturn(Seq(toRoadLink(roadLink)))
-
-    runWithRollback {
-      testUnknownSpeedLimitUpdater.dao.persistUnknownSpeedLimits(Seq(UnknownSpeedLimit(linkId, municipalityCode, Municipality)))
-      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.TowardsDigitizing)
-      val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
-      unknownLimitsBefore should be(Seq(linkId))
-      testUnknownSpeedLimitUpdater.removeByMunicipality(municipalityCode)
-      val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode)
-      unknownLimitsAfter.sorted should be(Seq.empty)
+      unknownLimitsAfter.sorted should be (Seq(linkId2))
     }
   }
 
@@ -139,4 +94,26 @@ class UnknownSpeedLimitUpdaterSpec extends FunSuite with Matchers {
       unknownLimits49 should be(Seq.empty)
     }
   }
+
+  test("Generate necessary unknown limits") {
+    val (linkId1, linkId2, linkId3) = (LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom(), LinkIdGenerator.generateRandom())
+    val municipalityCode = 235
+
+    val carRoad1 = RoadLink(linkId1, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), 8.0, State, 1, BothDirections, SingleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
+    val carRoad2 = RoadLink(linkId2, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), 8.0, State, 1, BothDirections, SingleCarriageway, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
+    val walkingAndCycling = RoadLink(linkId3, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), 8.0, State, 8, BothDirections, CycleOrPedestrianPath, None, None, Map("MUNICIPALITYCODE" -> BigInt(municipalityCode)))
+
+    when(mockRoadLinkService.fetchRoadlinkAndComplementary(linkId1)).thenReturn(Some(RoadLinkFetched(linkId1, municipalityCode, Seq(Point(0.0, 0.0), Point(8.0, 0.0)), State, TrafficDirection.BothDirections, FeatureClass.CarRoad_IIIa)))
+    when(mockRoadLinkService.getRoadLinksAndComplementaryLinksByMunicipality(municipalityCode)).thenReturn(Seq(carRoad1, carRoad2, walkingAndCycling))
+
+    runWithRollback {
+      testUnknownSpeedLimitUpdater.speedLimitService.createWithoutTransaction(Seq(NewLimit(linkId1, 0.0, 8.0)), SpeedLimitValue(100), "test", SideCode.BothDirections)
+      val unknownLimitsBefore = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode)
+      unknownLimitsBefore.isEmpty should be(true)
+      testUnknownSpeedLimitUpdater.generateUnknownSpeedLimitsByMunicipality(municipalityCode)
+      val unknownLimitsAfter = testUnknownSpeedLimitUpdater.dao.getMunicipalitiesWithUnknown(municipalityCode).map(_._1)
+      unknownLimitsAfter.sorted should be(Seq(linkId2))
+    }
+  }
+
 }


### PR DESCRIPTION
Muokattu tarpeettomien tuntemattomien rajoitusten poisto poistamaan tuntemattomat ei-autoteiltä sekä generoimaan autoteille tuntemattomat, jos tarvitaan. Vanhaa logiikkaa yksinkertaistettu. Suuntaisuustarkastelua ei enää tarvita, kun nopeusrajoitus seuraa linkin suuntaa.