### PR TITLE
DROTH-3172 fix failing tests

### DIFF
--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -413,7 +413,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       val assetFields = Map("valtakunnallinen id" -> 1, "pysäkin nimi" -> "NewName")
       val csv =  massTransitStopImporterUpdate.csvRead(assetFields)
 
-      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser,  roadTypeLimitations = Set(Municipality))
+      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser,  roadTypeLimitations = Set(State, Private))
       result should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset(
         excludedRows = List(ExcludedRow(affectedRows = "State", csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(assetFields))))))
 
@@ -425,7 +425,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockMassTransitStopService)
       val csv = massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1, "pysäkin nimi" -> "NewName"))
 
-      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(Municipality))
+      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(State, Private))
       result should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
       val properties = Set(SimplePointAssetProperty("nimi_suomeksi", Seq(PropertyValue("NewName"))))
       verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
@@ -436,7 +436,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       val massTransitStopCsvOperation = new TestMassTransitStopCsvOperation(mockRoadLinkClient, mockRoadLinkService, mockEventBus, mockMassTransitStopService)
       val csv = massTransitStopImporterUpdate.csvRead(Map("valtakunnallinen id" -> 1, "pysäkin nimi" -> "NewName1"), Map("valtakunnallinen id" -> 2, "pysäkin nimi" -> "NewName2"))
 
-      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(State, Municipality))
+      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(Private))
       result should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
 
       val properties1 = Set(SimplePointAssetProperty("nimi_suomeksi", List(PropertyValue("NewName1", None, false))))
@@ -453,7 +453,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       val assetOnRoadFields = Map("valtakunnallinen id" -> 2, "pysäkin nimi" -> "NewName2")
       val csv = massTransitStopImporterUpdate.csvRead(assetOnStreetFields, assetOnRoadFields)
 
-      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(Private))
+      val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(State, Municipality))
       result should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset(
         excludedRows = List(ExcludedRow(affectedRows = "State", csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(assetOnRoadFields))),
           ExcludedRow(affectedRows = "Municipality", csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(assetOnStreetFields))))))


### PR DESCRIPTION
Testit on korjattu vastaamaan tiketillä käännettyä logiikkaa csv-importin tuontirajoituksissa.