### PR TITLE
 DROTH-3956 more test logging

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -423,6 +423,7 @@ class RoadLinkPropertyUpdater {
   }
 
   def performIncompleteLinkUpdate(incompleteLinks: Seq[IncompleteLink]) = {
+    incompleteLinks.take(25).foreach(link => logger.info(s"TEST LOG sample incomplete link id: ${link.linkId}"))
     val roadLinkData = roadLinkService.getExistingAndExpiredRoadLinksByLinkIds(incompleteLinks.map(_.linkId).toSet, false)
     val incompleteLinksInUse = incompleteLinks.filter(il => incompleteLinkIsInUse(il, roadLinkData))
     logger.info(s"TEST LOG Total of ${incompleteLinks.size} incomplete links generated in process, " +


### PR DESCRIPTION
roadLinkService.getExistingAndExpiredRoadLinksByLinkIds(incompleteLinks.map(_.linkId).toSet, false)

palauttaa 0 linkkiä, eli yksikään samuutuksessa generoitu puutteellinen linkki ei näyttäisi olevan käytössä. Tulostellaan luotuja puuttellisia linkkejä manuaalista tarkistusta varten.