### PR TITLE
 DROTH-4026 Added null checks for serialization

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -108,6 +108,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     {
       case JString(dateTimeStr) =>
         DateTimePropertyFormat.parseDateTime(dateTimeStr)
+      case JNull => null
     },
     {
       case dateTime: DateTime => JString(dateTime.toString(DateTimePropertyFormat))
@@ -122,36 +123,42 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
 
   case object WidthLimitReasonSerializer extends CustomSerializer[WidthLimitReason](format => ({
     case JInt(lg) => WidthLimitReason.apply(lg.toInt)
+    case JNull => WidthLimitReason.Unknown
   }, {
     case lg: WidthLimitReason => JInt(lg.value)
   }))
 
   case object LinkGeomSourceSerializer extends CustomSerializer[LinkGeomSource](format => ({
     case JInt(lg) => LinkGeomSource.apply(lg.toInt)
+    case JNull => LinkGeomSource.Unknown
   }, {
     case lg: LinkGeomSource => JInt(lg.value)
   }))
 
   case object TrafficDirectionSerializer extends CustomSerializer[TrafficDirection](format => ( {
     case JString(direction) => TrafficDirection(direction)
+    case JNull => TrafficDirection.UnknownDirection
   }, {
     case t: TrafficDirection => JString(t.toString)
   }))
 
   case object DayofWeekSerializer extends CustomSerializer[ValidityPeriodDayOfWeek](format => ( {
     case JString(dayOfWeek) => ValidityPeriodDayOfWeek(dayOfWeek)
+    case JNull => ValidityPeriodDayOfWeek.Unknown
   }, {
     case d: ValidityPeriodDayOfWeek => JString(d.toString)
   }))
 
   case object LinkTypeSerializer extends CustomSerializer[LinkType](format => ( {
     case JInt(linkType) => LinkType(linkType.toInt)
+    case JNull => UnknownLinkType
   }, {
     case lt: LinkType => JInt(BigInt(lt.value))
   }))
 
   case object AdministrativeClassSerializer extends CustomSerializer[AdministrativeClass](format => ( {
     case JString(administrativeClass) => AdministrativeClass(administrativeClass)
+    case JNull => Unknown
   }, {
     case ac: AdministrativeClass => JString(ac.toString)
   }))
@@ -164,6 +171,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
         val groupedId: Long =  (jsonObj \ "groupedId").extractOrElse(0)
 
         SimplePointAssetProperty(publicId, propertyValue, groupedId)
+      case JNull => null
     },
       {
         case tv : SimplePointAssetProperty => Extraction.decompose(tv)
@@ -171,6 +179,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
 
   case object AdditionalInfoClassSerializer extends CustomSerializer[AdditionalInformation](format => ( {
     case JString(additionalInfo) => AdditionalInformation(additionalInfo)
+    case JNull => null
   }, {
     case ai: AdditionalInformation => JString(ai.toString)
   }))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/RoadLinkChangeClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/RoadLinkChangeClient.scala
@@ -84,10 +84,12 @@ class RoadLinkChangeClient {
     {
       case JString(stringValue) =>
         RoadLinkChangeType(stringValue)
+      case JNull => RoadLinkChangeType.Unknown
     },
     {
       case changeType: RoadLinkChangeType =>
         JObject(JField("changeType", JString(changeType.value)))
+      case _ => JNull
     }
   ))
 
@@ -100,6 +102,7 @@ class RoadLinkChangeClient {
     {
       case adminClass: AdministrativeClass =>
         JObject(JField("adminClass", JInt(adminClass.value)))
+      case _ => JNull
     }
   ))
 
@@ -174,10 +177,12 @@ class RoadLinkChangeClient {
     {
       case JString(lineString) =>
         lineStringToPoints(lineString)
+      case JNull => null
     },
     {
       case points: List[Point] =>
         JObject(JField("geometry", JString(""))) // not implemented until reverse operation is needed
+      case _ => JNull
     }
   ))
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/TrafficSignManager.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/TrafficSignManager.scala
@@ -11,7 +11,7 @@ import fi.liikennevirasto.digiroad2.service.linearasset.ManoeuvreService
 import fi.liikennevirasto.digiroad2.service.pointasset.TrafficSignInfo
 import org.joda.time.DateTime
 import org.json4s.jackson.Json
-import org.json4s.{CustomSerializer, DefaultFormats, Formats, JInt, JString}
+import org.json4s.{CustomSerializer, DefaultFormats, Formats, JInt, JNull, JString}
 
 
 object TrafficSignManager {
@@ -47,14 +47,17 @@ case class TrafficSignManager(manoeuvreService: ManoeuvreService, roadLinkServic
 
   case object LinkGeomSourceSerializer extends CustomSerializer[LinkGeomSource](format => ({
     case JInt(lg) => LinkGeomSource.apply(lg.toInt)
+    case JNull => LinkGeomSource.Unknown
   }, {
     case lg: LinkGeomSource => JInt(lg.value)
+    case _ => JNull
   }))
 
   case object DateTimeSerializer extends CustomSerializer[DateTime](format => ( {
     case _ => throw new NotImplementedError("DateTime deserialization")
   }, {
     case d: DateTime => JString(DateParser.dateToString(d, DateParser.DateTimePropertyFormat))
+    case JNull => null
   }))
 
   protected implicit val jsonFormats: Formats = DefaultFormats + LinkGeomSourceSerializer + DateTimeSerializer

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/TrafficSignLinearGenerator.scala
@@ -17,7 +17,7 @@ import fi.liikennevirasto.digiroad2.service.pointasset.TrafficSignService
 import fi.liikennevirasto.digiroad2.user.UserProvider
 import org.joda.time.DateTime
 import org.json4s.jackson.Json
-import org.json4s.{CustomSerializer, DefaultFormats, Extraction, Formats, JInt, JObject}
+import org.json4s.{CustomSerializer, DefaultFormats, Extraction, Formats, JInt, JNull, JObject}
 import org.slf4j.LoggerFactory
 
 import scala.util.Try
@@ -55,16 +55,20 @@ trait TrafficSignLinearGenerator {
         val numCharacterMax = (jsonObj \ "numCharacterMax").extractOpt[Int]
 
         Property(id, publicId, propertyType, required, values, numCharacterMax)
+      case JNull => null
     },
       {
         case tv : Property =>
           Extraction.decompose(tv)
+        case _ => JNull
       }))
 
   case object LinkGeomSourceSerializer extends CustomSerializer[LinkGeomSource](format => ({
     case JInt(lg) => LinkGeomSource.apply(lg.toInt)
+    case JNull => LinkGeomSource.Unknown
   }, {
     case lg: LinkGeomSource => JInt(lg.value)
+    case _ => JNull
   }))
 
   protected implicit val jsonFormats: Formats = DefaultFormats + TrafficSignSerializer + LinkGeomSourceSerializer


### PR DESCRIPTION
Lisää null-checkejä serialisaatioon.

Digiroad2Api.scalan deserialisaatio (case _ => JNull) aheutti jotain häikkää ja kaatoi testejä. Ei ollut aikaa perehtyä siihen ja sen tarpeeseen tarkemmin, joten jätin sen pois. Tarvetta voi analysoida paremmalla ajalla.