### PR TITLE
 DROTH-2844 Removed selectionTool deactivation from layer stoppage

### DIFF
--- a/UI/src/view/providers/layer.js
+++ b/UI/src/view/providers/layer.js
@@ -38,7 +38,6 @@
     this.stop = function() {
       if (me.isStarted()) {
         me.removeLayerFeatures();
-        me.deactivateSelection();
         me.eventListener.stopListening(eventbus);
         me.eventListener.running = false;
       }


### PR DESCRIPTION
Operaattorien toiveesta toteutettu laajennus tiketille.

Kohteiden tulee olla deselektoitavissa (ei-valittavissa? valinta poistettavissa?) myös niillä tasoilla, joilla layerin muut toiminnot eivät ole käytössä.