### PR TITLE
Droth 2844 block zooming out during modifications

### DIFF
--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -277,8 +277,7 @@
       condition: function(event) {
         var zoomOut = event.originalEvent.deltaY > 0;  // Wheel scrolled down
         if (zoomOut) {
-          var zoomLevel = zoomlevels.getViewZoom(map);
-          return applicationModel.canZoomOut(zoomLevel);
+          return applicationModel.handleZoomOut(map);
         }
         else
           return true;

--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -273,14 +273,20 @@
         return (!originalEvent.altKey && !originalEvent.shiftKey);
       }
     }));
+
     map.addInteraction(new ol.interaction.MouseWheelZoom({
       condition: function(event) {
-        var zoomOut = event.originalEvent.deltaY > 0;  // Wheel scrolled down
-        if (zoomOut) {
+        var deltaY = event.originalEvent.deltaY;
+        if (deltaY > 0) {
+          // Wheel scrolled down (Zoom out)
           return applicationModel.handleZoomOut(map);
-        }
-        else
+        } else if (deltaY < 0) {
+          // Wheel scrolled up (Zoom in)
+          return applicationModel.handleZoomIn(map);
+        } else {
+          // no zoom -> no reason to block
           return true;
+        }
       }
     }));
     return map;

--- a/UI/src/model/applicationModel.js
+++ b/UI/src/model/applicationModel.js
@@ -103,7 +103,7 @@
         var nextZoomLevel = zoomlevels.getViewZoom(map) + 1;
         var outOfEditableBoundaries = this.isOutOfEditableBoundaries(nextZoomLevel);
         if (!outOfEditableBoundaries) {
-          eventbus.trigger('zoomedWithinEditableBoundaries');
+          eventbus.trigger('zoomedIntoEditableBoundaries');
         }
         return true;
       },

--- a/UI/src/model/applicationModel.js
+++ b/UI/src/model/applicationModel.js
@@ -85,8 +85,15 @@
       isDirty: function() {
         return isDirty();
       },
-      isFeedbackState: function(){
-        return isFeedbackState();
+      handleZoomOut: function(map) {
+        var zoomLevel = zoomlevels.getViewZoom(map);
+        var canZoomOut = applicationModel.canZoomOut(zoomLevel);
+        if (canZoomOut) {
+          return true;
+        } else {
+          new Confirm();
+          return false;
+        }
       },
       canZoomOut: function(zoomLevel) {
         return !(isDirty() && (zoomLevel <= minDirtyZoomLevel));

--- a/UI/src/model/applicationModel.js
+++ b/UI/src/model/applicationModel.js
@@ -86,17 +86,32 @@
         return isDirty();
       },
       handleZoomOut: function(map) {
-        var zoomLevel = zoomlevels.getViewZoom(map);
-        var canZoomOut = applicationModel.canZoomOut(zoomLevel);
+        var nextZoomLevel = zoomlevels.getViewZoom(map) - 1;
+        var canZoomOut = this.canZoomOut(nextZoomLevel);
         if (canZoomOut) {
+          var outOfEditableBoundaries = this.isOutOfEditableBoundaries(nextZoomLevel);
+          if (outOfEditableBoundaries) {
+            eventbus.trigger('zoomedOutOfEditableBoundaries');
+          }
           return true;
         } else {
           new Confirm();
           return false;
         }
       },
+      handleZoomIn: function(map) {
+        var nextZoomLevel = zoomlevels.getViewZoom(map) + 1;
+        var outOfEditableBoundaries = this.isOutOfEditableBoundaries(nextZoomLevel);
+        if (!outOfEditableBoundaries) {
+          eventbus.trigger('zoomedWithinEditableBoundaries');
+        }
+        return true;
+      },
       canZoomOut: function(zoomLevel) {
-        return !(isDirty() && (zoomLevel <= minDirtyZoomLevel));
+        return !(isDirty() && (this.isOutOfEditableBoundaries(zoomLevel)));
+      },
+      isOutOfEditableBoundaries: function(zoomLevel) {
+        return (zoomLevel < minDirtyZoomLevel);
       },
       assetDragDelay: 100,
       assetGroupingDistance: 36,

--- a/UI/src/view/navigationpanel/editModeToggleButton.js
+++ b/UI/src/view/navigationpanel/editModeToggleButton.js
@@ -33,7 +33,7 @@
       toggleEditMode(true);
       disableEditMode(true);
     });
-    eventbus.on('zoomedWithinEditableBoundaries', function() {
+    eventbus.on('zoomedIntoEditableBoundaries', function() {
       disableEditMode(false);
     });
     var reset = function() {

--- a/UI/src/view/navigationpanel/editModeToggleButton.js
+++ b/UI/src/view/navigationpanel/editModeToggleButton.js
@@ -41,16 +41,13 @@
     };
 
     var toggleEditMode = function(mode) {
-
       toggleReadOnlyMode(mode);
     };
 
-    root.editModeToggleButtonInstance = {
+    return {
       element: element,
       reset: reset,
       toggleEditMode: toggleEditMode
     };
-
-    return root.editModeToggleButtonInstance;
   };
 }(this));

--- a/UI/src/view/navigationpanel/editModeToggleButton.js
+++ b/UI/src/view/navigationpanel/editModeToggleButton.js
@@ -21,23 +21,36 @@
       }
       button.text(mode ? 'Siirry muokkaustilaan' : 'Siirry katselutilaan');
     };
+    var disableEditMode = function(mode) {
+      button.prop('disabled', mode);
+    };
     button.click(function() {
       executeOrShowConfirmDialog(function() {
         toggleReadOnlyMode(!applicationModel.isReadOnly());
       });
+    });
+    eventbus.on('zoomedOutOfEditableBoundaries', function() {
+      toggleEditMode(true);
+      disableEditMode(true);
+    });
+    eventbus.on('zoomedWithinEditableBoundaries', function() {
+      disableEditMode(false);
     });
     var reset = function() {
       toggleReadOnlyMode(true);
     };
 
     var toggleEditMode = function(mode) {
+
       toggleReadOnlyMode(mode);
     };
 
-    return {
+    root.editModeToggleButtonInstance = {
       element: element,
       reset: reset,
       toggleEditMode: toggleEditMode
     };
+
+    return root.editModeToggleButtonInstance;
   };
 }(this));


### PR DESCRIPTION
Lisätty operaattorin toiveesta lisärajauksia zoomaukseen ja muokkaukseen:

- jos muokkaukset kesken ja yritetään zoomata hiirellä kauemmas kuin 1:20000 -> sama pop-up ilmestyy kuin zoom-näppäimellä yritettäessä
- jos ei muokkauksia kesken zoomatessa kauemmas kuin 1:20000 -> siirrytään automaattisesti katselutilaan ja muokkaustilaan siirtymisnappi disabloidaan
- kun zoomataan takaisin 1:20000 tai lähemmäs, muokkaustilaan siirtymisnappi avataan taas