### PR TITLE
Droth 3956 road link property updater performance improvements

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -1279,46 +1279,39 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
 
   def getRoadLinkValuesMass(linkIds: Set[String]): RoadLinkValueCollection = {
     LogUtils.time(logger, s"TEST LOG getRoadLinkValuesMass for ${linkIds.size} links", startLogging = true) {
-      /*val functionalClassMap = FunctionalClassDao.getExistingValues(linkIds)
-      val linkTypeMap = LinkTypeDao.getExistingValues(linkIds)
-      val trafficDirectionMap = TrafficDirectionDao.getExistingValues(linkIds)
-      val adminClassMap = AdministrativeClassDao.getExistingValues(linkIds)
-      val linkAttributeMap = linkIds.map(linkId => RoadLinkAttribute(linkId, LinkAttributesDao.getExistingValues(linkId)))
-      RoadLinkValueCollection(functionalClassMap, linkTypeMap, trafficDirectionMap, adminClassMap, linkAttributeMap)*/
+      def propertyRowsToValueCollection(rows: RoadLinkPropertyRows): RoadLinkValueCollection = {
+
+        val functionalClassValues = rows.functionalClassRowsByLinkId.map {
+          case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
+        }.toSeq
+
+        val linkTypeValues = rows.linkTypeRowsByLinkId.map {
+          case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
+        }.toSeq
+
+        val trafficDirectionValues = rows.trafficDirectionRowsByLinkId.map {
+          case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
+        }.toSeq
+
+        val adminClassValues = rows.administrativeClassRowsByLinkId.map {
+          case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
+        }.toSeq
+
+        val linkAttributeValues = rows.roadLinkAttributesByLinkId.map {
+          case (linkId, attributes) => RoadLinkAttribute(linkId, attributes.toMap)
+        }.toSeq
+
+        RoadLinkValueCollection(
+          functionalClassValues,
+          linkTypeValues,
+          trafficDirectionValues,
+          adminClassValues,
+          linkAttributeValues
+        )
+      }
       val propertyRows = fetchRoadLinkPropertyRows(linkIds, withPrivateRoadModification = false)
       propertyRowsToValueCollection(propertyRows)
     }
-  }
-
-  def propertyRowsToValueCollection(rows: RoadLinkPropertyRows): RoadLinkValueCollection = {
-
-    val functionalClassValues = rows.functionalClassRowsByLinkId.map {
-      case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
-    }.toSeq
-
-    val linkTypeValues = rows.linkTypeRowsByLinkId.map {
-      case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
-    }.toSeq
-
-    val trafficDirectionValues = rows.trafficDirectionRowsByLinkId.map {
-      case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
-    }.toSeq
-
-    val adminClassValues = rows.administrativeClassRowsByLinkId.map {
-      case (linkId, (_, value, _, _)) => RoadLinkValue(linkId, Some(value))
-    }.toSeq
-
-    val linkAttributeValues = rows.roadLinkAttributesByLinkId.map {
-      case (linkId, attributes) => RoadLinkAttribute(linkId, attributes.toMap)
-    }.toSeq
-
-    RoadLinkValueCollection(
-      functionalClassValues,
-      linkTypeValues,
-      trafficDirectionValues,
-      adminClassValues,
-      linkAttributeValues
-    )
   }
 
   def insertRoadLinkValuesMass(valueCollection: RoadLinkValueCollection): Unit = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -1309,8 +1309,12 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
           linkAttributeValues
         )
       }
-      val propertyRows = fetchRoadLinkPropertyRows(linkIds, withPrivateRoadModification = false)
-      propertyRowsToValueCollection(propertyRows)
+      val propertyRows = LogUtils.time(logger, s"TEST LOG fetchRoadLinkPropertyRows with ${linkIds.size} links", startLogging = true) {
+        fetchRoadLinkPropertyRows(linkIds, withPrivateRoadModification = false)
+      }
+      LogUtils.time(logger, s"TEST LOG convert fetched RoadLinkPropertyRows to a RoadLinkValueCollection", startLogging = true) {
+        propertyRowsToValueCollection(propertyRows)
+      }
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -1312,9 +1312,10 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
       val propertyRows = LogUtils.time(logger, s"TEST LOG fetchRoadLinkPropertyRows with ${linkIds.size} links", startLogging = true) {
         fetchRoadLinkPropertyRows(linkIds, withPrivateRoadModification = false)
       }
-      LogUtils.time(logger, s"TEST LOG convert fetched RoadLinkPropertyRows to a RoadLinkValueCollection", startLogging = true) {
+      val valueCollection = LogUtils.time(logger, s"TEST LOG convert fetched RoadLinkPropertyRows to a RoadLinkValueCollection", startLogging = true) {
         propertyRowsToValueCollection(propertyRows)
       }
+      valueCollection
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -435,7 +435,7 @@ class RoadLinkPropertyUpdater {
   def runProcess(changes: Seq[RoadLinkChange]): ChangeReport = {
     LogUtils.time(logger, s"TEST LOG RoadLinkPropertyUpdater runProcess with ${changes.size} changes", startLogging = true) {
       val (addChanges, removeChanges, otherChanges) = partitionChanges(changes)
-      val allLinkIds = getAllLinkIds(changes)
+      val allLinkIds = getAllLinkIds(changes).toSet
 
       val valueCollection = roadLinkService.getRoadLinkValuesMass(allLinkIds)
 


### PR DESCRIPTION
Muutettu samuutuksen alussa suoritettavaa roadlink propertyjen hakua käyttämään vanhasta koodista löytynyttä massahakua erillisten kantayhteyksien sijasta, sillä ne ovat suhteessa hitain vaihe koko prosessissa. Testataan isolla hypyllä kuinka paljon nopeampi joineihin perustuva yksittäinen massahaku on. 

Mitataan propertyRowsToValueCollection suorituksen kesto. Mikäli se osoittautuu ajallisesti kalliiksi, hylätään conversio ja muutetaan koko prosessi hyödyntämään suoraan RoadLinkPropertyRows-oliota.

Pyritty vielä alkutestailussa selkeyden vuoksi olemaan muuttamatta vanhasta koodista löytynyttä fetchOverridedRoadLinkAttributes-metodin rakennetta, mutta sitä voisi kyllä vielä refaktoroida hyödyntämään RoadLinkOverrideDao:ta. Tällä hetkellä metodi (ja muutama muu vanha saman luokan metodi) tekee MassQuery-kutsuja suoraan servicestä.