### PR TITLE
DROTH-4213 ignore commas within quotes to fix split bug

### DIFF
--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/RoadLinkDAO.scala
@@ -560,7 +560,9 @@ class RoadLinkDAO {
       case Some(sqlArray: SqlArray) =>
         sqlArray.getArray.asInstanceOf[Array[AnyRef]].collect {
           case pgObject: PGobject =>
-            val Array(name, value, modifiedDate, modifiedBy) = pgObject.getValue.stripPrefix("(").stripSuffix(")").split(",", -1)
+            // Some private road association names may contain commas. These commas are ignored with this pattern.
+            val commasOutsideQuotedStrings = """,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)"""
+            val Array(name, value, modifiedDate, modifiedBy) = pgObject.getValue.stripPrefix("(").stripSuffix(")").split(commasOutsideQuotedStrings, -1)
             (
               Option(name).filter(_.nonEmpty).map(cleanValue),
               Option(value).filter(_.nonEmpty).map(cleanValue),


### PR DESCRIPTION
Jos yksityistien tiekunnan nimessä on pilkku, split erottaa nimen osat toisistaan. Lisätty regex splittaa vain pilkuilla, jotka eivät ole lainausmerkkien sisällä.