### PR TITLE
DROTH-4083 allow csv import to state roads

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
@@ -30,7 +30,7 @@ class ObstaclesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: D
       val position = getCoordinatesFromProperties(csvProperties)
       val obstacleType = getPropertyValue(csvProperties, "type").asInstanceOf[String].toInt
 
-      val nearestRoadLink = nearbyLinks.filter(_.administrativeClass != State).minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
+      val nearestRoadLink = nearbyLinks.minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
 
       val floating = checkMinimumDistanceFromRoadLink(position, nearestRoadLink.geometry)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/RailwayCrossingCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/RailwayCrossingCsvImporter.scala
@@ -35,7 +35,7 @@ class RailwayCrossingCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusI
       val safetyEquipment = getPropertyValue(csvProperties, "safety equipment").asInstanceOf[String].toInt
       val optName = getPropertyValueOption(csvProperties, "name").map(_.toString)
 
-      val nearestRoadLink = nearbyLinks.filter(_.administrativeClass != State).minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
+      val nearestRoadLink = nearbyLinks.minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
 
       val floating = checkMinimumDistanceFromRoadLink(position, nearestRoadLink.geometry)
 


### PR DESCRIPTION
Virheitä aiheuttaneet csv:t menee nyt devillä läpi (ei kaadu). Pistotarkistuksilla katsottu, että este/tasoristeys luodaan onnistuneesti, jos deviltä löytyy koordinaateille tielinkki. Kaikilla koordinaateilla ei ole devillä linkkiä.