### PR TITLE
DROTH-3172 include complimentary links in roadtype limitation

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
@@ -159,7 +159,7 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
 
   private def updateAssetByNationalIdLimitedByRoadType(nationalId: Long, properties: Seq[AssetProperty], roadTypeLimitations: Set[AdministrativeClass], username: String, optPosition: Option[Position]): Either[AdministrativeClass, MassTransitStopWithProperties] = {
     def massTransitStopTransformation(stop: PersistedMassTransitStop): (CsvImportMassTransitStop, Option[FloatingReason]) = {
-      val roadLink = roadLinkService.fetchByLinkId(stop.linkId).orElse(roadLinkService.fetchComplimentaryByLinkId(stop.linkId))
+      val roadLink = roadLinkService.fetchNormalOrComplimentaryRoadLinkByLinkId(stop.linkId)
       val (floating, floatingReason) = massTransitStopService.isFloating(stop, roadLink)
       (CsvImportMassTransitStop(stop.id, floating, roadLink.map(_.administrativeClass).getOrElse(Unknown)), floatingReason)
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
@@ -159,7 +159,7 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
 
   private def updateAssetByNationalIdLimitedByRoadType(nationalId: Long, properties: Seq[AssetProperty], roadTypeLimitations: Set[AdministrativeClass], username: String, optPosition: Option[Position]): Either[AdministrativeClass, MassTransitStopWithProperties] = {
     def massTransitStopTransformation(stop: PersistedMassTransitStop): (CsvImportMassTransitStop, Option[FloatingReason]) = {
-      val roadLink = roadLinkService.fetchByLinkId(stop.linkId)
+      val roadLink = roadLinkService.fetchByLinkId(stop.linkId).orElse(roadLinkService.fetchComplimentaryByLinkId(stop.linkId))
       val (floating, floatingReason) = massTransitStopService.isFloating(stop, roadLink)
       (CsvImportMassTransitStop(stop.id, floating, roadLink.map(_.administrativeClass).getOrElse(Unknown)), floatingReason)
     }


### PR DESCRIPTION
Testauksessa huomattu, että csv-importissa tuotavien rivien hallinnolliseen luokkaan perustuvassa rajauksessa ei oteta täydentäviä linkkejä huomioon.