### PR TITLE
DROTH-4163 Change hard coded Ely code in unit test

### DIFF
--- a/digiroad2-api-common/src/test/scala/fi/liikennevirasto/digiroad2/user/UserConfigurationApiSpec.scala
+++ b/digiroad2-api-common/src/test/scala/fi/liikennevirasto/digiroad2/user/UserConfigurationApiSpec.scala
@@ -53,7 +53,7 @@ class UserConfigurationApiSpec extends AuthenticatedApiSpec {
         municipality766_749; ; 4, 5, 6, 49, 235; Name from batch
         municipality49; ; 1, 2, 3, 49; Replaced name from batch
         newuser; ; 2, 3, 6; Another name from batch
-        testEly; 0; ;
+        testEly; 16; ;
       """
     try {
       putJsonWithUserAuth("/userconfig/municipalitiesbatch", batchString, Map("Content-type" -> "text/plain")) {


### PR DESCRIPTION
Yksi testi failannut. Korjattu vaihtamalla kovakoodattu ely-koodi oikeaan