### PR TITLE
DROTH-4166 fix mandatory header behavior and roadname generation logic

### DIFF
--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/MassTransitStopCsvImporterSpec.scala
@@ -236,7 +236,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, Set())
 
     val properties = Set(SimplePointAssetProperty("yllapitajan_tunnus", Seq(PropertyValue("NewAdminId"))), SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))))
-    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
   }
 
   test("Should not update asset LiVi id by CSV import") {
@@ -247,7 +247,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
 
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, Set()) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
     val properties = Set(SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))), SimplePointAssetProperty("yllapitajan_tunnus", Seq(PropertyValue("Livi987654")))).filterNot(_.publicId == "yllapitajan_koodi")
-    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(),anyBoolean())
   }
 
   test("update asset stop code by CSV import") {
@@ -258,7 +258,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
 
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
     val properties = Set(SimplePointAssetProperty("matkustajatunnus", Seq(PropertyValue("H156"))), SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))))
-    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(),anyBoolean())
   }
 
   test("update additional information by CSV import", Tag("db")) {
@@ -270,7 +270,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
 
     massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
     val properties = Set(SimplePointAssetProperty("lisatiedot", Seq(PropertyValue("Updated additional info"))), SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))))
-    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
   }
 
   val exampleValues = Map(
@@ -333,7 +333,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       SimplePointAssetProperty(key, Seq(PropertyValue(value._2)))
     }.filterNot(_.publicId == "yllapitajan_koodi").toSet
 
-    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+    verify(mockService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
   }
 
   test("When imported value is a comma (-), value should be set to empty for text fields and unknown for multiple choice fields") {
@@ -348,7 +348,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
     massTransitStopCsvOperation.propertyUpdater.processing(csvWithDash, testUser, Set()) should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
 
     val properties2: Set[SimplePointAssetProperty] = Set(SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))),SimplePointAssetProperty("palauteosoite", Seq(PropertyValue(""))), SimplePointAssetProperty("pysakin_palvelutaso", Seq(PropertyValue("99"))))
-    verify(mockService).updateExistingById(ArgumentMatchers.eq(1L), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties2), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+    verify(mockService).updateExistingById(ArgumentMatchers.eq(1L), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties2), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
   }
 
   test("raise an error when updating non-existent asset", Tag("db")) {
@@ -378,7 +378,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       incompleteRows = List(IncompleteRow(missingParameters = List("pysäkin nimi"),
         csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(Map()) - "pysäkin nimi" ++ Map("valtakunnallinen id" -> 1, "tietojen ylläpitäjä" -> 1, "pysäkin tyyppi" -> 1))))))
 
-    verify(mockService, never).updateExistingById(anyLong(), anyObject(), anyObject(), anyString(), anyObject(), anyBoolean())
+    verify(mockService, never).updateExistingById(anyLong(), anyObject(), anyObject(), anyString(), anyObject(), anyBoolean(), anyBoolean())
   }
     test("ignore updates on other road types than streets when import is limited to streets") {
       val (mockMassTransitStopService, mockRoadLinkClient) = mockWithMassTransitStops(Seq((1l, State)))
@@ -390,7 +390,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       result should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset(
         excludedRows = List(ExcludedRow(affectedRows = "State", csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(assetFields))))))
 
-      verify(mockMassTransitStopService, never).updateExistingById(anyLong(), anyObject(), anyObject(), anyString(), anyObject(), anyBoolean())
+      verify(mockMassTransitStopService, never).updateExistingById(anyLong(), anyObject(), anyObject(), anyString(), anyObject(), anyBoolean(), anyBoolean())
     }
 
     test("update asset on street when import is limited to streets") {
@@ -401,7 +401,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
       val result = massTransitStopCsvOperation.propertyUpdater.processing(csv, testUser, roadTypeLimitations = Set(State, Private))
       result should equal(massTransitStopCsvOperation.propertyUpdater.ImportResultPointAsset())
       val properties = Set(SimplePointAssetProperty("nimi_suomeksi", Seq(PropertyValue("NewName"))), SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))))
-      verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+      verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
     }
 
     test("update asset on roads and streets when import is limited to roads and streets") {
@@ -414,8 +414,8 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
 
       val properties1 = Set(SimplePointAssetProperty("nimi_suomeksi", List(PropertyValue("NewName1"))), SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("1"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("1"))))
       val properties2 = Set(SimplePointAssetProperty("nimi_suomeksi", List(PropertyValue("NewName2"))), SimplePointAssetProperty("pysakin_tyyppi", Seq(PropertyValue("2"))), SimplePointAssetProperty("tietojen_yllapitaja", Seq(PropertyValue("2"))))
