### PR TITLE
 DROTH-4184 Added missing information to generated unknownSpeedLimits

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/RoadLink.scala
@@ -30,7 +30,7 @@ case class RoadLinkProperties(linkId: String,
 
 case class TinyRoadLink(linkId: String)
 
-case class RoadLinkForUnknownGeneration(linkId: String, length:Double, geometry: Seq[Point], trafficDirection:TrafficDirection, administrativeClass:AdministrativeClass, linkSource:LinkGeomSource)
+case class RoadLinkForUnknownGeneration(linkId: String, municipalityCode: Int, constructionType: ConstructionType, length:Double, geometry: Seq[Point], trafficDirection:TrafficDirection, administrativeClass:AdministrativeClass, linkSource:LinkGeomSource)
 
 case class RoadLink(linkId: String, geometry: Seq[Point],
                     length: Double, administrativeClass: AdministrativeClass,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/linearasset/PostGISSpeedLimitDao.scala
@@ -246,7 +246,7 @@ class PostGISSpeedLimitDao(val roadLinkService: RoadLinkService) extends Dynamic
     }.toSeq
 
     val emptyRoadLinks = emptyRoadLinkRows.map(rl => {
-      RoadLinkForUnknownGeneration(rl.linkId, rl.roadLinkLength, rl.geometry, rl.trafficDirection, rl.administrativeClass, rl.linkSource)
+      RoadLinkForUnknownGeneration(rl.linkId, rl.municipalityCode, rl.constructionType, rl.roadLinkLength, rl.geometry, rl.trafficDirection, rl.administrativeClass, rl.linkSource)
     })
     (speedLimitAssets, emptyRoadLinks)
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -69,11 +69,12 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
 
   def emptyRoadLinkToUnknownSpeedLimit(emptyRoadLinks: Seq[RoadLinkForUnknownGeneration]): Seq[PieceWiseLinearAsset] = {
     emptyRoadLinks.map(rl => {
+      val attributes = Map("municipality" -> rl.municipalityCode, "constructionType" -> rl.constructionType.value)
       PieceWiseLinearAsset(id = 0L, linkId = rl.linkId, sideCode = SideCode.BothDirections, value = None, geometry = rl.geometry,
         expired = false, startMeasure = 0.0, endMeasure = rl.length, endpoints = Set(rl.geometry.head, rl.geometry.last),
         modifiedBy = None, modifiedDateTime = None, createdBy = None, createdDateTime = None, typeId = SpeedLimitAsset.typeId,
         trafficDirection = rl.trafficDirection, timeStamp = 0L, geomModifiedDate = None, linkSource = rl.linkSource,
-        administrativeClass = rl.administrativeClass, attributes = Map.empty, verifiedBy = None, verifiedDate = None, informationSource = None)
+        administrativeClass = rl.administrativeClass, attributes = attributes, verifiedBy = None, verifiedDate = None, informationSource = None)
     })
   }
 


### PR DESCRIPTION
Lisätty puuttuvat tiedot piirrettäessä generoiduille nopeusrajoituksille. Kuntakoodin puute johti siihen, etteivät tuntemattomat kuuluneet minkään kunnan käyttäjille. constructionType lisätty future proofina, sillä myös se löytyy tunnetuilta nopeusrajoituksilta.