### PR TITLE
 DROTH-4218 add prohibition additionalInfo to intergrationAPI output

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/IntegrationApi.scala
@@ -277,7 +277,7 @@ class IntegrationApi(val massTransitStopService: MassTransitStopService, implici
           case Nil => Map()
           case _ => Map("validityPeriods" -> prohibitionValue.validityPeriods.map(toTimeDomain))
         }
-        Map("typeId" -> prohibitionValue.typeId) ++ validityPeriods ++ exceptions
+        Map("typeId" -> prohibitionValue.typeId) ++ validityPeriods ++ exceptions ++ Map("additionalInfo" -> prohibitionValue.additionalInfo)
       }
       case Some(TextualValue(x)) => x.split("\n").toSeq
       case Some(DynamicValue(x)) => x.properties.flatMap { dynamicTypeProperty => dynamicTypeProperty.values.map { v =>


### PR DESCRIPTION
Lisätty tarkennetieto mukaan ajoneuvokohtaisten rajoitusten integraatio-APIssa välitettävään dataan. 