### PR TITLE
DROTH-3338 set experimental assets empty after trAssets removal

### DIFF
--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -14,7 +14,7 @@
     var selectedManoeuvreSource = new SelectedManoeuvreSource(manoeuvresCollection);
     var instructionsPopup = new InstructionsPopup($('.digiroad2'));
     var assetConfiguration = new AssetTypeConfiguration();
-    var enabledExperimentalAssets = isExperimental ? assetConfiguration.experimentalAssetsConfig : [];
+    var enabledExperimentalAssets = [];
     var enabledLinearAssetSpecs = assetConfiguration.linearAssetsConfig.concat(enabledExperimentalAssets);
     var authorizationPolicy = new AuthorizationPolicy();
     var municipalitySituationCollection = new MunicipalitySituationCollection(backend);


### PR DESCRIPTION
UI:n integraatiotestit taisi hajota, kun experimentalAssetsConfig jäi poistojen jälkeen undefined. Muutoksen jälkeen testit meni ainakin lokaalisti läpi.