-      verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties1), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
-      verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(2l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties2), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean())
+      verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(1l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties1), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
+      verify(mockMassTransitStopService).updateExistingById(ArgumentMatchers.eq(2l), ArgumentMatchers.eq(None), ArgumentMatchers.eq(properties2), ArgumentMatchers.eq("CsvDataImportApiSpec"), anyObject(), anyBoolean(), anyBoolean())
     }
 
     test("ignore updates on all other road types than private roads when import is limited to private roads") {
@@ -430,7 +430,7 @@ class MassTransitStopCsvImporterSpec extends AuthenticatedApiSpec with BeforeAnd
         excludedRows = List(ExcludedRow(affectedRows = "State", csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(assetOnRoadFields))),
           ExcludedRow(affectedRows = "Municipality", csvRow = massTransitStopCsvOperation.propertyUpdater.rowToString(massTransitStopImporterUpdate.defaultValues(assetOnStreetFields))))))
 
-      verify(mockMassTransitStopService, never).updateExistingById(anyLong(), anyObject(), anyObject(), anyString(), anyObject(), anyBoolean())
+      verify(mockMassTransitStopService, never).updateExistingById(anyLong(), anyObject(), anyObject(), anyString(), anyObject(), anyBoolean(), anyBoolean())
     }
 
   private def csvToInputStream(csv: String): InputStream = new ByteArrayInputStream(csv.getBytes())

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/MassTransitStopCsvImporter.scala
@@ -76,10 +76,15 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
     new MassTransitStopServiceWithDynTransaction(eventBus, roadLinkService, roadAddressService)
   }
 
-  private val isValidTypeEnumeration = Set(1, 2, 5, 99)
+  private val isValidTypeEnumeration = Set(1, 2, 5)
   private val singleChoiceValueMappings = Set(1, 2, 99).map(_.toString)
-  private val stopAdministratorValueMappings = Set(1, 2, 3, 99).map(_.toString)
+  private val stopAdministratorValueMappings = Set(1, 2, 3).map(_.toString)
   private val serviceLevelValueMappings = Set(1, 2, 3, 4, 5, 6, 7, 8, 99).map(_.toString)
+
+  private val roadNameMappings = Map(
+    "osoite suomeksi" -> "osoite_suomeksi",
+    "osoite ruotsiksi" -> "osoite_ruotsiksi"
+  )
 
   private val textFieldMappings = Map(
     "pysäkin nimi" -> "nimi_suomeksi",
@@ -91,14 +96,12 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
     "vyöhyketieto" -> "vyohyketieto",
     "vaihtoehtoinen link_id" -> "alternative_link_id",
     "pysäkin omistaja" -> "pysakin_omistaja",
-    "osoite suomeksi" -> "osoite_suomeksi",
-    "osoite ruotsiksi" -> "osoite_ruotsiksi",
     "laiturinumero" -> "laiturinumero",
     "esteettömyys liikuntarajoitteiselle" -> "esteettomyys_liikuntarajoitteiselle",
     "liityntäpysäköintipaikkojen määrä" -> "liityntapysakointipaikkojen_maara",
     "liityntäpysäköinnin lisätiedot" -> "liityntapysakoinnin_lisatiedot",
     "palauteosoite" -> "palauteosoite"
-  )
+  ) ++ roadNameMappings
 
   val massTransitStopType = Map("pysäkin tyyppi" -> "pysakin_tyyppi")
 
@@ -140,7 +143,7 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
     "viimeinen voimassaolopäivä" -> "viimeinen_voimassaolopaiva"
   ) ++ inventoryDateMapping
 
-  val mandatoryMappings = nationalIdMapping ++ stopAdministratorProperty ++ massTransitStopType
+  val mandatoryMappings = nationalIdMapping
 
   val mappings: Map[String, String] = textFieldMappings ++ multipleChoiceFieldMappings ++ singleChoiceFieldMappings ++ dateFieldsMapping ++ coordinateMappings
 
@@ -159,7 +162,7 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
     val optionalAsset = massTransitStopService.getMassTransitStopByNationalId(nationalId, municipalityValidation, false)
     optionalAsset match {
       case Some(asset) =>
-        massTransitStopService.updateExistingById(asset.id, optPosition, convertProperties(properties).toSet, user.username, (_, _) => Unit, false)
+        massTransitStopService.updateExistingById(asset.id, optPosition, convertProperties(properties).toSet, user.username, (_, _) => Unit, true,false)
       case None => throw new AssetNotFoundException(nationalId)
     }
   }
