### PR TITLE
DROTH-4149 use functional class 9 in ui

### DIFF
--- a/UI/src/enumerations.js
+++ b/UI/src/enumerations.js
@@ -22,6 +22,18 @@
       Unknown: {value: 99, text: 'Tuntematon'}
     };
 
+    this.functionalClasses = {
+      1: {value: 1, text: 'Luokka 1'},
+      2: {value: 2, text: 'Luokka 2'},
+      3: {value: 3, text: 'Luokka 3'},
+      4: {value: 4, text: 'Luokka 4'},
+      5: {value: 5, text: 'Luokka 5'},
+      6: {value: 6, text: 'Luokka 6: Muu yksityistie'},
+      7: {value: 7, text: 'Luokka 7: Ajopolku'},
+      8: {value: 8, text: 'Luokka 8: Kävelyn ja pyöräilyn väylä'},
+      9: {value: 9, text: 'Luokka 9'}
+    };
+
     this.twoWayLaneLinkTypes = [
       this.linkTypes.SpecialTransportWithoutGate,
       this.linkTypes.SpecialTransportWithGate,

--- a/UI/src/less/site/action-panel.less
+++ b/UI/src/less/site/action-panel.less
@@ -537,6 +537,7 @@
     .linear-asset-6  { .linear-asset-legend-entry(@linear-asset-5, @linear-asset-node-5); }
     .linear-asset-7  { .linear-asset-legend-entry(@linear-asset-6, @linear-asset-node-6); }
     .linear-asset-8  { .linear-asset-legend-entry(@linear-asset-6, @linear-asset-node-6); }
+    .linear-asset-9  { .linear-asset-legend-entry(@linear-asset-3, @linear-asset-node-3); }
   }
 }
 

--- a/UI/src/view/link_property/linkPropertyForm.js
+++ b/UI/src/view/link_property/linkPropertyForm.js
@@ -1,7 +1,6 @@
 (function (root) {
   root.LinkPropertyForm = function(selectedLinkProperty, feedbackCollection) {
     var layer;
-    var functionalClasses = [1, 2, 3, 4, 5, 6, 7, 8];
     var authorizationPolicy = new LinkPropertyAuthorizationPolicy();
     var enumerations = new Enumerations();
     new FeedbackDataTool(feedbackCollection, 'linkProperty', authorizationPolicy);
@@ -75,6 +74,11 @@
         },
         container: '.container'
       };
+    };
+
+    var getLocalizedFunctionalClass = function(functionalClass) {
+      var localizedFunctionalClass = _.find(enumerations.functionalClasses, function(x) { return x.value === functionalClass; });
+      return localizedFunctionalClass && localizedFunctionalClass.value;
     };
 
     var getLocalizedAdministrativeClass = function(administrativeClass) {
@@ -331,7 +335,7 @@
         roadNameSms : linkProperty.roadNameSms || '',
         roadNumber : linkProperty.roadNumber || '',
         roadPartNumber : linkProperty.roadPartNumber || '',
-        localizedFunctionalClass : _.find(functionalClasses, function(x) { return x === linkProperty.functionalClass; }) || 'Tuntematon',
+        localizedFunctionalClass : getLocalizedFunctionalClass(linkProperty.functionalClass)|| 'Tuntematon',
         localizedAdministrativeClass : getLocalizedAdministrativeClass(linkProperty.administrativeClass)|| 'Tuntematon',
         localizedAdditionalInfoIds: getAdditionalInfo(parseInt(linkProperty.additionalInfo)) || '',
         localizedTrafficDirection : getLocalizedTrafficDirection(linkProperty.trafficDirection) || 'Tuntematon',
@@ -371,9 +375,9 @@
           return '<option value="' + trafficDirection.stringValue + '"' + selected + '>' + trafficDirection.text + '</option>';
         }).join('');
 
-        var functionalClassOptionTags = _.map(functionalClasses, function(value) {
-          var selected = value === linkProperty.functionalClass ? " selected" : "";
-          return '<option value="' + value + '"' + selected + '>' + value + '</option>';
+        var functionalClassOptionTags = _.map(enumerations.functionalClasses, function(functionalClass) {
+          var selected = functionalClass.value === linkProperty.functionalClass ? " selected" : "";
+          return '<option value="' + functionalClass.value + '"' + selected + '>' + functionalClass.value + '</option>';
         }).join('');
 
         var linkTypesOptionTags = _.map(enumerations.linkTypes, function(linkType) {

--- a/UI/src/view/link_property/linkPropertyLayerStyles.js
+++ b/UI/src/view/link_property/linkPropertyLayerStyles.js
@@ -9,7 +9,8 @@
       new StyleRule().where('functionalClass').is(5).use({ stroke : { color: '#01b'}, fill : { color: '#01b'}, icon: { src: 'images/link-properties/arrow-drop-blue.svg'} }),
       new StyleRule().where('functionalClass').is(6).use({ stroke : { color: '#01b'}, fill : { color: '#01b'}, icon: { src: 'images/link-properties/arrow-drop-blue.svg'} }),
       new StyleRule().where('functionalClass').is(7).use({ stroke : { color: '#888'}, fill : { color: '#888'}, icon: { src: 'images/link-properties/arrow-drop-grey.svg'} }),
-      new StyleRule().where('functionalClass').is(8).use({ stroke : { color: '#888'}, fill : { color: '#888'}, icon: { src: 'images/link-properties/arrow-drop-grey.svg'} })
+      new StyleRule().where('functionalClass').is(8).use({ stroke : { color: '#888'}, fill : { color: '#888'}, icon: { src: 'images/link-properties/arrow-drop-grey.svg'} }),
+      new StyleRule().where('functionalClass').is(9).use({ stroke : { color: '#1b0'},  fill : { color: '#1b0'}, icon: { src: 'images/link-properties/arrow-drop-green.svg' } }),
     ];
 
     var unknownFunctionalClassDefaultRules = [

--- a/UI/src/view/navigationpanel/roadLinkBox.js
+++ b/UI/src/view/navigationpanel/roadLinkBox.js
@@ -49,20 +49,10 @@
     administrativeClassLegend.append(administrativeClassLegendEntries);
 
     var functionalClassLegend = $('<div class="panel-section panel-legend linear-asset-legend functional-class-legend"></div>');
-    var functionalClasses = [
-      [1, '1'],
-      [2, '2'],
-      [3, '3'],
-      [4, '4'],
-      [5, '5'],
-      [6, '6: Muu yksityistie'],
-      [7, '7: Ajopolku'],
-      [8, '8: Kävelyn ja pyöräilyn väylä']
-    ];
-    var functionalClassLegendEntries = _.map(functionalClasses, function(functionalClass) {
+    var functionalClassLegendEntries = _.map(enumerations.functionalClasses, function(functionalClass) {
       return '<div class="legend-entry">' +
-        '<div class="label">Luokka ' + functionalClass[1] + '</div>' +
-        '<div class="symbol linear linear-asset-' + functionalClass[0] + '" />' +
+        '<div class="label">' + functionalClass.text + '</div>' +
+        '<div class="symbol linear linear-asset-' + functionalClass.value + '" />' +
         '</div>';
     }).join('');
     functionalClassLegend.append(functionalClassLegendEntries);


### PR DESCRIPTION
Lisätty toiminnallinen luokka 9 käyttöliittymään. Backend-koodissa tämä jo olikin. Refaktoroitu functionalClass käytämään enumeration.js:ää. Tietokantamuutokset tiketissä, katselmoija voisi katsoa ne samalla.