### PR TITLE
Droth 4055 to development

### DIFF
--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -251,7 +251,6 @@ object Digiroad2Context {
 
   system.scheduler.schedule(FiniteDuration(2, TimeUnit.MINUTES), FiniteDuration(1, TimeUnit.MINUTES)) {
     try {
-      logger.info("Send feedback scheduler started.")
       applicationFeedback.sendFeedbacks()
     } catch {
       case ex: Exception => logger.error(s"Exception at send feedback: ${ex.getMessage}")

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/VKMClient.scala
@@ -168,7 +168,6 @@ class VKMClient {
   def fetchRoadAddressesByLinkIds(linkIds: Seq[String]): Seq[RoadAddressForLink] = {
     val params = linkIds.map(linkId =>
       Map(
-        VkmQueryIdentifier -> "TestiTunniste",
         VkmLinkId -> linkId,
         VkmRangeSearch -> "true",
         VkmResponseValues -> s"$roadAddressFrameWorkValue,$linearLocationFrameWorkValue"

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadAddressService.scala
@@ -90,7 +90,7 @@ class RoadAddressService() {
         parChunk.flatMap { chunk =>
           val linksString2 = s"[${chunk.map(id => s""""$id"""").mkString(",")}]"
           ClientUtils.retry(5, logger, commentForFailing = s"JSON payload for failing: $linksString2") {
-            LogUtils.time(logger, "TEST LOG Retrieve road address by links") {
+            LogUtils.time(logger, s"TEST LOG Retrieve VKM road address for ${chunk.size} linkIds") {
               vkmClient.fetchRoadAddressesByLinkIds(chunk)
             }
           }


### PR DESCRIPTION
Poistettu `logger.info("Send feedback scheduler started.")` täyttämästä lokia. Poistettu kehityksen aikainen TestiTunniste vkm kutsuista, parannettu lokitusta