### PR TITLE
 DROTH-4265 increase varchart length so that velho assets can be saved

### DIFF
--- a/digiroad2-oracle/src/main/resources/db/migration/V1_52__increase_externalId_lenght.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_52__increase_externalId_lenght.sql
@@ -1,0 +1,1 @@
+ALTER TABLE asset ALTER COLUMN external_ids TYPE varchar(10000) USING external_ids::varchar(10000);


### PR DESCRIPTION
Lisätään merkijonon pituus 10000, varmasti riittää.