### PR TITLE
 DROTH-4196 Fixed migration file for history purposes

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_47__update_single_choice_value_and_delete_from_enumerated_value.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_47__update_single_choice_value_and_delete_from_enumerated_value.sql
@@ -37,7 +37,7 @@ SELECT ev.id
 FROM enumerated_value ev 
 JOIN property p ON ev.property_id = p.id
 AND public_id = 'paallysteluokka' AND 
-ev.name_fi IN ('Soratien pintaus', 'Sorakulutuskerros');
+ev.name_fi IN ('Sorakulutuskerros');
 
 WITH updated_rows AS (
     UPDATE single_choice_value  
@@ -63,7 +63,7 @@ SELECT ev.id
 FROM enumerated_value ev 
 JOIN property p ON ev.property_id = p.id
 AND public_id = 'paallysteluokka' AND 
-ev.name_fi IN ('Betoni', 'Muut pinnoitteet');
+ev.name_fi IN ('Soratien pintaus', 'Betoni', 'Muut pinnoitteet');
 
 WITH updated_rows AS (
     UPDATE single_choice_value  


### PR DESCRIPTION
Muutettu aiempi migraatio uuden määrittelyn mukaiseksi. Ei ajeta uudestaan, mutta hyvä olla korjattu historioinnin vuoksi, ja jos joskus täytyy alustaa kanta migraatioiden kanssa.

Näissä tapauksissa huomaa että olisi tosiaan parempi jos ero skeeman ja aineiston muokkauksen välillä pysyisi kliinisenä.