### PR TITLE
DROTH-3966 remove animal warnings

### DIFF
--- a/UI/src/enumerations.js
+++ b/UI/src/enumerations.js
@@ -93,7 +93,6 @@
       Manoeuvres: { typeId: 380, geometryType: 'linear', label: 'Manoeuvre', layerName: 'manoeuvre', nameFI: 'Kääntymisrajoitus' },
       CareClass: { typeId: 390, geometryType: 'linear', label: 'CareClass', layerName: 'careClass', nameFI: 'Hoitoluokat' },
       CarryingCapacity: { typeId: 400, geometryType: 'linear', label: 'CarryingCapacity', layerName: 'carryingCapacity', nameFI: 'Kantavuus' },
-      AnimalWarnings: { typeId: 410, geometryType: 'linear', label: 'AnimalWarnings', layerName: 'animalWarnings', nameFI: 'Elainvaroitukset' },
       RoadWorksAsset: { typeId: 420, geometryType: 'linear', label: 'RoadWorks', layerName: 'roadWorks', nameFI: 'Tietyot' },
       ParkingProhibition: { typeId: 430, geometryType: 'linear', label: 'ParkingProhibition', layerName: 'parkingProhibition', nameFI: 'Pysäköintikielto' },
       CyclingAndWalking: { typeId: 440, geometryType: 'linear', label: 'CyclingAndWalking', layerName: 'cyclingAndWalking', nameFI: 'Käpy tietolaji' },

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -294,7 +294,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
       case Prohibition.typeId => prohibitionService
       case HazmatTransportProhibition.typeId => hazmatTransportProhibitionService
       case EuropeanRoads.typeId | ExitNumbers.typeId => textValueLinearAssetService
-      case CareClass.typeId | CarryingCapacity.typeId | AnimalWarnings.typeId | LitRoad.typeId => dynamicLinearAssetService
+      case CareClass.typeId | CarryingCapacity.typeId | LitRoad.typeId => dynamicLinearAssetService
       case HeightLimitInfo.typeId => linearHeightLimitService
       case LengthLimit.typeId => linearLengthLimitService
       case WidthLimitInfo.typeId => linearWidthLimitService
@@ -903,7 +903,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
       tags "Integration API (Kalpa API)"
       summary "List all valid assets on a specific municipality."
       authorizations "Contact your service provider for more information"
