### PR TITLE
DROTH-4049 Fix bug with multipart upload dropping ends of chunks

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/AwsService.scala
@@ -117,7 +117,7 @@ class AwsService {
         .partNumber(partNumber)
         .build()
       val chunkInputStream = new ByteArrayInputStream(chunkData.getBytes(StandardCharsets.UTF_8))
-      val requestBody = RequestBody.fromInputStream(chunkInputStream, chunkData.length.toLong)
+      val requestBody = RequestBody.fromInputStream(chunkInputStream, chunkData.getBytes(StandardCharsets.UTF_8).length)
 
       Future {
         val uploadPartResponse = s3.uploadPart(partRequest, requestBody)


### PR DESCRIPTION
Korjattu bugi S3 multipart upload. Body voi sisältää merkkejä, jotka ovat useamman tavun pituisia ja tästä syystä requestBody:sta voi leikkantua loppu pois. 