### PR TITLE
Droth 4342 speedlimits bug fix

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
@@ -44,27 +44,23 @@ object LinearAssetPartitioner extends GraphPartitioner {
       roadNumber.orElse(roadNameFi).orElse(roadNameSe)
     }
 
-    val groupedTwoWay = twoWayLinks.groupBy { link =>
-      (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0, link.trafficDirection, link.attributes.get("ROADPARTNUMBER").orElse(None))
+    def partitionLinkGroup(linkGroup:  Seq[T]):Seq[Seq[T]] = {
+      val grouped = linkGroup.groupBy { link =>
+        (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0, link.trafficDirection, link.attributes.get("ROADPARTNUMBER").orElse(None))
+      }
+
+      val (linksToPartition, linksToPass) = grouped.partition { case ((roadIdentifier, _, _, _, _, _), _) => roadIdentifier.isDefined }
+      val clusters = linksToPartition.values.map(p => {
+        clusterLinks(p)
+      }).toSeq.flatten
+
+      val linkPartitions = clusters.map(linksFromCluster)
+      val result = linkPartitions ++ linksToPass.values.flatten.map(x => Seq(x))
+      result
     }
 
-    val groupedOneWay = oneWayLinks.groupBy { link =>
-      (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0, link.trafficDirection, link.attributes.get("ROADPARTNUMBER").orElse(None))
-    }
-
-    val (linksToPartitionTwoWay, linksToPassTwoWay) = groupedTwoWay.partition { case ((roadIdentifier, _, _, _, _, _), _) => roadIdentifier.isDefined }
-    val clustersTwoWay = linksToPartitionTwoWay.values.map(p => {
-      clusterLinks(p)
-    }).toSeq.flatten
-    val linkPartitionsTwoWay = clustersTwoWay.map(linksFromCluster)
-    val twoWayResult = linkPartitionsTwoWay ++ linksToPassTwoWay.values.flatten.map(x => Seq(x))
-
-    val (linksToPartitionOneWay, linksToPassOneWay) = groupedOneWay.partition { case ((roadIdentifier, _, _, _, _, _), _) => roadIdentifier.isDefined }
-    val clustersOneWay = linksToPartitionOneWay.values.map(p => {
-      clusterLinks(p)
-    }).toSeq.flatten
-    val linkPartitionsOneWay = clustersOneWay.map(linksFromCluster)
-    val oneWayResult = linkPartitionsOneWay ++ linksToPassOneWay.values.flatten.map(x => Seq(x))
+    val twoWayResult = partitionLinkGroup(twoWayLinks)
+    val oneWayResult = partitionLinkGroup(oneWayLinks)
 
     twoWayResult ++ oneWayResult
   }

--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
@@ -44,18 +44,28 @@ object LinearAssetPartitioner extends GraphPartitioner {
       roadNumber.orElse(roadNameFi).orElse(roadNameSe)
     }
 
-    val linkGroups = twoWayLinks.groupBy { link =>
-      (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0, link.trafficDirection, link.attributes.get("ROADPARTNUMBER").orElse(None))
-
-    } ++ oneWayLinks.groupBy { link =>
+    val groupedTwoWay = twoWayLinks.groupBy { link =>
       (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0, link.trafficDirection, link.attributes.get("ROADPARTNUMBER").orElse(None))
     }
 
-    val (linksToPartition, linksToPass) = linkGroups.partition { case ((roadIdentifier, _, _, _, _, _), _) => roadIdentifier.isDefined }
-    val clusters = linksToPartition.values.map(p => {
+    val groupedOneWay = oneWayLinks.groupBy { link =>
+      (extractRoadIdentifier(link), link.administrativeClass, link.value, link.id == 0, link.trafficDirection, link.attributes.get("ROADPARTNUMBER").orElse(None))
+    }
+
+    val (linksToPartitionTwoWay, linksToPassTwoWay) = groupedTwoWay.partition { case ((roadIdentifier, _, _, _, _, _), _) => roadIdentifier.isDefined }
+    val clustersTwoWay = linksToPartitionTwoWay.values.map(p => {
       clusterLinks(p)
     }).toSeq.flatten
-    val linkPartitions = clusters.map(linksFromCluster)
-    linkPartitions ++ linksToPass.values.flatten.map(x => Seq(x))
+    val linkPartitionsTwoWay = clustersTwoWay.map(linksFromCluster)
+    val twoWayResult = linkPartitionsTwoWay ++ linksToPassTwoWay.values.flatten.map(x => Seq(x))
+
+    val (linksToPartitionOneWay, linksToPassOneWay) = groupedOneWay.partition { case ((roadIdentifier, _, _, _, _, _), _) => roadIdentifier.isDefined }
+    val clustersOneWay = linksToPartitionOneWay.values.map(p => {
+      clusterLinks(p)
+    }).toSeq.flatten
+    val linkPartitionsOneWay = clustersOneWay.map(linksFromCluster)
+    val oneWayResult = linkPartitionsOneWay ++ linksToPassOneWay.values.flatten.map(x => Seq(x))
+
+    twoWayResult ++ oneWayResult
   }
 }


### PR DESCRIPTION
LinearAssetPartitioner partition funktiossa oli bugi, jonka takia osa nopeusrajoituksista (mahdollisesti myös muilla tietolajeilla toistuisi) ei palautunut funktiosta, eivätkä siten piirtyneet. Bugin aiheutti tapa, jolla rivillä 50 yhdistettiin oneWay ja twoWay assettien mapit ++ operaattorilla. Jos jälkimmäisessä mapissa oli sama avain kuin ensimmäisessä mapissa, niin kyseisen avaimen arvot ylikirjoitettiin jälkimmäisen mapin arvoilla.

Käsitellään nyt twoWay ja oneWay assetit erikseen kunnes lopussa yhdistetään lopulliset Seq[Seq[T]] tulokset