### PR TITLE
 DROTH-4045 deletable speedLimit value should not be parsed to int

### DIFF
--- a/UI/src/view/workListView.js
+++ b/UI/src/view/workListView.js
@@ -97,7 +97,7 @@
               container: '#work-list',
               successCallback: function () {
                 $(".verificationCheckbox:checkbox:checked").each(function () {
-                  selected.push(parseInt(($(this).attr('value'))));
+                  selected.push($(this).attr('value'));
                 });
                 backend.deleteUnknownSpeedLimit(selected, function (){
                   new GenericConfirmPopup("Valitut tuntemattomat nopeusrajoitukset poistettu!", {container: '#work-list',type: "alert", okCallback: function() {location.reload();}});


### PR DESCRIPTION
Korjaa tiketin ensimmäisen bulletin, jossa työlistan kohteiden poisto ei toimi.

Tiketin toinen bullet päätettiin laajentaa omaksi tiketikseen, jotta saadaan muutokset toimimaan yhteneväisesti kaikille työlistoille.