### PR TITLE
Droth 2844 block zooming out during modifications

### DIFF
--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -261,13 +261,28 @@
         projection: 'EPSG:3067',
         zoom: startupParameters.zoom,
         resolutions: [2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4, 2, 1, 0.5, 0.25, 0.125, 0.0625]
-      })
+      }),
+      interactions: ol.interaction.defaults({
+        mouseWheelZoom: false
+      }),
     });
     map.setProperties({extent : [-548576, 6291456, 1548576, 8388608]});
     map.addInteraction(new ol.interaction.DragPan({
       condition: function (mapBrowserEvent) {
         var originalEvent = mapBrowserEvent.originalEvent;
         return (!originalEvent.altKey && !originalEvent.shiftKey);
+      }
+    }));
+    map.addInteraction(new ol.interaction.MouseWheelZoom({
+      condition: function(event) {
+        var zoomOut = event.originalEvent.deltaY > 0;  // Wheel scrolled down
+        if (zoomOut) {
+          var newZoomLevel = zoomlevels.getViewZoom(map);
+          applicationModel.setZoomLevel(newZoomLevel);
+          return applicationModel.canZoomOut();
+        }
+        else
+          return true;
       }
     }));
     return map;

--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -277,9 +277,8 @@
       condition: function(event) {
         var zoomOut = event.originalEvent.deltaY > 0;  // Wheel scrolled down
         if (zoomOut) {
-          var newZoomLevel = zoomlevels.getViewZoom(map);
-          applicationModel.setZoomLevel(newZoomLevel);
-          return applicationModel.canZoomOut();
+          var zoomLevel = zoomlevels.getViewZoom(map);
+          return applicationModel.canZoomOut(zoomLevel);
         }
         else
           return true;

--- a/UI/src/model/applicationModel.js
+++ b/UI/src/model/applicationModel.js
@@ -88,8 +88,8 @@
       isFeedbackState: function(){
         return isFeedbackState();
       },
-      canZoomOut: function() {
-        return !(isDirty() && (zoom.level <= minDirtyZoomLevel));
+      canZoomOut: function(zoomLevel) {
+        return !(isDirty() && (zoomLevel <= minDirtyZoomLevel));
       },
       assetDragDelay: 100,
       assetGroupingDistance: 36,

--- a/UI/src/view/zoomBox.js
+++ b/UI/src/view/zoomBox.js
@@ -14,10 +14,10 @@
       });
     });
     container.find('.minus').click(function() {
-      if (applicationModel.canZoomOut()) {
-        var zoom= zoomlevels.getViewZoom(map);
+      var zoomLevel = zoomlevels.getViewZoom(map);
+      if (applicationModel.canZoomOut(zoomLevel)) {
         map.getView().animate({
-          zoom: zoom -1,
+          zoom: zoomLevel -1,
           duration: 150
         });
       } else {


### PR DESCRIPTION
Lisätty toiminnallisuus, joka estää kauas pois zoomaamisen hiiren rullalla, mikäli muokkaukset kesken. Tehty pieni muutos canZoomOut-tarkitukseen jotta se olisi funktionaalisempi, mutta muuten koetettu olla koskematta alla olevaan himmeliin.