### PR TITLE
 DROTH-4114 replace old speedLimit get with new, faster one

### DIFF
--- a/UI/src/controller/speedLimitsCollection.js
+++ b/UI/src/controller/speedLimitsCollection.js
@@ -49,8 +49,8 @@
           speedLimit.endMeasure.toFixed(2);
     };
 
-    this.fetch = function(boundingBox, center, useExperimentalFetch) {
-      return backend.getSpeedLimits(boundingBox, applicationModel.getWithRoadAddress(), useExperimentalFetch).then(function(speedLimitGroups) {
+    this.fetch = function(boundingBox, center) {
+      return backend.getSpeedLimits(boundingBox, applicationModel.getWithRoadAddress()).then(function(speedLimitGroups) {
         var partitionedSpeedLimitGroups = _.groupBy(speedLimitGroups, function(speedLimitGroup) {
           return _.some(speedLimitGroup, function(speedLimit) { return _.has(speedLimit, "id"); });
         });

--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -155,12 +155,9 @@
       });
     });
 
-    this.getSpeedLimits = latestResponseRequestor(function(boundingBox, withRoadAddress, useExperimental) {
-      var baseURL;
-      if(useExperimental) baseURL = 'api/speedlimits_experimental?bbox=';
-      else baseURL = 'api/speedlimits?bbox=';
+    this.getSpeedLimits = latestResponseRequestor(function(boundingBox, withRoadAddress) {
       return validateBoundingBox(boundingBox,{
-        url: baseURL + boundingBox + '&withRoadAddress=' + withRoadAddress
+        url: 'api/speedlimits?bbox=' + boundingBox + '&withRoadAddress=' + withRoadAddress
       });
     });
 

--- a/UI/src/view/linear_asset/speedLimitLayer.js
+++ b/UI/src/view/linear_asset/speedLimitLayer.js
@@ -12,7 +12,6 @@ window.SpeedLimitLayer = function(params) {
   var isActiveTrafficSigns = false;
   var extraEventListener = _.extend({running: false}, eventbus);
   var authorizationPolicy = new LinearAssetAuthorizationPolicy();
-  var useExperimentalFetch = false;
 
   Layer.call(this, layerName, roadLayer);
   this.activateSelection = function() {
@@ -61,7 +60,7 @@ window.SpeedLimitLayer = function(params) {
   this.refreshView = function(event) {
     vectorLayer.setVisible(true);
     adjustStylesByZoomLevel(zoomlevels.getViewZoom(map));
-    collection.fetch(map.getView().calculateExtent(map.getSize()), map.getView().getCenter(), useExperimentalFetch).then(function() {
+    collection.fetch(map.getView().calculateExtent(map.getSize()), map.getView().getCenter()).then(function() {
       eventbus.trigger('layer:speedLimit:' + event);
     });
     if (isActive) {
@@ -321,8 +320,6 @@ window.SpeedLimitLayer = function(params) {
     eventListener.listenTo(eventbus, 'speedLimits:drawSpeedLimitsHistory', drawSpeedLimitsHistory);
     eventListener.listenTo(eventbus, 'speedLimits:hideSpeedLimitsHistory', hideSpeedLimitsHistory);
     eventListener.listenTo(eventbus, 'speedLimits:showSpeedLimitsHistory', showSpeedLimitsHistory);
-    eventListener.listenTo(eventbus, 'speedLimits:enableExperimentalFetch', enableExperimentalFetch);
-    eventListener.listenTo(eventbus, 'speedLimits:disableExperimentalFetch', disableExperimentalFetch);
     eventListener.listenTo(eventbus, 'toggleWithRoadAddress', refreshSelectedView);
     eventListener.listenTo(eventbus, 'speedLimit:unselect speedLimit:massUpdateUnselected', handleSpeedLimitUnselected);
   };
@@ -355,16 +352,6 @@ window.SpeedLimitLayer = function(params) {
   var showSpeedLimitsComplementary = function() {
     collection.activeComplementary(true);
     trafficSignReadOnlyLayer.showTrafficSignsComplementary();
-    me.refreshView();
-  };
-
-  var enableExperimentalFetch = function() {
-    useExperimentalFetch = true;
-    me.refreshView();
-  };
-
-  var disableExperimentalFetch = function() {
-    useExperimentalFetch = false;
     me.refreshView();
   };
 

--- a/UI/src/view/navigationpanel/speedLimitBox.js
+++ b/UI/src/view/navigationpanel/speedLimitBox.js
@@ -44,13 +44,7 @@
         '</div>'
       ].join('');
 
-      var speedLimitExperimentalFetchCheckBox = [
-        '<div class="check-box-container">' +
-        '<input id="experimentalFetchCheckbox" type="checkbox" /> <lable>Käytä kokeellista hakua</lable>' +
-        '</div>'
-      ].join('');
-
-      return speedLimitHistoryCheckBox.concat(speedLimitComplementaryCheckBox).concat(speedLimitSignsCheckBox).concat(speedLimitExperimentalFetchCheckBox);
+      return speedLimitHistoryCheckBox.concat(speedLimitComplementaryCheckBox).concat(speedLimitSignsCheckBox);
 
     };
 
@@ -102,15 +96,6 @@
           eventbus.trigger('speedLimits:showSpeedLimitsHistory');
         } else {
           eventbus.trigger('speedLimits:hideSpeedLimitsHistory');
-        }
-      });
-
-      $(me.expanded).find('#experimentalFetchCheckbox').on('change', function (event) {
-        var eventTarget = $(event.currentTarget);
-        if (eventTarget.prop('checked')) {
-          eventbus.trigger('speedLimits:enableExperimentalFetch');
-        } else {
-          eventbus.trigger('speedLimits:disableExperimentalFetch');
         }
       });
 

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1372,7 +1372,12 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     params.get("bbox").map { bbox =>
       val boundingRectangle = constructBoundingRectangle(bbox)
       validateBoundingBox(boundingRectangle)
-      val speedLimits = speedLimitService.getSpeedLimitsByBbox(boundingRectangle)
+      val speedLimits =
+        if (params("withRoadAddress").toBoolean)
+          roadAddressService.linearAssetWithRoadAddress(
+            speedLimitService.getSpeedLimitsByBbox(boundingRectangle))
+        else
+          speedLimitService.getSpeedLimitsByBbox(boundingRectangle)
       speedLimits.map { speedLimitGroup => speedLimitGroup.map {
         speedLimitAsset =>
           Map(

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -1378,27 +1378,32 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             speedLimitService.getSpeedLimitsByBbox(boundingRectangle))
         else
           speedLimitService.getSpeedLimitsByBbox(boundingRectangle)
-      speedLimits.map { speedLimitGroup => speedLimitGroup.map {
-        speedLimitAsset =>
+      speedLimits.map { linkPartition =>
+        linkPartition.map { link =>
           Map(
-            "id" -> (if (speedLimitAsset.id == 0) None else Some(speedLimitAsset.id)),
-            "linkId" -> speedLimitAsset.linkId,
-            "sideCode" -> speedLimitAsset.sideCode,
-            "trafficDirection" -> speedLimitAsset.trafficDirection,
-            "value" -> speedLimitService.getSpeedLimitValue(speedLimitAsset.value).map(x => Map("isSuggested" -> x.isSuggested, "value" -> x.value)),
-            "points" -> speedLimitAsset.geometry,
-            "startMeasure" -> speedLimitAsset.startMeasure,
-            "endMeasure" -> speedLimitAsset.endMeasure,
-            "modifiedBy" -> speedLimitAsset.modifiedBy,
-            "modifiedAt" -> speedLimitAsset.modifiedDateTime,
-            "createdBy" -> speedLimitAsset.createdBy,
-            "createdAt" -> speedLimitAsset.createdDateTime,
-            "linkSource" -> speedLimitAsset.linkSource.value,
-            "administrativeClass" -> speedLimitAsset.administrativeClass,
-            "municipalityCode" -> extractIntValue(speedLimitAsset.attributes, "municipality"),
-            "constructionType" -> extractIntValue(speedLimitAsset.attributes, "constructionType")
+            "id" -> (if (link.id == 0) None else Some(link.id)),
+            "linkId" -> link.linkId,
+            "sideCode" -> link.sideCode,
+            "trafficDirection" -> link.trafficDirection,
+            "value" -> speedLimitService.getSpeedLimitValue(link.value).map(x => Map("isSuggested" -> x.isSuggested, "value" -> x.value)),
+            "points" -> link.geometry,
+            "startMeasure" -> link.startMeasure,
+            "endMeasure" -> link.endMeasure,
+            "modifiedBy" -> link.modifiedBy,
+            "modifiedAt" -> link.modifiedDateTime,
+            "createdBy" -> link.createdBy,
+            "createdAt" -> link.createdDateTime,
+            "linkSource" -> link.linkSource.value,
+            "roadPartNumber" -> extractLongValue(link.attributes, "ROAD_PART_NUMBER"),
+            "roadNumber" -> extractLongValue(link.attributes, "ROAD_NUMBER"),
+            "track" -> extractIntValue(link.attributes, "TRACK"),
+            "startAddrMValue" -> extractLongValue(link.attributes, "START_ADDR"),
+            "endAddrMValue" -> extractLongValue(link.attributes, "END_ADDR"),
+            "administrativeClass" -> link.attributes.get("ROAD_ADMIN_CLASS"),
+            "municipalityCode" -> extractIntValue(link.attributes, "municipality"),
+            "constructionType" -> extractIntValue(link.attributes, "constructionType")
           )
-      }
+        }
       }
     } getOrElse {
       BadRequest("Missing mandatory 'bbox' parameter")

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
@@ -11,7 +11,7 @@ case class SpeedLimitRow(id: Long, linkId: String, sideCode: SideCode, value: Op
                                modifiedBy: Option[String], modifiedDate: Option[DateTime], createdBy: Option[String], createdDate: Option[DateTime],
                                timeStamp: Long, geomModifiedDate: Option[DateTime], expired: Boolean = false, linkSource: LinkGeomSource, publicId: String)
 
-case class SpeedLimitRowExperimental(id: Long, linkId: String, sideCode: SideCode, trafficDirection: TrafficDirection,
+case class SpeedLimitRowWithRoadInfo(id: Long, linkId: String, sideCode: SideCode, trafficDirection: TrafficDirection,
                                      value: Option[Int], geometry: Seq[Point], startMeasure: Double, endMeasure: Double, roadLinkLength: Double,
                                      modifiedBy: Option[String], modifiedDate: Option[DateTime], createdBy: Option[String],
                                      createdDate: Option[DateTime], administrativeClass: AdministrativeClass, municipalityCode: Int,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
@@ -8,7 +8,7 @@ import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.ComplimentaryLinkInterf
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, ConstructionType}
 import fi.liikennevirasto.digiroad2.client.RoadLinkFetched
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import fi.liikennevirasto.digiroad2.util.LogUtils
+import fi.liikennevirasto.digiroad2.util.{KgvUtil, LogUtils}
 import org.joda.time.DateTime
 import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult}
@@ -86,7 +86,7 @@ class ComplementaryLinkDAO extends RoadLinkDAO {
       }
 
       RoadLinkFetched(linkId, municipality, geometry, AdministrativeClass.apply(administrativeClass),
-        extractTrafficDirection(directionType), featureClass, modifiedAt, attributes,
+        KgvUtil.extractTrafficDirection(directionType), featureClass, modifiedAt, attributes,
         ConstructionType.apply(constructionType), ComplimentaryLinkInterface, length)
     }
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ComplementaryLinkDAO.scala
@@ -36,7 +36,7 @@ class ComplementaryLinkDAO extends RoadLinkDAO {
     def apply(r: PositionedResult): RoadLinkFetched = {
       val linkId = r.nextString()
       val municipality = r.nextInt()
-      val path = r.nextObjectOption().map(extractGeometry).get
+      val path = r.nextObjectOption().map(KgvUtil.extractGeometry).get
       val administrativeClass = r.nextInt()
       val directionType = r.nextIntOption()
       val mtkClass = r.nextInt()

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -4,7 +4,7 @@ import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import org.locationtech.jts.geom.Polygon
 import fi.liikennevirasto.digiroad2.Point
-import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, BoundingRectangle, ConstructionType, LinkGeomSource, TrafficDirection}
+import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, BoundingRectangle, ConstructionType, LinkGeomSource}
 import fi.liikennevirasto.digiroad2.client.{FeatureClass, LinkIdAndExpiredDate, RoadLinkFetched}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.withDbConnection
@@ -195,7 +195,7 @@ class RoadLinkDAO {
       }
 
       RoadLinkFetched(linkId, municipality, geometry, AdministrativeClass.apply(administrativeClass),
-        extractTrafficDirection(directionType), featureClass, modifiedAt, attributes,
+        KgvUtil.extractTrafficDirection(directionType), featureClass, modifiedAt, attributes,
         ConstructionType.apply(constructionType), LinkGeomSource.NormalLinkInterface, length)
     }
   }
@@ -436,15 +436,6 @@ class RoadLinkDAO {
 
   protected def extractFeatureClass(code: Int): FeatureClass = {
     KgvUtil.extractFeatureClass(code)
-  }
-
-  def extractTrafficDirection(code: Option[Int]): TrafficDirection = {
-    code match {
-      case Some(0) => TrafficDirection.BothDirections
-      case Some(1) => TrafficDirection.TowardsDigitizing
-      case Some(2) => TrafficDirection.AgainstDigitizing
-      case _ => TrafficDirection.UnknownDirection
-    }
   }
 
   protected def extractModifiedDate(createdDate:Option[Long],lastEdited:Option[Long]): Option[DateTime] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -9,15 +9,12 @@ import fi.liikennevirasto.digiroad2.client.{FeatureClass, LinkIdAndExpiredDate, 
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase.withDbConnection
 import fi.liikennevirasto.digiroad2.util.{KgvUtil, LogUtils}
-import net.postgis.jdbc.geometry.GeometryBuilder
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
-import org.postgresql.util.PGobject
 import org.slf4j.LoggerFactory
 import slick.jdbc.{GetResult, PositionedResult}
 import slick.jdbc.StaticQuery.interpolation
 
-import scala.collection.mutable.ListBuffer
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -134,7 +131,7 @@ class RoadLinkDAO {
       val mtkId = r.nextLong()
       val mtkHereFlip = r.nextInt()
       val municipality = r.nextInt()
-      val path = r.nextObjectOption().map(extractGeometry).get
+      val path = r.nextObjectOption().map(KgvUtil.extractGeometry).get
       val administrativeClass = r.nextInt()
       val directionType = r.nextIntOption()
       val mtkClass = r.nextInt()
@@ -440,21 +437,6 @@ class RoadLinkDAO {
 
   protected def extractModifiedDate(createdDate:Option[Long],lastEdited:Option[Long]): Option[DateTime] = {
     KgvUtil.extractModifiedAt(createdDate,lastEdited)
-  }
-
-  def extractGeometry(data: Object): List[List[Double]] = {
-    val geometry = data.asInstanceOf[PGobject]
-    if (geometry == null) Nil
-    else {
-      val geomValue = geometry.getValue
-      val geom = GeometryBuilder.geomFromString(geomValue)
-      val listOfPoint= ListBuffer[List[Double]]()
-      for (i <- 0 until geom.numPoints() ){
-        val point =geom.getPoint(i)
-        listOfPoint += List(point.x, point.y, point.z, point.m)
-      }
-      listOfPoint.toList
-    }
   }
 
   def deleteRoadLinksByIds(linkIdsToDelete: Set[String]) = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -10,7 +10,7 @@ import Database.dynamicSession
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.{NormalLinkInterface, values}
 import fi.liikennevirasto.digiroad2.client.FeatureClass
-import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, Queries, RoadLinkDAO, Sequences}
+import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, Queries, Sequences}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.{Measures, NewSpeedLimitMassOperation}
 import fi.liikennevirasto.digiroad2.util.{KgvUtil, LinearAssetUtils}
@@ -22,8 +22,6 @@ case class UnknownLimit(linkId: String, municipality: String, administrativeClas
 case class NewSpeedLimitWithId(asset:NewSpeedLimitMassOperation, id:Long, positionId:Long)
 class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends DynamicLinearAssetDao {
   def MassQueryThreshold = 500
-
-  val roadLinkDAO = new RoadLinkDAO
 
   implicit object GetByteArray extends GetResult[Array[Byte]] {
     def apply(rs: PositionedResult) = rs.nextBytes()
@@ -63,7 +61,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       val sideCodeValue = r.nextIntOption()
       val directionType = r.nextIntOption()
       val value = r.nextIntOption()
-      val path = r.nextObjectOption().map(roadLinkDAO.extractGeometry).get
+      val path = r.nextObjectOption().map(KgvUtil.extractGeometry).get
       val startMeasure = r.nextDouble()
       val endMeasure = r.nextDouble()
       val geometryLength = r.nextDouble()

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -54,9 +54,9 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
     }
   }
 
-  implicit val getSpeedLimitRowExperimental = new GetResult[SpeedLimitRowExperimental] {
+  implicit val getSpeedLimitRowWithRoadInfo = new GetResult[SpeedLimitRowWithRoadInfo] {
 
-    def apply(r: PositionedResult) : SpeedLimitRowExperimental = {
+    def apply(r: PositionedResult) : SpeedLimitRowWithRoadInfo = {
       val id = r.nextLong()
       val linkId = r.nextString()
       val sideCodeValue = r.nextIntOption()
@@ -82,7 +82,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       val adminClass = AdministrativeClass.apply(adminClassValue)
 
 
-      SpeedLimitRowExperimental(id = id, linkId = linkId, sideCode = sideCode, trafficDirection = trafficDirection,
+      SpeedLimitRowWithRoadInfo(id = id, linkId = linkId, sideCode = sideCode, trafficDirection = trafficDirection,
         value = value, geometry = geometry, startMeasure = startMeasure, endMeasure = endMeasure, roadLinkLength = geometryLength, modifiedBy = modifiedBy,
         modifiedDate = modifiedDateTime, createdBy = createdBy, createdDate = createdDateTime, administrativeClass = adminClass,
         municipalityCode = municipality, constructionType = constructionType, linkSource = NormalLinkInterface, publicId = publicId)
@@ -98,7 +98,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
     }
   }
 
-  def fetchByBBoxExperimental(bbox: BoundingRectangle): (Seq[PieceWiseLinearAsset], Seq[RoadLinkForUnknownGeneration]) = {
+  def fetchByBBox(bbox: BoundingRectangle): (Seq[PieceWiseLinearAsset], Seq[RoadLinkForUnknownGeneration]) = {
     val bboxFilter = PostGISDatabase.boundingBoxFilter(bbox, "shape")
 
     val query =
@@ -183,11 +183,11 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       FROM cte_kgv_roadlink cte_kgv;
     """
 
-    val speedLimitRows = query.as[SpeedLimitRowExperimental].list
-    groupSpeedLimitsResultExperimental(speedLimitRows)
+    val speedLimitRows = query.as[SpeedLimitRowWithRoadInfo].list
+    groupSpeedLimitsResultWithRoadInfo(speedLimitRows)
   }
 
-  def groupSpeedLimitsResultExperimental(speedLimitRows: Seq[SpeedLimitRowExperimental]) : (Seq[PieceWiseLinearAsset], Seq[RoadLinkForUnknownGeneration]) = {
+  def groupSpeedLimitsResultWithRoadInfo(speedLimitRows: Seq[SpeedLimitRowWithRoadInfo]) : (Seq[PieceWiseLinearAsset], Seq[RoadLinkForUnknownGeneration]) = {
     val (assetRows, roadLinkRows) = speedLimitRows.partition(_.id != 0)
     val emptyRoadLinkRows = roadLinkRows.filterNot(rlRow => assetRows.map(_.linkId).contains(rlRow.linkId))
     val groupedSpeedLimit = assetRows.groupBy(_.id)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -9,10 +9,11 @@ import slick.driver.JdbcDriver.backend.Database
 import Database.dynamicSession
 import com.github.tototoshi.slick.MySQLJodaSupport._
 import fi.liikennevirasto.digiroad2.asset.LinkGeomSource.{NormalLinkInterface, values}
+import fi.liikennevirasto.digiroad2.client.FeatureClass
 import fi.liikennevirasto.digiroad2.dao.{DynamicLinearAssetDao, Queries, RoadLinkDAO, Sequences}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.linearasset.{Measures, NewSpeedLimitMassOperation}
-import fi.liikennevirasto.digiroad2.util.LinearAssetUtils
+import fi.liikennevirasto.digiroad2.util.{KgvUtil, LinearAssetUtils}
 import slick.jdbc.StaticQuery.interpolation
 import slick.jdbc.{GetResult, PositionedResult, StaticQuery => Q}
 
@@ -75,7 +76,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       val constructionTypeValue = r.nextInt()
       val publicId = r.nextString()
 
-      val trafficDirection = roadLinkDAO.extractTrafficDirection(directionType)
+      val trafficDirection = KgvUtil.extractTrafficDirection(directionType)
       val constructionType = ConstructionType.apply(constructionTypeValue)
       val geometry = path.map(point => Point(point(0), point(1), point(2)))
       val sideCode = SideCode.apply(sideCodeValue.getOrElse(99))
@@ -100,7 +101,24 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
 
   def fetchByBBox(bbox: BoundingRectangle): (Seq[PieceWiseLinearAsset], Seq[RoadLinkForUnknownGeneration]) = {
     val bboxFilter = PostGISDatabase.boundingBoxFilter(bbox, "shape")
-
+    val constructionFilter = Seq(ConstructionType.Planned.value, ConstructionType.UnderConstruction.value).mkString(", ")
+    val linkTypeFilter = Seq(
+      RestArea.value,
+      CycleOrPedestrianPath.value,
+      PedestrianZone.value,
+      ServiceOrEmergencyRoad.value,
+      TractorRoad.value,
+      ServiceAccess.value,
+      SpecialTransportWithoutGate.value,
+      SpecialTransportWithGate.value,
+      CableFerry.value).mkString(", ")
+    val functionalClassFilter = Seq(
+      FunctionalClass1.value,
+      FunctionalClass2.value,
+      FunctionalClass3.value,
+      FunctionalClass4.value,
+      FunctionalClass5.value,
+      AnotherPrivateRoad.value).mkString(", ")
     val query =
       sql"""
       WITH cte_kgv_roadlink AS (
@@ -117,11 +135,11 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
         JOIN functional_class fc ON kgv.linkid = fc.link_id
         WHERE #$bboxFilter
           AND kgv.expired_date IS NULL
-          AND kgv.constructiontype NOT IN (1, 2)
+          AND kgv.constructiontype NOT IN (#$constructionFilter)
           AND kgv.mtkclass NOT IN (12318, 12312) -- Filter out HardShoulder and WinterRoad links
-          AND (kgv.adminclass != 1 OR (kgv.adminclass = 1 AND lt.link_type NOT IN (7, 8, 9, 10, 12, 13, 14, 15, 21))) -- Filter out unallowed types on state roads
-          AND fc.functional_class IN (1, 2, 3, 4, 5, 6) -- Filter by allowed FunctionalClass values
-      )
+          AND (kgv.adminclass != #${State.value} OR (kgv.adminclass = #${State.value} AND lt.link_type NOT IN (#$linkTypeFilter)) -- Filter out unallowed types on state roads
+          AND fc.functional_class IN (#$functionalClassFilter) -- Filter by allowed FunctionalClass values
+      ))
 
       SELECT
         a.id,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -59,9 +59,9 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
       speedLimitDao.getLinksWithLength(id)
   }
 
-  def getSpeedLimitsByBboxExperimental(bbox: BoundingRectangle): Seq[Seq[PieceWiseLinearAsset]] = {
+  def getSpeedLimitsByBbox(bbox: BoundingRectangle): Seq[Seq[PieceWiseLinearAsset]] = {
     val (speedLimits, emptyRoadLinks) = withDynTransaction {
-      speedLimitDao.fetchByBBoxExperimental(bbox)
+      speedLimitDao.fetchByBBox(bbox)
     }
     val unknownSpeedLimits = emptyRoadLinkToUnknownSpeedLimit(emptyRoadLinks)
     LinearAssetPartitioner.partition(speedLimits ++ unknownSpeedLimits)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/KgvUtil.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/KgvUtil.scala
@@ -2,7 +2,11 @@ package fi.liikennevirasto.digiroad2.util
 
 import fi.liikennevirasto.digiroad2.asset.TrafficDirection
 import fi.liikennevirasto.digiroad2.client.FeatureClass
+import net.postgis.jdbc.geometry.GeometryBuilder
 import org.joda.time.DateTime
+import org.postgresql.util.PGobject
+
+import scala.collection.mutable.ListBuffer
 
 object KgvUtil {
 
@@ -32,6 +36,21 @@ object KgvUtil {
       case Some(1) => TrafficDirection.TowardsDigitizing
       case Some(2) => TrafficDirection.AgainstDigitizing
       case _ => TrafficDirection.UnknownDirection
+    }
+  }
+
+  def extractGeometry(data: Object): List[List[Double]] = {
+    val geometry = data.asInstanceOf[PGobject]
+    if (geometry == null) Nil
+    else {
+      val geomValue = geometry.getValue
+      val geom = GeometryBuilder.geomFromString(geomValue)
+      val listOfPoint = ListBuffer[List[Double]]()
+      for (i <- 0 until geom.numPoints()) {
+        val point = geom.getPoint(i)
+        listOfPoint += List(point.x, point.y, point.z, point.m)
+      }
+      listOfPoint.toList
     }
   }
 }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/KgvUtil.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/util/KgvUtil.scala
@@ -1,5 +1,6 @@
 package fi.liikennevirasto.digiroad2.util
 
+import fi.liikennevirasto.digiroad2.asset.TrafficDirection
 import fi.liikennevirasto.digiroad2.client.FeatureClass
 import org.joda.time.DateTime
 
@@ -22,6 +23,15 @@ object KgvUtil {
       case 12131 => FeatureClass.CarRoad_IIIa
       case 12132 => FeatureClass.CarRoad_IIIb
       case _ => FeatureClass.AllOthers
+    }
+  }
+
+  def extractTrafficDirection(code: Option[Int]): TrafficDirection = {
+    code match {
+      case Some(0) => TrafficDirection.BothDirections
+      case Some(1) => TrafficDirection.TowardsDigitizing
+      case Some(2) => TrafficDirection.AgainstDigitizing
+      case _ => TrafficDirection.UnknownDirection
     }
   }
 }


### PR DESCRIPTION
Otettu  #3240 testatut muutokset ja tehty niistä oletustyökalu nopeusrajoitusten hakuun. Vanha haku ei säily rinnakkaisena, vaan se ja valinta-optio poistetaan. 