### PR TITLE
Droth 4114 faster speed limit query as default

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
@@ -1,6 +1,7 @@
 package fi.liikennevirasto.digiroad2.linearasset
 
 import fi.liikennevirasto.digiroad2.asset.SideCode
+import scala.util.Try
 
 object LinearAssetPartitioner extends GraphPartitioner {
   def partition[T <: LinearAsset](links: Seq[T], roadLinksForSpeedLimits: Map[String, RoadLink]): Seq[Seq[T]] = {
@@ -22,18 +23,25 @@ object LinearAssetPartitioner extends GraphPartitioner {
 
   def partition[T <: PieceWiseLinearAsset](links: Seq[T]): Seq[Seq[T]] = {
     val (twoWayLinks, oneWayLinks) = links.partition(_.sideCode == SideCode.BothDirections)
-    val linkGroups = twoWayLinks.groupBy { link =>
-      (link.administrativeClass, link.value, link.id == 0)
+
+    def extractRoadIdentifier(link: T): Option[Either[Int, String]] = {
+      Try(Left(link.attributes("ROADNUMBER").asInstanceOf[BigInt].intValue()))
+        .orElse(Try(Right(getStringAttribute(link.attributes)("ROADNAME_FI"))))
+        .orElse(Try(Right(getStringAttribute(link.attributes)("ROADNAME_SE"))))
+        .toOption
     }
 
-    val (linksToPartition, linksToPass) = linkGroups.partition { case ((_, _, _), _) => true }
+    def getStringAttribute(attributes: Map[String, Any])(key: String): String =
+      attributes.get(key).map(_.toString).getOrElse("")
 
+    val linkGroups = twoWayLinks.groupBy { link =>
+      (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0)
+    }
+    val (linksToPartition, linksToPass) = linkGroups.partition { case ((roadIdentifier, _, _, _), _) => roadIdentifier.isDefined }
     val clusters = linksToPartition.values.map(p => {
       clusterLinks(p)
     }).toSeq.flatten
-
     val linkPartitions = clusters.map(linksFromCluster)
-
     linkPartitions ++ linksToPass.values.flatten.map(x => Seq(x)) ++ oneWayLinks.map(x => Seq(x))
   }
 }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/SpeedLimit.scala
@@ -15,4 +15,4 @@ case class SpeedLimitRowWithRoadInfo(id: Long, linkId: String, sideCode: SideCod
                                      value: Option[Int], geometry: Seq[Point], startMeasure: Double, endMeasure: Double, roadLinkLength: Double,
                                      modifiedBy: Option[String], modifiedDate: Option[DateTime], createdBy: Option[String],
                                      createdDate: Option[DateTime], administrativeClass: AdministrativeClass, municipalityCode: Int,
-                                     constructionType: ConstructionType, linkSource: LinkGeomSource, publicId: String)
+                                     constructionType: ConstructionType, linkSource: LinkGeomSource, publicId: String, roadNameFi: String, roadNameSe: String)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -72,7 +72,6 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       val adminClassValue = r.nextInt()
       val municipality = r.nextInt()
       val constructionTypeValue = r.nextInt()
-      val roadNumber = r.nextString()
       val roadNameFi = r.nextString()
       val roadNameSe = r.nextString()
       val publicId = r.nextString()
@@ -140,9 +139,9 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
           AND kgv.expired_date IS NULL
           AND kgv.constructiontype NOT IN (#$constructionFilter)
           AND kgv.mtkclass NOT IN (12318, 12312) -- Filter out HardShoulder and WinterRoad links
-          AND (kgv.adminclass != #${State.value} OR (kgv.adminclass = #${State.value} AND lt.link_type NOT IN (#$linkTypeFilter)) -- Filter out unallowed types on state roads
+          AND (kgv.adminclass != #${State.value} OR (kgv.adminclass = #${State.value} AND lt.link_type NOT IN (#$linkTypeFilter))) -- Filter out unallowed types on state roads
           AND fc.functional_class IN (#$functionalClassFilter) -- Filter by allowed FunctionalClass values
-      ))
+      )
 
       SELECT
         a.id,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -72,6 +72,9 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       val adminClassValue = r.nextInt()
       val municipality = r.nextInt()
       val constructionTypeValue = r.nextInt()
+      val roadNumber = r.nextString()
+      val roadNameFi = r.nextString()
+      val roadNameSe = r.nextString()
       val publicId = r.nextString()
 
       val trafficDirection = KgvUtil.extractTrafficDirection(directionType)
@@ -84,7 +87,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
       SpeedLimitRowWithRoadInfo(id = id, linkId = linkId, sideCode = sideCode, trafficDirection = trafficDirection,
         value = value, geometry = geometry, startMeasure = startMeasure, endMeasure = endMeasure, roadLinkLength = geometryLength, modifiedBy = modifiedBy,
         modifiedDate = modifiedDateTime, createdBy = createdBy, createdDate = createdDateTime, administrativeClass = adminClass,
-        municipalityCode = municipality, constructionType = constructionType, linkSource = NormalLinkInterface, publicId = publicId)
+        municipalityCode = municipality, constructionType = constructionType, linkSource = NormalLinkInterface, publicId = publicId, roadNameFi = roadNameFi, roadNameSe = roadNameSe)
       }
   }
 
@@ -127,7 +130,9 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
           kgv.geometrylength,
           kgv.adminclass,
           kgv.municipalitycode,
-          kgv.constructiontype
+          kgv.constructiontype,
+          kgv.roadname_fi,
+          kgv.roadname_se
         FROM kgv_roadlink kgv
         JOIN link_type lt ON kgv.linkid = lt.link_id
         JOIN functional_class fc ON kgv.linkid = fc.link_id
@@ -163,6 +168,8 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
         cte_kgv.adminclass,
         cte_kgv.municipalitycode,
         cte_kgv.constructiontype,
+        cte_kgv.roadname_fi,
+        cte_kgv.roadname_se,
         p.public_id
       FROM asset a
       JOIN asset_link al ON a.id = al.asset_id
@@ -195,6 +202,8 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
         cte_kgv.adminclass,
         cte_kgv.municipalitycode,
         cte_kgv.constructiontype,
+        cte_kgv.roadname_fi,
+        cte_kgv.roadname_se,
         NULL AS public_id
       FROM cte_kgv_roadlink cte_kgv;
     """
@@ -222,7 +231,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
         case _ => None
       }
 
-      val attributes = Map("municipality" -> asset.municipalityCode, "constructionType" -> asset.constructionType.value)
+      val attributes = Map("municipality" -> asset.municipalityCode, "constructionType" -> asset.constructionType.value, "ROADNAME_FI" -> asset.roadNameFi, "ROADNAME_SE" -> asset.roadNameSe)
 
       PieceWiseLinearAsset(id = assetId, linkId = asset.linkId, sideCode = asset.sideCode, value = speedLimitValue, geometry = asset.geometry, expired = false,
         startMeasure = asset.startMeasure, endMeasure = asset.endMeasure, endpoints = Set(asset.geometry.head, asset.geometry.last),


### PR DESCRIPTION
Korjattu bugit:

- kevareille piirtyy nopeusrajoituksia -> sql-sulkumerkki väärässä paikassa
- valintatyökalu nappaa liian monta linkkiä kerralla -> Yksiparametrinen partition-metodi ei osannut erotella linkkejä tarpeeksi kattavasti. Lisätty metodiin roadIdentifier-käsittely. Lisäksi lisätty noperusrajoitus-tielinkkitieto-yhdistelmäluokkaan Partitionerin tarvitsemat tiedot (nimi suomeksi ja ruotsiksi).