### PR TITLE
 DROTH-4115 fixed wrong constructionType bug

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/RoadLinkService.scala
@@ -418,7 +418,11 @@ class RoadLinkService(val roadLinkClient: RoadLinkClient, val eventbus: Digiroad
           link.trafficDirection,
           link.linkType,
           link.modifiedAt.map(DateTimePropertyFormat.print),
-          Some(link.attributes.getOrElse("MODIFIED_BY", "").toString), link.attributes)
+          Some(link.attributes.getOrElse("MODIFIED_BY", "").toString),
+          link.attributes,
+          link.constructionType,
+          link.linkSource
+          )
       }
     }
     val enrichedFetched = withDbConnection {roadLinkDAO.fetchEnrichedByMunicipalitiesAndBounds(bounds, municipalities)}


### PR DESCRIPTION
Korjattu bugi, jossa haettujen tielinkkien tila on unohtunut siirtää lopulliseen luokkaan ja käyttöön on tullut RoadLinkin default arvo "InUse". Lisätty samalla linkSource, jolle RoadLinkillä on myös default arvo. 