### PR TITLE
Droth 4050 faster speed limits get

### DIFF
--- a/UI/src/controller/speedLimitsCollection.js
+++ b/UI/src/controller/speedLimitsCollection.js
@@ -49,8 +49,8 @@
           speedLimit.endMeasure.toFixed(2);
     };
 
-    this.fetch = function(boundingBox, center) {
-      return backend.getSpeedLimits(boundingBox, applicationModel.getWithRoadAddress()).then(function(speedLimitGroups) {
+    this.fetch = function(boundingBox, center, useExperimentalFetch) {
+      return backend.getSpeedLimits(boundingBox, applicationModel.getWithRoadAddress(), useExperimentalFetch).then(function(speedLimitGroups) {
         var partitionedSpeedLimitGroups = _.groupBy(speedLimitGroups, function(speedLimitGroup) {
           return _.some(speedLimitGroup, function(speedLimit) { return _.has(speedLimit, "id"); });
         });

--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -155,9 +155,12 @@
       });
     });
 
-    this.getSpeedLimits = latestResponseRequestor(function(boundingBox, withRoadAddress) {
+    this.getSpeedLimits = latestResponseRequestor(function(boundingBox, withRoadAddress, useExperimental) {
+      var baseURL;
+      if(useExperimental) baseURL = 'api/speedlimits_experimental?bbox=';
+      else baseURL = 'api/speedlimits?bbox=';
       return validateBoundingBox(boundingBox,{
-        url: 'api/speedlimits?bbox=' + boundingBox + '&withRoadAddress=' + withRoadAddress
+        url: baseURL + boundingBox + '&withRoadAddress=' + withRoadAddress
       });
     });
 

--- a/UI/src/view/linear_asset/speedLimitLayer.js
+++ b/UI/src/view/linear_asset/speedLimitLayer.js
@@ -12,6 +12,7 @@ window.SpeedLimitLayer = function(params) {
   var isActiveTrafficSigns = false;
   var extraEventListener = _.extend({running: false}, eventbus);
   var authorizationPolicy = new LinearAssetAuthorizationPolicy();
+  var useExperimentalFetch = false;
 
   Layer.call(this, layerName, roadLayer);
   this.activateSelection = function() {
@@ -60,7 +61,7 @@ window.SpeedLimitLayer = function(params) {
   this.refreshView = function(event) {
     vectorLayer.setVisible(true);
     adjustStylesByZoomLevel(zoomlevels.getViewZoom(map));
-    collection.fetch(map.getView().calculateExtent(map.getSize()), map.getView().getCenter()).then(function() {
+    collection.fetch(map.getView().calculateExtent(map.getSize()), map.getView().getCenter(), useExperimentalFetch).then(function() {
       eventbus.trigger('layer:speedLimit:' + event);
     });
     if (isActive) {
@@ -320,6 +321,8 @@ window.SpeedLimitLayer = function(params) {
     eventListener.listenTo(eventbus, 'speedLimits:drawSpeedLimitsHistory', drawSpeedLimitsHistory);
     eventListener.listenTo(eventbus, 'speedLimits:hideSpeedLimitsHistory', hideSpeedLimitsHistory);
     eventListener.listenTo(eventbus, 'speedLimits:showSpeedLimitsHistory', showSpeedLimitsHistory);
+    eventListener.listenTo(eventbus, 'speedLimits:enableExperimentalFetch', enableExperimentalFetch);
+    eventListener.listenTo(eventbus, 'speedLimits:disableExperimentalFetch', disableExperimentalFetch);
     eventListener.listenTo(eventbus, 'toggleWithRoadAddress', refreshSelectedView);
     eventListener.listenTo(eventbus, 'speedLimit:unselect speedLimit:massUpdateUnselected', handleSpeedLimitUnselected);
   };
@@ -352,6 +355,16 @@ window.SpeedLimitLayer = function(params) {
   var showSpeedLimitsComplementary = function() {
     collection.activeComplementary(true);
     trafficSignReadOnlyLayer.showTrafficSignsComplementary();
+    me.refreshView();
+  };
+
+  var enableExperimentalFetch = function() {
+    useExperimentalFetch = true;
+    me.refreshView();
+  };
+
+  var disableExperimentalFetch = function() {
+    useExperimentalFetch = false;
     me.refreshView();
   };
 

--- a/UI/src/view/navigationpanel/speedLimitBox.js
+++ b/UI/src/view/navigationpanel/speedLimitBox.js
@@ -44,7 +44,13 @@
         '</div>'
       ].join('');
 
-      return speedLimitHistoryCheckBox.concat(speedLimitComplementaryCheckBox).concat(speedLimitSignsCheckBox);
+      var speedLimitExperimentalFetchCheckBox = [
+        '<div class="check-box-container">' +
+        '<input id="experimentalFetchCheckbox" type="checkbox" /> <lable>Käytä kokeellista hakua</lable>' +
+        '</div>'
+      ].join('');
+
+      return speedLimitHistoryCheckBox.concat(speedLimitComplementaryCheckBox).concat(speedLimitSignsCheckBox).concat(speedLimitExperimentalFetchCheckBox);
 
     };
 
@@ -96,6 +102,15 @@
           eventbus.trigger('speedLimits:showSpeedLimitsHistory');
         } else {
           eventbus.trigger('speedLimits:hideSpeedLimitsHistory');
+        }
+      });
+
+      $(me.expanded).find('#experimentalFetchCheckbox').on('change', function (event) {
+        var eventTarget = $(event.currentTarget);
+        if (eventTarget.prop('checked')) {
+          eventbus.trigger('speedLimits:enableExperimentalFetch');
+        } else {
+          eventbus.trigger('speedLimits:disableExperimentalFetch');
         }
       });
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1373,7 +1373,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       val boundingRectangle = constructBoundingRectangle(bbox)
       validateBoundingBox(boundingRectangle)
       val speedLimits = speedLimitService.getSpeedLimitsByBboxExperimental(boundingRectangle)
-      speedLimits.map { speedLimitAsset =>
+      speedLimits.map { speedLimitGroup => speedLimitGroup.map {
+        speedLimitAsset =>
           Map(
             "id" -> (if (speedLimitAsset.id == 0) None else Some(speedLimitAsset.id)),
             "linkId" -> speedLimitAsset.linkId,
@@ -1392,6 +1393,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             "municipalityCode" -> extractIntValue(speedLimitAsset.attributes, "municipality"),
             "constructionType" -> extractIntValue(speedLimitAsset.attributes, "constructionType")
           )
+      }
       }
     } getOrElse {
       BadRequest("Missing mandatory 'bbox' parameter")

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1368,6 +1368,36 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     }
   }
 
+  get("/speedlimits_experimental") {
+    params.get("bbox").map { bbox =>
+      val boundingRectangle = constructBoundingRectangle(bbox)
+      validateBoundingBox(boundingRectangle)
+      val speedLimits = speedLimitService.getSpeedLimitsByBboxExperimental(boundingRectangle)
+      speedLimits.map { speedLimitAsset =>
+          Map(
+            "id" -> (if (speedLimitAsset.id == 0) None else Some(speedLimitAsset.id)),
+            "linkId" -> speedLimitAsset.linkId,
+            "sideCode" -> speedLimitAsset.sideCode,
+            "trafficDirection" -> speedLimitAsset.trafficDirection,
+            "value" -> speedLimitService.getSpeedLimitValue(speedLimitAsset.value).map(x => Map("isSuggested" -> x.isSuggested, "value" -> x.value)),
+            "points" -> speedLimitAsset.geometry,
+            "startMeasure" -> speedLimitAsset.startMeasure,
+            "endMeasure" -> speedLimitAsset.endMeasure,
+            "modifiedBy" -> speedLimitAsset.modifiedBy,
+            "modifiedAt" -> speedLimitAsset.modifiedDateTime,
+            "createdBy" -> speedLimitAsset.createdBy,
+            "createdAt" -> speedLimitAsset.createdDateTime,
+            "linkSource" -> speedLimitAsset.linkSource.value,
+            "administrativeClass" -> speedLimitAsset.administrativeClass,
+            "municipalityCode" -> extractIntValue(speedLimitAsset.attributes, "municipality"),
+            "constructionType" -> extractIntValue(speedLimitAsset.attributes, "constructionType")
+          )
+      }
+    } getOrElse {
+      BadRequest("Missing mandatory 'bbox' parameter")
+    }
+  }
+
   get("/speedlimits") {
     val municipalities: Set[Int] = Set()
 

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -30,6 +30,8 @@ case class RoadLinkProperties(linkId: String,
 
 case class TinyRoadLink(linkId: String)
 
+case class RoadLinkForUnknownGeneration(linkId: String, length:Double, geometry: Seq[Point], trafficDirection:TrafficDirection, administrativeClass:AdministrativeClass, linkSource:LinkGeomSource)
+
 case class RoadLink(linkId: String, geometry: Seq[Point],
                     length: Double, administrativeClass: AdministrativeClass,
                     functionalClass: Int, trafficDirection: TrafficDirection,

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
@@ -1,5 +1,6 @@
 package fi.liikennevirasto.digiroad2.linearasset
 
+import fi.liikennevirasto.digiroad2.Point
 import fi.liikennevirasto.digiroad2.asset._
 import org.joda.time.DateTime
 
@@ -9,3 +10,9 @@ case class UnknownSpeedLimit(linkId: String, municipalityCode: Int, administrati
 case class SpeedLimitRow(id: Long, linkId: String, sideCode: SideCode, value: Option[Int], startMeasure: Double, endMeasure: Double,
                                modifiedBy: Option[String], modifiedDate: Option[DateTime], createdBy: Option[String], createdDate: Option[DateTime],
                                timeStamp: Long, geomModifiedDate: Option[DateTime], expired: Boolean = false, linkSource: LinkGeomSource, publicId: String)
+
+case class SpeedLimitRowExperimental(id: Long, linkId: String, sideCode: SideCode, trafficDirection: TrafficDirection,
+                                     value: Option[Int], geometry: Seq[Point], startMeasure: Double, endMeasure: Double,
+                                     modifiedBy: Option[String], modifiedDate: Option[DateTime], createdBy: Option[String],
+                                     createdDate: Option[DateTime], administrativeClass: AdministrativeClass, municipalityCode: Int,
+                                     constructionType: ConstructionType, linkSource: LinkGeomSource, publicId: String)

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
@@ -12,7 +12,7 @@ case class SpeedLimitRow(id: Long, linkId: String, sideCode: SideCode, value: Op
                                timeStamp: Long, geomModifiedDate: Option[DateTime], expired: Boolean = false, linkSource: LinkGeomSource, publicId: String)
 
 case class SpeedLimitRowExperimental(id: Long, linkId: String, sideCode: SideCode, trafficDirection: TrafficDirection,
-                                     value: Option[Int], geometry: Seq[Point], startMeasure: Double, endMeasure: Double,
+                                     value: Option[Int], geometry: Seq[Point], startMeasure: Double, endMeasure: Double, roadLinkLength: Double,
                                      modifiedBy: Option[String], modifiedDate: Option[DateTime], createdBy: Option[String],
                                      createdDate: Option[DateTime], administrativeClass: AdministrativeClass, municipalityCode: Int,
                                      constructionType: ConstructionType, linkSource: LinkGeomSource, publicId: String)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -438,7 +438,7 @@ class RoadLinkDAO {
     KgvUtil.extractFeatureClass(code)
   }
 
-  protected def extractTrafficDirection(code: Option[Int]): TrafficDirection = {
+  def extractTrafficDirection(code: Option[Int]): TrafficDirection = {
     code match {
       case Some(0) => TrafficDirection.BothDirections
       case Some(1) => TrafficDirection.TowardsDigitizing
@@ -451,7 +451,7 @@ class RoadLinkDAO {
     KgvUtil.extractModifiedAt(createdDate,lastEdited)
   }
 
-  protected def extractGeometry(data: Object): List[List[Double]] = {
+  def extractGeometry(data: Object): List[List[Double]] = {
     val geometry = data.asInstanceOf[PGobject]
     if (geometry == null) Nil
     else {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -119,7 +119,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
           AND kgv.expired_date IS NULL
           AND kgv.constructiontype NOT IN (1, 2)
           AND kgv.mtkclass NOT IN (12318, 12312) -- Filter out HardShoulder and WinterRoad links
-          AND (kgv.adminclass != 1 OR (kgv.adminclass = 1 AND lt.link_type NOT IN (7, 8, 9, 10, 12, 13, 14, 15, 21))) -- Filter out PedestrianZone and CableFerry links
+          AND (kgv.adminclass != 1 OR (kgv.adminclass = 1 AND lt.link_type NOT IN (7, 8, 9, 10, 12, 13, 14, 15, 21))) -- Filter out unallowed types on state roads
           AND fc.functional_class IN (1, 2, 3, 4, 5, 6) -- Filter by allowed FunctionalClass values
       )
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -59,11 +59,11 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       speedLimitDao.getLinksWithLength(id)
   }
 
-  def getSpeedLimitsByBboxExperimental(bbox: BoundingRectangle): Seq[PieceWiseLinearAsset] = {
+  def getSpeedLimitsByBboxExperimental(bbox: BoundingRectangle): Seq[Seq[PieceWiseLinearAsset]] = {
     val speedLimits = withDynTransaction {
       speedLimitDao.fetchByBBoxExperimental(bbox)
     }
-    speedLimits
+    LinearAssetPartitioner.partition(speedLimits)
   }
 
   def getSpeedLimitAssetsByIds(ids: Set[Long], newTransaction: Boolean = true): Seq[PieceWiseLinearAsset] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -60,10 +60,21 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
   }
 
   def getSpeedLimitsByBboxExperimental(bbox: BoundingRectangle): Seq[Seq[PieceWiseLinearAsset]] = {
-    val speedLimits = withDynTransaction {
+    val (speedLimits, emptyRoadLinks) = withDynTransaction {
       speedLimitDao.fetchByBBoxExperimental(bbox)
     }
-    LinearAssetPartitioner.partition(speedLimits)
+    val unknownSpeedLimits = emptyRoadLinkToUnknownSpeedLimit(emptyRoadLinks)
+    LinearAssetPartitioner.partition(speedLimits ++ unknownSpeedLimits)
+  }
+
+  def emptyRoadLinkToUnknownSpeedLimit(emptyRoadLinks: Seq[RoadLinkForUnknownGeneration]): Seq[PieceWiseLinearAsset] = {
+    emptyRoadLinks.map(rl => {
+      PieceWiseLinearAsset(id = 0L, linkId = rl.linkId, sideCode = SideCode.BothDirections, value = None, geometry = rl.geometry,
+        expired = false, startMeasure = 0.0, endMeasure = rl.length, endpoints = Set(rl.geometry.head, rl.geometry.last),
+        modifiedBy = None, modifiedDateTime = None, createdBy = None, createdDateTime = None, typeId = SpeedLimitAsset.typeId,
+        trafficDirection = rl.trafficDirection, timeStamp = 0L, geomModifiedDate = None, linkSource = rl.linkSource,
+        administrativeClass = rl.administrativeClass, attributes = Map.empty, verifiedBy = None, verifiedDate = None, informationSource = None)
+    })
   }
 
   def getSpeedLimitAssetsByIds(ids: Set[Long], newTransaction: Boolean = true): Seq[PieceWiseLinearAsset] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -59,6 +59,13 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       speedLimitDao.getLinksWithLength(id)
   }
 
+  def getSpeedLimitsByBboxExperimental(bbox: BoundingRectangle): Seq[PieceWiseLinearAsset] = {
+    val speedLimits = withDynTransaction {
+      speedLimitDao.fetchByBBoxExperimental(bbox)
+    }
+    speedLimits
+  }
+
   def getSpeedLimitAssetsByIds(ids: Set[Long], newTransaction: Boolean = true): Seq[PieceWiseLinearAsset] = {
     if (newTransaction)
       withDynTransaction {


### PR DESCRIPTION
Lisätty kokeellinen tapa hakea UI:lle tarvittavat tiedot nopeusrajoitusten piirtämistä varten. Haetaan yhdellä SQL kyselyllä tielinkit ja niillä mahdollisesti olevat nopeusrajoitus assetit kaikkine tietoineen. 
Nopeusrajoituksilla tielinkin rajoitus ei voi olla osittain tuntematon, joten lisätty yksinkertainen toteutus tyhjän linkin muuntamiseksi tuntemattomaksi assetiksi.
Lisätty SpeedLimitBox checkBox kokeellisen haun käyttämistä varten. 
Testattu lokaalisti devi kantaa vasten SSH putken lävitse, kuopiossa 200m zoomilla yli 2x nopeampi