### PR TITLE
 DROTH-4029 update aws sdk

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -14,7 +14,6 @@ object Digiroad2Build extends Build {
     * ScalaVersion 2.8.x does not support scala 2.11
     */
   val ScalatraVersion = "2.6.3"
-  //val AwsSdkVersion = "2.17.148"
   val AwsSdkVersion = "2.26.7"
   val jettyVersion = "9.2.30.v20200428"
   /**

--- a/project/build.scala
+++ b/project/build.scala
@@ -3,7 +3,6 @@ import sbt.Keys.{unmanagedResourceDirectories, _}
 import org.scalatra.sbt._
 import sbtassembly.Plugin.AssemblyKeys._
 import sbtassembly.Plugin.{MergeStrategy, PathList}
-import org.scalatra.sbt.PluginKeys._
 
 object Digiroad2Build extends Build {
   val Organization = "fi.liikennevirasto"
@@ -15,8 +14,8 @@ object Digiroad2Build extends Build {
     * ScalaVersion 2.8.x does not support scala 2.11
     */
   val ScalatraVersion = "2.6.3"
-  
-  val AwsSdkVersion = "2.17.148"
+  //val AwsSdkVersion = "2.17.148"
+  val AwsSdkVersion = "2.26.7"
   val jettyVersion = "9.2.30.v20200428"
   /**
     * ScalaVersion 2.6.x and 2.7.x is no compatible with newer json4s. 


### PR DESCRIPTION
https://mvnrepository.com/artifact/software.amazon.awssdk/aws-core/2.26.7 

com.google.guava haavoittuvuus säilyy. 
https://mvnrepository.com/artifact/com.google.guava/guava/15.0
Netty korjaantuu.