### PR TITLE
 DROTH-2844 readded deactivation during stoppage

### DIFF
--- a/UI/src/view/providers/layer.js
+++ b/UI/src/view/providers/layer.js
@@ -38,6 +38,7 @@
     this.stop = function() {
       if (me.isStarted()) {
         me.removeLayerFeatures();
+        me.deactivateSelection();
         me.eventListener.stopListening(eventbus);
         me.eventListener.running = false;
       }


### PR DESCRIPTION
Operaattorin toiveesta viimeinen laajennus (kohteen valinta poistettavissa myös kauemmas zoomatessa) kumotaan, sillä se ei liity tiketin alkuperäiseen tapaukseen ja siitä syntyi bugi muualle käyttöliittymään. Mikäli laajennus halutaan myöhemmin toteuttaa, tehdään se omalla tiketillään.