@@ -188,7 +191,7 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
     optionalAsset match {
       case Some(asset) =>
         val roadLinkType = asset.roadLinkType
-        if (!roadTypeLimitations(roadLinkType)) Right(massTransitStopService.updateExistingById(asset.id, optPosition, convertProperties(properties).toSet, username, (_, _) => Unit, false))
+        if (!roadTypeLimitations(roadLinkType)) Right(massTransitStopService.updateExistingById(asset.id, optPosition, convertProperties(properties).toSet, username, (_, _) => Unit, true, false))
         else Left(roadLinkType)
       case None => throw new AssetNotFoundException(nationalId)
     }
@@ -245,6 +248,8 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
       } else if (value.equals("-")) {
           if (mandatoryMappings.contains(key)) {
             result.copy(_1 = List(key) ::: result._1, _2 = result._2)
+          } else if (multipleChoiceFieldMappings.contains(key)) {
+            result.copy(_1 = List(key) ::: result._1, _2 = result._2)
           } else if (singleChoiceFieldMappings.contains(key)) {
             val (malformedParameters, properties) = assetSingleChoiceToProperty(key, Unknown.value.toString)
             result.copy(_1 = malformedParameters ::: result._1, _2 = properties ::: result._2)
@@ -252,12 +257,12 @@ trait MassTransitStopCsvImporter extends PointAssetCsvImporter {
             result.copy(_2 = AssetProperty(columnName = inventoryDateMapping(key), value = Seq(PropertyValue(value))) :: result._2)
           } else if (dateFieldsMapping.contains(key)) {
             result.copy(_2 = AssetProperty(columnName = dateFieldsMapping(key), value = Seq(PropertyValue(""))) :: result._2)
+          } else if (roadNameMappings.contains(key)) {
+            result.copy(_2 = AssetProperty(columnName = roadNameMappings(key), value = Seq(PropertyValue("-"))) :: result._2)
           } else if (textFieldMappings.contains(key)) {
             result.copy(_2 = AssetProperty(columnName = textFieldMappings(key), value = Seq(PropertyValue(""))) :: result._2)
           } else if (longValueFieldsMapping.contains(key)) {
             result.copy(_2 = AssetProperty(columnName = longValueFieldsMapping(key), value = Seq(PropertyValue(""))) :: result._2)
-          } else if (multipleChoiceFieldMappings.contains(key)) {
-            result.copy(_2 = AssetProperty(columnName = multipleChoiceFieldMappings(key), value = Seq(PropertyValue(Unknown.value.toString))) :: result._2)
           } else result
       } else {
         if (longValueFieldsMapping.contains(key)) {
@@ -398,8 +403,8 @@ class Updater(roadLinkClientImpl: RoadLinkClient, roadLinkServiceImpl: RoadLinkS
   override def roadLinkClient: RoadLinkClient = roadLinkClientImpl
   override def eventBus: DigiroadEventBus = eventBusImpl
 
-  override def mandatoryFields: Set[String] = nationalIdMapping.keySet ++ stopAdministratorProperty.keySet ++ massTransitStopType.keySet
-  override val decisionFieldsMapping = nationalIdMapping ++ stopAdministratorProperty ++ massTransitStopType
+  override def mandatoryFields: Set[String] = nationalIdMapping.keySet
+  override val decisionFieldsMapping = nationalIdMapping
   override def mandatoryFieldsMapping: Map[String, String] = mappings ++ nationalIdMapping
 
   override def createOrUpdate(row: Map[String, String], roadTypeLimitations: Set[AdministrativeClass], user: User, properties: ParsedProperties): List[ExcludedRow] = {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MassTransitStopDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/MassTransitStopDao.scala
@@ -294,6 +294,16 @@ class MassTransitStopDao {
     Q.query[(Long, Long), Long](existsMultipleChoiceProperty).apply((assetId, propertyId)).firstOption.isEmpty
   }
 
+  /**
+   * Updates asset specific properties when updated via CSV import.
+   * Inserting an empty value in a CSV row does not alter the property value unlike an empty value in the UI sets the value as empty.
+   * Therefore updates from CSV import require a separate implementation.
+   * @param assetId
+   * @param propertyPublicId
+   * @param propertyId
+   * @param propertyType
+   * @param propertyValues
+   */
   private def updateAssetSpecificPropertyFromCSV(assetId: Long, propertyPublicId: String, propertyId: Long, propertyType: String, propertyValues: Seq[PropertyValue]) {
     propertyType match {
       case Text | LongText => {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ServicePointBusStopDao.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/ServicePointBusStopDao.scala
@@ -159,7 +159,7 @@ class ServicePointBusStopDao extends MassTransitStopDao {
     (Q.query[Long, String](propertyTypeByPropertyId).apply(propertyId).first, Some(propertyId), property)
   }
 
-  override def updateAssetProperties(assetId: Long, properties: Seq[SimplePointAssetProperty]) {
+  private def updateAssetProperties(assetId: Long, properties: Seq[SimplePointAssetProperty]) {
     properties.filterNot(prop => AssetPropertyConfiguration.commonAssetProperties.contains(prop.publicId)).map(propertyWithTypeAndId).foreach { propertyWithTypeAndId =>
       updateProperties(assetId, propertyWithTypeAndId._3.publicId, propertyWithTypeAndId._2.get, propertyWithTypeAndId._1, propertyWithTypeAndId._3.values)
     }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/BusStopStrategy.scala
@@ -199,7 +199,7 @@ class BusStopStrategy(val typeId : Int, val massTransitStopDao: MassTransitStopD
     (resultAsset, PublishInfo(Some(resultAsset)))
   }
 
-  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink): (PersistedMassTransitStop, AbstractPublishInfo) = {
+  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink, isCsvImported: Boolean): (PersistedMassTransitStop, AbstractPublishInfo) = {
 
     if (properties.exists(prop => prop.publicId == "vaikutussuunta")) {
       validateBusStopDirections(properties.toSeq, roadLink)
@@ -218,8 +218,8 @@ class BusStopStrategy(val typeId : Int, val massTransitStopDao: MassTransitStopD
     val commonAssetProperties = AssetPropertyConfiguration.commonAssetProperties.
       filterNot(_._1 == AssetPropertyConfiguration.ValidityDirectionId)
 
-    val props = MassTransitStopOperations.setPropertiesDefaultValues(properties.toSeq, roadLink)
-    updatePropertiesForAsset(asset.id, props, roadLink.administrativeClass, asset.nationalId)
+    val props = MassTransitStopOperations.setPropertiesDefaultValues(properties.toSeq, roadLink, isCsvImported)
+    updatePropertiesForAsset(asset.id, props, roadLink.administrativeClass, asset.nationalId, isCsvImported)
 
     val resultAsset = enrichBusStop(fetchAsset(asset.id))._1
     (resultAsset, PublishInfo(Some(resultAsset)))

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/MassTransitStopOperations.scala
@@ -183,7 +183,7 @@ object MassTransitStopOperations {
       .getOrElse("")
   }
 
-  def setPropertiesDefaultValues(properties: Seq[SimplePointAssetProperty], roadLink: RoadLinkLike): Seq[SimplePointAssetProperty] = {
+  def setPropertiesDefaultValues(properties: Seq[SimplePointAssetProperty], roadLink: RoadLinkLike, isCsvImported: Boolean = false): Seq[SimplePointAssetProperty] = {
     val arrayProperties = Seq(MassTransitStopOperations.RoadName_FI, MassTransitStopOperations.RoadName_SE )
     val defaultproperties =  arrayProperties.flatMap{
       key =>
@@ -194,7 +194,9 @@ object MassTransitStopOperations {
     } ++ properties
 
     defaultproperties.map { parameter =>
-      if ((parameter.values.exists(_.asInstanceOf[PropertyValue].propertyValue == "") && parameter.values.exists(_.asInstanceOf[PropertyValue].propertyDisplayValue.nonEmpty)) || parameter.values.exists(_.asInstanceOf[PropertyValue].propertyValue == "" && parameter.values.exists(_.asInstanceOf[PropertyValue].propertyDisplayValue == None))) {
+      if ((isCsvImported && parameter.values.exists(_.asInstanceOf[PropertyValue].propertyValue == "-")) ||
+        (!isCsvImported && (parameter.values.isEmpty || parameter.values.exists(_.asInstanceOf[PropertyValue].propertyValue == "")))) {
+
         parameter.publicId match {
           case MassTransitStopOperations.RoadName_FI => parameter.copy(values = Seq(PropertyValue(roadLink.attributes.getOrElse("ROADNAME_FI", "").toString)))
           case MassTransitStopOperations.RoadName_SE => parameter.copy(values = Seq(PropertyValue(roadLink.attributes.getOrElse("ROADNAME_SE", "").toString)))
@@ -202,7 +204,6 @@ object MassTransitStopOperations {
         }
       } else
         parameter
-
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/OthBusStopLifeCycleBusStopStrategy.scala
@@ -107,12 +107,12 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
     (persistedAsset, PublishInfo(Some(persistedAsset)))
   }
 
-  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], props: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink): (PersistedMassTransitStop, AbstractPublishInfo) = {
+  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], props: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink, isCsvImported: Boolean): (PersistedMassTransitStop, AbstractPublishInfo) = {
     if(props.exists(prop => prop.publicId == "vaikutussuunta")) {
       validateBusStopDirections(props.toSeq, roadLink)
     }
 
-    val properties = MassTransitStopOperations.setPropertiesDefaultValues(props.toSeq, roadLink).toSet
+    val properties = MassTransitStopOperations.setPropertiesDefaultValues(props.toSeq, roadLink, isCsvImported).toSet
 
     if (MassTransitStopOperations.mixedStoptypes(properties))
       throw new IllegalArgumentException
@@ -135,19 +135,19 @@ class OthBusStopLifeCycleBusStopStrategy(typeId : Int, massTransitStopDao: MassT
     if (was(asset)) {
       val liviId = getLiviIdValue(asset.propertyData).orElse(getLiviIdValue(properties.toSeq)).getOrElse(throw new NoSuchElementException)
       update(asset, optionalPosition, verifiedProperties.toSeq, roadLink, liviId,
-          username)
+        username, isCsvImported)
     } else {
       //Updates the asset in OTH with new liviId
       update(asset, optionalPosition, verifiedProperties.toSeq, roadLink, toLiviId.format(asset.nationalId),
-        username)
+        username, isCsvImported)
     }
   }
 
 
-  private def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Seq[SimplePointAssetProperty], roadLink: RoadLink, liviId: String, username: String): (PersistedMassTransitStop, AbstractPublishInfo) = {
+  private def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Seq[SimplePointAssetProperty], roadLink: RoadLink, liviId: String, username: String, isCsvImported: Boolean): (PersistedMassTransitStop, AbstractPublishInfo) = {
     optionalPosition.map(updatePositionWithBearing(asset.id, roadLink))
     massTransitStopDao.updateAssetLastModified(asset.id, username)
-    massTransitStopDao.updateAssetProperties(asset.id, properties)
+    massTransitStopDao.updateAssetProperties(asset.id, properties, isCsvImported)
     massTransitStopDao.updateTextPropertyValue(asset.id, MassTransitStopOperations.LiViIdentifierPublicId, liviId)
     updateAdministrativeClassValue(asset.id, roadLink.administrativeClass)
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminalBusStopStrategy.scala
@@ -105,7 +105,7 @@ class TerminalBusStopStrategy(typeId : Int, massTransitStopDao: MassTransitStopD
     (resultAsset, TerminalPublishInfo(Some(resultAsset), children, Seq()))
   }
 
-  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink): (PersistedMassTransitStop, AbstractPublishInfo) = {
+  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink, isCsvImported: Boolean = false): (PersistedMassTransitStop, AbstractPublishInfo) = {
 
     if (MassTransitStopOperations.mixedStoptypes(properties))
       throw new IllegalArgumentException

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/pointasset/masstransitstop/TerminatedBusStopStrategy.scala
@@ -43,7 +43,7 @@ class TerminatedBusStopStrategy(typeId: Int, massTransitStopDao: MassTransitStop
     val isOnTerminatedRoad = properties.find(_.publicId == MassTransitStopOperations.FloatingReasonPublicId).exists(_.values.headOption.exists(_.asInstanceOf[PropertyValue].propertyValue == FloatingReason.TerminatedRoad.value.toString))
     isOnTerminatedRoad
   }
-  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink): (PersistedMassTransitStop, AbstractPublishInfo) = {
+  override def update(asset: PersistedMassTransitStop, optionalPosition: Option[Position], properties: Set[SimplePointAssetProperty], username: String, municipalityValidation: (Int, AdministrativeClass) => Unit, roadLink: RoadLink, isCsvImported: Boolean = false): (PersistedMassTransitStop, AbstractPublishInfo) = {
     if(!allowedPropertyChanges(properties) || changesOnDefaultValues(properties, asset))
       throw new UnsupportedOperationException("Changes on bus stops on terminated roads only allowed on: " + allowedChanges.mkString(","))
 


### PR DESCRIPTION
Osoitteiden generointi ei toiminut oikein kaikissa tilanteissa joten vaihdoin käyttämään booleania csv-importin tunnistamiseksi, ettei mene liian monimutkaiseksi setPropertiesDefaultValues-funktion toteutus. Tämä vaikutti myös testeihin, jotka muokattu sisältämään uusi boolean arvo.

Lisäksi ominaisuustiedoilta pysäkin tyyppi ja tietojen ylläpitäjä, on riisuttu pakollisuus, sekä mahdollisuus asettaa CSV-importissa arvoon 99 (ei tietoa).