### PR TITLE
DROTH-2877 Fix name_fi column values in enumerated_value table for 'o…

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_40__fix_traffic_sign_enumerated_values.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_40__fix_traffic_sign_enumerated_values.sql
@@ -1,0 +1,9 @@
+UPDATE enumerated_value
+SET name_fi = 'Väärä', modified_date = current_timestamp, modified_by = 'db_migration_v1_40'
+WHERE property_id = (SELECT id FROM property WHERE public_id = 'old_traffic_code')
+AND value = 0;
+
+UPDATE enumerated_value
+SET name_fi = 'Totta', modified_date = current_timestamp, modified_by = 'db_migration_v1_40'
+WHERE property_id = (SELECT id FROM property WHERE public_id = 'old_traffic_code')
+AND value = 1;

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_40__fix_traffic_sign_enumerated_values.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_40__fix_traffic_sign_enumerated_values.sql
@@ -1,9 +1,9 @@
 UPDATE enumerated_value
-SET name_fi = 'Väärä', modified_date = current_timestamp, modified_by = 'db_migration_v1_40'
+SET name_fi = 'Epätosi', modified_date = current_timestamp, modified_by = 'db_migration_v1_40'
 WHERE property_id = (SELECT id FROM property WHERE public_id = 'old_traffic_code')
 AND value = 0;
 
 UPDATE enumerated_value
-SET name_fi = 'Totta', modified_date = current_timestamp, modified_by = 'db_migration_v1_40'
+SET name_fi = 'Tosi', modified_date = current_timestamp, modified_by = 'db_migration_v1_40'
 WHERE property_id = (SELECT id FROM property WHERE public_id = 'old_traffic_code')
 AND value = 1;


### PR DESCRIPTION
Kannassa 'old_traffic_code' propertyn 0 ja 1 arvoilla on suomenkieliset selitteet väärin päin enumerated_value taulussa. Korjataan oikein päin migraatiossa. 