### PR TITLE
DROTH-4251 remove duplicate ol-popup styling

### DIFF
--- a/UI/src/less/site/pop-up-map-plugins.less
+++ b/UI/src/less/site/pop-up-map-plugins.less
@@ -139,20 +139,6 @@
   }
 }
 
-.ol-popup {
-  position: absolute;
-  color: white;
-  background-color: #383836;
-  -webkit-filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
-  filter: drop-shadow(0 1px 4px rgba(0,0,0,0.2));
-  padding: 5px;
-  border-radius: 5px;
-  border: 1px solid #383836;
-  top: 12px;
-  left: -50px;
-  min-width: 150px;
-}
-
 #pop-up-mapdiv {
   position: relative; /* Allow absolutely positioned children */
   width: 100%;


### PR DESCRIPTION
Kääntymisrajoituksien worklist työkalun UI-koodissa oli määritelty uudelleen .ol-pop-up luokan tyyli, jota ei todellisuudessa käytetä työkalussa. Kaksoismäärittely sekoitti Tieosoiteinfo-työkalun tyylin. 