### PR TITLE
 DROTH-3956 revert changes to getRoadLinkValuesMass due to old code not reusable

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/assetUpdater/RoadLinkPropertyUpdater.scala
@@ -435,7 +435,7 @@ class RoadLinkPropertyUpdater {
   def runProcess(changes: Seq[RoadLinkChange]): ChangeReport = {
     LogUtils.time(logger, s"TEST LOG RoadLinkPropertyUpdater runProcess with ${changes.size} changes", startLogging = true) {
       val (addChanges, removeChanges, otherChanges) = partitionChanges(changes)
-      val allLinkIds = getAllLinkIds(changes).toSet
+      val allLinkIds = getAllLinkIds(changes)
 
       val valueCollection = roadLinkService.getRoadLinkValuesMass(allLinkIds)
 


### PR DESCRIPTION
Perutaan muutokset joilla prosessin alun erilliset tietokantayhteydet yhdistettiin yhdeksi joineihin perustuvaksi massahauksi valmiina olevan työkalun avulla. Syynä perumiselle se, että vanhasta koodista löytynyt fetchOverridedRoadLinkAttributes suorittaa omia filtteröintejä tyhjille riveille, mikä ei ole yhteensopivaa RoadLinkPropertyUpdaterin vaatimusten kanssa.

Erilliset kantahaut riittävät toistaiseksi.