### PR TITLE
DROTH-4072 Build auth token optional

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -19,7 +19,7 @@ object Digiroad2Build extends Build {
   val codeArtifactResolver = "digiroad--digiroad_maven_packages"
   val codeArtifactDomain = "digiroad-475079312496.d.codeartifact.eu-west-1.amazonaws.com"
   val awsCodeArtifactRepoURL: String = "https://digiroad-475079312496.d.codeartifact.eu-west-1.amazonaws.com/maven/digiroad_maven_packages/"
-  val awsCodeArtifactAuthToken: String = scala.sys.env("CODE_ARTIFACT_AUTH_TOKEN")
+  val awsCodeArtifactAuthToken: String = scala.sys.env.getOrElse("CODE_ARTIFACT_AUTH_TOKEN", null)
 
   lazy val geoJar =
     Project (


### PR DESCRIPTION
Muutettu CODE_ARTIFACT_AUTH_TOKEN env muuttujan käsittely valinnaiseksi, niin ei tarvitse aina asettaa kun buildaa projektia