-      description "Example URL: /api/integration/animal_warnings?municipality=749"
+      description "Example URL: /api/integration/speed_limits?municipality=749"
       )
 
   get("/:assetType", operation(getAssetsByTypeMunicipality)) {
@@ -951,7 +951,6 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
           case "carrying_capacity" => carryingCapacitiesToApi(municipalityNumber)
           case "care_classes" =>  linearAssetsToApi(CareClass.typeId, municipalityNumber)
           case "traffic_signs" => trafficSignsToApi(trafficSignService.getByMunicipality(municipalityNumber))
-          case "animal_warnings" => linearAssetsToApi(AnimalWarnings.typeId, municipalityNumber)
           case "road_works_asset" => roadWorksToApi(municipalityNumber)
           case "parking_prohibitions" => parkingProhibitionsToApi(municipalityNumber)
           case "cycling_and_walking" => linearAssetsToApi(CyclingAndWalking.typeId, municipalityNumber)

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/IntegrationApiSpec.scala
@@ -63,7 +63,7 @@ class IntegrationApiSpec extends FunSuite with ScalatraSuite with BeforeAndAfter
         case Prohibition.typeId => prohibitionService
         case HazmatTransportProhibition.typeId => hazmatTransportProhibitionService
         case EuropeanRoads.typeId | ExitNumbers.typeId => textValueLinearAssetService
-        case CareClass.typeId | CarryingCapacity.typeId | AnimalWarnings.typeId | LitRoad.typeId => testDynamicLinearAssetService
+        case CareClass.typeId | CarryingCapacity.typeId | LitRoad.typeId => testDynamicLinearAssetService
         case LengthLimit.typeId => linearLengthLimitService
         case TotalWeightLimit.typeId => testLinearTotalWeightLimitService
         case TrailerTruckWeightLimit.typeId => linearTrailerTruckWeightLimitService

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/asset/asset.scala
@@ -401,27 +401,6 @@ object ServicePointsClass {
   case object Unknown extends ServicePointsClass { def value = 99;  def isAuthorityData = true; val labelName = "Unknown";}
 }
 
-
-/**
-  * Values for AnimalWarningTypes types enumeration
-  */
-sealed trait AnimalWarningsType {
-  def value: Int
-  def typeDescription: String
-}
-object AnimalWarningsType {
-  val values = Set(MooseWarningArea, MooseFence, DeerWarningArea, Unknown)
-
-  def apply(value: Int): AnimalWarningsType = {
-    values.find(_.value == value).getOrElse(Unknown)
-  }
-
-  case object MooseWarningArea extends AnimalWarningsType { def value = 1; def typeDescription = "Moose Warning Area";}
-  case object MooseFence extends AnimalWarningsType { def value = 2; def typeDescription = "Moose Fence";}
-  case object DeerWarningArea extends AnimalWarningsType { def value = 3; def typeDescription = "Deer Warning Area";}
-  case object Unknown extends AnimalWarningsType { def value = 99;  def typeDescription = "Unknown";}
-}
-
 sealed trait TimePeriodClass {
   def value: Int
 
@@ -1009,7 +988,7 @@ object AssetTypeInfo {
                     TrafficVolume, WinterSpeedLimit, Prohibition, PedestrianCrossings, HazmatTransportProhibition, Obstacles,
                     RailwayCrossings, DirectionalTrafficSigns, ServicePoints, EuropeanRoads, ExitNumbers, TrafficLights,
                     MaintenanceRoadAsset, TrafficSigns, StateSpeedLimit, TrWeightLimit, TrTrailerTruckWeightLimit, TrAxleWeightLimit,
-                    TrBogieWeightLimit, TrHeightLimit, TrWidthLimit, Manoeuvres, CareClass, CarryingCapacity, AnimalWarnings, RoadWorksAsset,
+                    TrBogieWeightLimit, TrHeightLimit, TrWidthLimit, Manoeuvres, CareClass, CarryingCapacity, RoadWorksAsset,
                     ParkingProhibition, CyclingAndWalking, Lanes, RoadLinkProperties,
                     UnknownAssetTypeId)
 
@@ -1087,7 +1066,6 @@ case object TrWidthLimit extends  AssetTypeInfo {val typeId = 370; def geometryT
 case object Manoeuvres extends AssetTypeInfo { val typeId = 380; def geometryType = "linear"; val label = "Manoeuvre"; val layerName = "manoeuvre"; val nameFI = "Kääntymisrajoitus" }
 case object CareClass extends  AssetTypeInfo {val typeId = 390; def geometryType = "linear"; val label = "CareClass"; val layerName = "careClass"; val nameFI = "Hoitoluokat"}
 case object CarryingCapacity extends AssetTypeInfo { val typeId = 400; def geometryType = "linear"; val label = "CarryingCapacity" ; val layerName = "carryingCapacity"; val nameFI = "Kantavuus"}
-case object AnimalWarnings extends AssetTypeInfo { val typeId = 410; def geometryType = "linear"; val label = "AnimalWarnings" ; val layerName = "animalWarnings"; val nameFI = "Elainvaroitukset"}
 case object RoadWorksAsset extends AssetTypeInfo { val typeId = 420; def geometryType = "linear"; val label = "RoadWorks" ; val layerName = "roadWorks"; val nameFI = "Tietyot"}
 case object ParkingProhibition extends AssetTypeInfo { val typeId = 430; def geometryType = "linear"; val label = "ParkingProhibition" ; val layerName = "parkingProhibition"; val nameFI = "Pysäköintikielto"}
 case object CyclingAndWalking extends AssetTypeInfo { val typeId = 440; def geometryType = "linear"; val label = "CyclingAndWalking" ; val layerName = "cyclingAndWalking"; val nameFI = "Käpy tietolaji"}

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_42__delete_animal_warnings.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_42__delete_animal_warnings.sql
@@ -1,0 +1,4 @@
+delete from enumerated_value where property_id in (select id from property where asset_type_id = 410);
+delete from property where asset_type_id = 410;
+delete from localized_string where value_fi = 'Hirvivaro';
+delete from asset_type where id = 410;


### PR DESCRIPTION
Poistetaan eläinvaroitukset koodista sekä migraatiolla luodut arvot kannasta uudella migraatiolla. Assettien poistoa varten tehdyt sql:t kirjattu tikettiin, joten katselmoija voisi katsoa ne samalla.