### PR TITLE
DROTH-4043 Filter out unneeded 'counter' property before saving

### DIFF
--- a/UI/src/model/selectedPointAsset.js
+++ b/UI/src/model/selectedPointAsset.js
@@ -126,6 +126,12 @@
     function save() {
       eventbus.trigger(assetName + ':saving');
       current = _.omit(current, 'geometry');
+      // Filter property 'counter' as it is not a real property to save.
+      // 'counter' is used only to group nearby TrafficSigns together in UI
+      current.propertyData = _.filter(current.propertyData, function(prop) {
+        return prop.publicId !== 'counter';
+      });
+
       if (current.toBeDeleted) {
         eventbus.trigger(endPointName + ':deleted', current, 'deleted');
         backend.removePointAsset(current.id, endPointName).done(done).fail(fail);


### PR DESCRIPTION
Tallennus kaatui backendillä, kun yritettiin tallentaa 'counter' propertyä, jota ei ole olemassa kannassa.
Suodatetaan 'counter' property pois frontilla ennen tallennusta. Kyseinen property ei ole "oikea" property, joka tallentuu kantaan, vaan kyseessä on laskettu arvo, jota käytetään lähekkäisten liikennemerkkien päällekkäiseen visualisointiin. 