### PR TITLE
 DROTH-4255 changeAPI to handle missing municipalityCodes on history links

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvClient.scala
@@ -289,7 +289,10 @@ class ExtractHistory extends ExtractorBase {
     val linkGeometryWKTForApi = Map("geometryWKT" -> (s"LINESTRING ZM (${path.map(point => anyToDouble(point(0)).get + " " + anyToDouble(point(1)).get + " " + anyToDouble(point(2)).get + " " + anyToDouble(point(3)).get).mkString(", ")})"))
 
     val linkId = attributes("id").asInstanceOf[String]
-    val municipalityCode = attributes("municipalitycode").asInstanceOf[String].toInt
+    val municipalityCode = attributes("municipalitycode") match {
+      case Some(value: String) => value.toInt
+      case _ => 0
+    }
     val roadClassCode = attributes("roadclass").asInstanceOf[String].toInt
     val roadClass = featureClassCodeToFeatureClass(roadClassCode)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/client/kgv/KgvOperation.scala
@@ -245,7 +245,10 @@ class Extractor extends ExtractorBase {
     val linkGeometryWKTForApi = Map("geometryWKT" -> (s"LINESTRING ZM (${path.map(point => anyToDouble(point(0)).get + " " + anyToDouble(point(1)).get + " " + anyToDouble(point(2)).get + " " + anyToDouble(point(3)).get).mkString(", ")})"))
 
     val linkId = attributes("id").asInstanceOf[String]
-    val municipalityCode = attributes("municipalitycode").asInstanceOf[String].toInt
+    val municipalityCode = attributes("municipalitycode") match {
+      case Some(value: String) => value.toInt
+      case _ => 0
+    }
 
     val geometryLength: Double = anyToDouble(attributes("horizontallength")).getOrElse(0.0)
 


### PR DESCRIPTION
Operaattorin uuden määrittelyn mukaan KGV:n rajapinnasta haetuille historialinkeille otetaan yhdenmukaisuuden nimissä käyttöön sama ratkaisu puuttuvan kuntakoodin suhteen kuin Digiroadin omissa kantaoperaatioissa, eli se esitetään keinotekoisena ei-mihinkään-viittaavana arvona 0 (RoadLinkDAO -> GetResult[RoadLinkFetched]). Tämä johtuu tavasta jolla slick.jdbc.PositionedResult reagoi null-arvoihin eikä vaikuta itsessään tavoitteelliselta ratkaisulta (ei ole dokumentoitu minnekään). 

Lopullinen tahtotila on kuitenkin, ettei tuntemattoman kuntakoodin käyttö jää pysyväksi eikä rajojen ulkopuolisia kohteita käsitellä tulevaisuudessa ollenkaan. Asiasta on kirjattu backlogille tiketti, jonka yhteydessä palataan myös historialinkkien käsittelyyn.