### PR TITLE
Fixed samuutus start event cron schedule to include only mon, tue, we…

### DIFF
--- a/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
+++ b/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
@@ -194,7 +194,7 @@ Resources:
     Properties:
       Name: !Sub "${Environment}-${ApplicationName}-start-road-link-change-handler-event"
       Description: "Scheduled event to start fetching of road link changes"
-      ScheduleExpression: "cron(0 1 ? * 2-6 *)" # Runs every weekday at 01:00 UTC
+      ScheduleExpression: "cron(0 1 ? * 2-5 *)" # Runs every weekday at 01:00 UTC
       State: ENABLED
       Targets:
         - Arn: !GetAtt Lambda.Arn

--- a/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
+++ b/lambda/road-link-change-handler/aws/cloudformation/lambda-resources.yaml
@@ -194,7 +194,7 @@ Resources:
     Properties:
       Name: !Sub "${Environment}-${ApplicationName}-start-road-link-change-handler-event"
       Description: "Scheduled event to start fetching of road link changes"
-      ScheduleExpression: "cron(0 1 ? * 2-5 *)" # Runs every weekday at 01:00 UTC
+      ScheduleExpression: "cron(0 1 ? * 3-6 *)" # Run Tuesday, Wednesday, Thursday, and Friday
       State: ENABLED
       Targets:
         - Arn: !GetAtt Lambda.Arn


### PR DESCRIPTION
Korjattu muutossetin muodostus lambdan käynnistyseventin ajastus. Jätetty perjantai pois.

Päivittäinen samuutus jätetään ajamatta seuraavina öinä:
- perjantain ja lauantain välinen yö (PTP aloittaa julkaisukannan päivityksen ajastetusti perjantaina klo 18)
- lauantain ja sunnuntain välinen yö (jos FME serverillä on ollut ruuhkaa, julkaisukannan päivitys voi päättyä vasta sunnuntaina) 
- sunnuntain ja maanataina välinen yö (maanantai on varattu julkaisukannan tietolajikohtaisiin manuaalipäivityksiin, jos joku tietolaji on feilanneet viikonloppuna) 