### PR TITLE
Droth 3838 remove unnecessary asset types from samuutus success

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_41__delete_unnecessary_asset_types_from_samuutus.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_41__delete_unnecessary_asset_types_from_samuutus.sql
@@ -1,0 +1,1 @@
+delete from samuutus_success where asset_type_id in (150, 250, 310, 320, 330, 340, 350, 360, 370, 410);

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/LinearAssetUpdateProcess.scala
@@ -98,7 +98,6 @@ object LinearAssetUpdateProcess {
       logger.info(s"Starting samuutus with parameter: $assetName")
       assetName match {
         // position, value and side code
-        case "animal_warnings" => getAssetUpdater(AnimalWarnings.typeId).updateLinearAssets(AnimalWarnings.typeId)
         case "care_class" => getAssetUpdater(CareClass.typeId).updateLinearAssets(CareClass.typeId)
         case "height_limit" => getAssetUpdater(HeightLimit.typeId).updateLinearAssets(HeightLimit.typeId)
         case "length_limit" => getAssetUpdater(LengthLimit.typeId).updateLinearAssets(LengthLimit.typeId)


### PR DESCRIPTION
Poistetaan tarpeettomat typet samuutus_success-taulusta:
150 = kyseille id:lle ei löydy typea nykykoodissa eikä asset_type taulussa
250 = palvelupiste (ei samuuteta)
310-370 = tierekisterin rajoituksia
410 = eläinvaroitukset

Lisäksi poistetaan eläinvaroitukset prosessista.

