### PR TITLE
Droth 4336 editing restrictions

### DIFF
--- a/UI/src/application.js
+++ b/UI/src/application.js
@@ -150,6 +150,7 @@
         window.applicationModel.selectLayer(assetTypeLayerName);
       });
     });
+    backend.getEditingRestrictions();
   };
 
   var startApplication = function(backend, models, linearAssets, pointAssets, withTileMaps, startupParameters, roadCollection, verificationInfoCollection, assetConfiguration, isExperimental, clusterDistance) {
@@ -374,6 +375,7 @@
         style: PointAssetStyle(asset.layerName),
         mapOverlay: mapOverlay,
         layerName: asset.layerName,
+        typeId: asset.typeId,
         assetLabel: asset.label,
         newAsset: asset.newAsset,
         roadAddressInfoPopup: roadAddressInfoPopup,

--- a/UI/src/authorizationpolicies/editingRestrictions.js
+++ b/UI/src/authorizationpolicies/editingRestrictions.js
@@ -1,0 +1,53 @@
+(function(root) {
+    root.EditingRestrictions = function() {
+        var me = this;
+        var backend = new Backend();
+        me.restrictions = [];
+        me.fetched = false;
+
+        backend.getEditingRestrictions();
+
+        eventbus.on('editingRestrictions:fetched', function(restrictions) {
+            me.restrictions = restrictions;
+            me.fetched = true;
+        });
+
+        me.hasStateRestriction = function(linearAsset, typeId) {
+            return _.some(linearAsset, function(asset){
+                if (asset.administrativeClass === 1 || asset.administrativeClass === 'State') {
+                    var restriction = _.find(me.restrictions, { municipalityId: asset.municipalityCode });
+                    return restriction && restriction.stateRoadRestrictedAssetTypes.includes(typeId);
+                }
+                return false;
+            });
+        };
+
+        me.hasMunicipalityRestriction = function(linearAsset, typeId) {
+            return _.some(linearAsset, function(asset){
+                if (asset.administrativeClass === 2 || asset.administrativeClass === 'Municipality') {
+                    var restriction = _.find(me.restrictions, { municipalityId: asset.municipalityCode });
+                    return restriction && restriction.municipalityRoadRestrictedAssetTypes.includes(typeId);
+                }
+                return false;
+            });
+        };
+
+        me.hasRestrictions = function (linearAsset, typeId) {
+            return me.hasStateRestriction(linearAsset, typeId) || me.hasMunicipalityRestriction(linearAsset, typeId);
+        };
+
+        me.pointAssetHasRestriction = function (municipalityCode, adminClass, typeId) {
+            var restriction = _.find(me.restrictions, { municipalityId: municipalityCode});
+            if (adminClass === '1' || adminClass === 'State') {
+                return restriction && restriction.stateRoadRestrictedAssetTypes.includes(typeId);
+            }
+            if (adminClass === '2' || adminClass === 'Municipality') {
+                return restriction && restriction.municipalityRoadRestrictedAssetTypes.includes(typeId);
+            }
+            return false;
+        };
+
+    };
+})(this);
+
+

--- a/UI/src/authorizationpolicies/editingRestrictions.js
+++ b/UI/src/authorizationpolicies/editingRestrictions.js
@@ -14,9 +14,17 @@
 
         me.hasStateRestriction = function(linearAsset, typeId) {
             return _.some(linearAsset, function(asset){
-                if (asset.administrativeClass === 1 || asset.administrativeClass === 'State') {
-                    var restriction = _.find(me.restrictions, { municipalityId: asset.municipalityCode });
-                    return restriction && restriction.stateRoadRestrictedAssetTypes.includes(typeId);
+                var restriction = _.find(me.restrictions, { municipalityId: asset.municipalityCode });
+                if (asset.administrativeClass) {
+                    if (asset.administrativeClass === 1 || asset.administrativeClass === 'State') {
+                        return restriction && restriction.stateRoadRestrictedAssetTypes.includes(typeId);
+                    }
+                // for lanes, admin class has to be derived from links
+                } else {
+                    var adminClasses = _.map(asset.selectedLinks, 'administrativeClass');
+                    if (adminClasses.includes(1)) {
+                        return restriction && restriction.stateRoadRestrictedAssetTypes.includes(typeId);
+                    }
                 }
                 return false;
             });
@@ -24,9 +32,16 @@
 
         me.hasMunicipalityRestriction = function(linearAsset, typeId) {
             return _.some(linearAsset, function(asset){
-                if (asset.administrativeClass === 2 || asset.administrativeClass === 'Municipality') {
-                    var restriction = _.find(me.restrictions, { municipalityId: asset.municipalityCode });
-                    return restriction && restriction.municipalityRoadRestrictedAssetTypes.includes(typeId);
+                var restriction = _.find(me.restrictions, {municipalityId: asset.municipalityCode});
+                if (asset.administrativeClass) {
+                    if (asset.administrativeClass === 2 || asset.administrativeClass === 'Municipality') {
+                        return restriction && restriction.municipalityRoadRestrictedAssetTypes.includes(typeId);
+                    }
+                } else {
+                    var adminClasses = _.map(asset.selectedLinks, 'administrativeClass');
+                    if (adminClasses.includes(2)) {
+                        return restriction && restriction.municipalityRoadRestrictedAssetTypes.includes(typeId);
+                    }
                 }
                 return false;
             });

--- a/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
+++ b/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
@@ -3,6 +3,8 @@
     AuthorizationPolicy.call(this);
 
     var me = this;
+    var editingRestrictions = new EditingRestrictions();
+    var typeId = 10;
 
     this.isElyMaintainerOrOperator = function(municipalityCode) {
       return (me.isElyMaintainer() && me.hasRightsInMunicipality(municipalityCode)) || me.isOperator();
@@ -32,6 +34,9 @@
 
     this.assetSpecificAccess = function(){
       var municipalityCode = selectedMassTransitStopModel.getMunicipalityCode();
+      var adminClass = selectedMassTransitStopModel.getAdministrativeClass();
+
+      if (editingRestrictions.pointAssetHasRestriction(municipalityCode, adminClass, typeId)) return false;
 
       var isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() && !selectedMassTransitStopModel.isAdminClassState() && me.hasRightsInMunicipality(municipalityCode);
       var isElyyAndHaveRights = me.isElyMaintainer() && me.hasRightsInMunicipality(municipalityCode);

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -532,20 +532,29 @@
       }
     }
 
-    function isAdminClassState(properties){
-      if(!properties)
-        properties = getProperties();
+    function getAdministrativeClass(properties) {
+      if (!properties) properties = getProperties();
 
       var adminClassProperty = _.find(properties, function(property){
         return property.publicId === 'linkin_hallinnollinen_luokka';
       });
 
-      if (adminClassProperty && !_.isEmpty(adminClassProperty.values))
-        return _.some(adminClassProperty.values, function(value){ return value.propertyValue === '1'; });
+      if (adminClassProperty && !_.isEmpty(adminClassProperty.values)) {
+        return _.first(adminClassProperty.values).propertyValue;
+      }
 
-      //Get administration class from roadlink
       var stopRoadLink = getRoadLink();
-      return stopRoadLink ? (stopRoadLink.getData().administrativeClass === 'State') : false;
+      if (stopRoadLink) {
+        return stopRoadLink.getData().administrativeClass;
+      }
+
+      return null;
+    }
+
+    function isAdminClassState(properties) {
+      var adminClass = getAdministrativeClass(properties);
+
+      return adminClass === '1' || adminClass === 'State';
     }
 
     function isAdministratorHSL(properties){
@@ -674,6 +683,7 @@
       getCurrentAsset: getCurrentAsset,
       deleteMassTransitStop: deleteMassTransitStop,
       getRoadLink: getRoadLink,
+      getAdministrativeClass: getAdministrativeClass,
       isAdminClassState: isAdminClassState,
       isAdministratorELY: isAdministratorELY,
       isAdministratorHSL: isAdministratorHSL,

--- a/UI/src/utils/backend-utils.js
+++ b/UI/src/utils/backend-utils.js
@@ -502,6 +502,12 @@
       });
     };
 
+    this.getEditingRestrictions = function () {
+      $.get('api/editingRestrictions', function (restrictions) {
+        eventbus.trigger('editingRestrictions:fetched', restrictions);
+      });
+    };
+
     this.getStartupParametersWithCallback = function(callback) {
       var url = 'api/startupParameters';
       $.getJSON(url, callback);

--- a/UI/src/view/assetCreationRestrictedPopup.js
+++ b/UI/src/view/assetCreationRestrictedPopup.js
@@ -1,0 +1,38 @@
+window.AssetCreationRestrictedPopup = function(message) {
+    var confirmDiv =
+        '<div class="modal-overlay confirm-modal">' +
+        '<div class="modal-dialog">' +
+        '<div class="content">' +
+        message +
+        '</div>' +
+        '<div class="actions">' +
+        '<button class="btn btn-secondary close">Sulje</button>' +
+        '</div>' +
+        '</div>' +
+        '</div>';
+
+    var renderConfirmDialog = function() {
+        jQuery('.container').append(confirmDiv);
+        var modal = $('.modal-dialog');
+    };
+
+    var bindEvents = function() {
+        jQuery('.confirm-modal .close').on('click', function() {
+            purge();
+        });
+    };
+
+    var show = function() {
+        purge();
+        renderConfirmDialog();
+        bindEvents();
+    };
+
+    var purge = function() {
+        jQuery('.confirm-modal').remove();
+    };
+
+    show();
+};
+
+

--- a/UI/src/view/dynamicAssetForm.js
+++ b/UI/src/view/dynamicAssetForm.js
@@ -958,7 +958,7 @@
         };
 
         this._isReadOnly = function(selectedAsset){
-            return applicationModel.isReadOnly() || editingRestrictions.hasRestrictions(selectedAsset.get(), self._assetTypeConfiguration.typeId) || !checkAuthorizationPolicy(selectedAsset);
+            return applicationModel.isReadOnly() || editingRestrictions.hasRestrictions(selectedAsset.get(), self._assetTypeConfiguration.typeId) || !this.checkAuthorizationPolicy(selectedAsset);
         };
 
         this.createHeaderElement = function(selectedAsset) {
@@ -1170,7 +1170,7 @@
             }
             else if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !hasMunicipality(selectedAsset)) {
                 message = limitedRights;
-            } else if(!checkAuthorizationPolicy(selectedAsset))
+            } else if(!this.checkAuthorizationPolicy(selectedAsset))
                 message = noRights;
 
             if(message) {
@@ -1229,10 +1229,10 @@
             return sideCode ? self._assetTypeConfiguration.className + '-' + sideCode : self._assetTypeConfiguration.className;
         };
 
-        function checkAuthorizationPolicy(selectedAsset){
+        this.checkAuthorizationPolicy = function(selectedAsset) {
             var auth = self._assetTypeConfiguration.authorizationPolicy || function() { return false; };
             return auth.validateMultiple(selectedAsset.get());
-        }
+        };
 
         this.isSplitOrSeparatedAllowed = function(){
             //When both are deleted

--- a/UI/src/view/dynamicAssetForm.js
+++ b/UI/src/view/dynamicAssetForm.js
@@ -1,6 +1,7 @@
 (function(root) {
     root.DynamicAssetForm = function (formStructure) {
     var self = this;
+    var editingRestrictions = new EditingRestrictions();
 
     this.DynamicField = function (fieldSettings, isDisabled) {
         var me = this;
@@ -957,7 +958,7 @@
         };
 
         this._isReadOnly = function(selectedAsset){
-            return applicationModel.isReadOnly() || !checkAuthorizationPolicy(selectedAsset);
+            return applicationModel.isReadOnly() || editingRestrictions.hasRestrictions(selectedAsset.get(), self._assetTypeConfiguration.typeId) || !checkAuthorizationPolicy(selectedAsset);
         };
 
         this.createHeaderElement = function(selectedAsset) {
@@ -1158,9 +1159,16 @@
 
             var limitedRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen. Voit muokata kohteita vain oman kuntasi alueelta.';
             var noRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen.';
+            var stateRoadEditingRestricted = 'Kohteiden muokkaus on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.';
+            var municipalityRoadEditingRestricted = 'Kunnan kohteiden muokkaus on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.';
             var message = '';
 
-            if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !hasMunicipality(selectedAsset)) {
+            if (editingRestrictions.hasStateRestriction(selectedAsset.get(), self._assetTypeConfiguration.typeId)) {
+                message = stateRoadEditingRestricted;
+            } else if(editingRestrictions.hasMunicipalityRestriction(selectedAsset.get(), self._assetTypeConfiguration.typeId)) {
+                message = municipalityRoadEditingRestricted;
+            }
+            else if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !hasMunicipality(selectedAsset)) {
                 message = limitedRights;
             } else if(!checkAuthorizationPolicy(selectedAsset))
                 message = noRights;

--- a/UI/src/view/link_property/linkPropertyForm.js
+++ b/UI/src/view/link_property/linkPropertyForm.js
@@ -1,7 +1,9 @@
 (function (root) {
   root.LinkPropertyForm = function(selectedLinkProperty, feedbackCollection) {
     var layer;
+    var typeId = 460;
     var authorizationPolicy = new LinkPropertyAuthorizationPolicy();
+    var editingRestrictions = new EditingRestrictions();
     var enumerations = new Enumerations();
     new FeedbackDataTool(feedbackCollection, 'linkProperty', authorizationPolicy);
 
@@ -163,9 +165,15 @@
 
       var limitedRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen. Voit muokata kohteita vain oman kuntasi alueelta.';
       var noRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen.';
+      var stateRoadEditingRestricted = 'Kohteiden muokkaus on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.';
+      var municipalityRoadEditingRestricted = 'Kunnan kohteiden muokkaus on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.';
       var message = '';
 
-      if (!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !hasMunicipality(selectedLinkProperty)) {
+      if (editingRestrictions.hasStateRestriction(selectedLinkProperty.get(), typeId)) {
+        message = stateRoadEditingRestricted;
+      } else if(editingRestrictions.hasMunicipalityRestriction(selectedLinkProperty.get(), typeId)) {
+        message = municipalityRoadEditingRestricted;
+      } else if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !hasMunicipality(selectedLinkProperty)) {
         message = limitedRights;
       } else if (!authorizationPolicy.validateMultiple(selectedLinkProperty.get()))
         message = noRights;
@@ -454,7 +462,7 @@
           selectedLinkProperty.setAdditionalInfo($(event.currentTarget).find(':selected').attr('value'));
         });
 
-        toggleMode(applicationModel.isReadOnly() || !authorizationPolicy.validateMultiple(selectedLinkProperty.get()));
+        toggleMode(applicationModel.isReadOnly() || editingRestrictions.hasRestrictions(selectedLinkProperty.get(), typeId) || !authorizationPolicy.validateMultiple(selectedLinkProperty.get()));
         controlAdministrativeClasses(linkProperty.administrativeClass);
       });
 
@@ -474,7 +482,7 @@
       });
 
       eventbus.on('application:readOnly', function(readOnly){
-        toggleMode(!authorizationPolicy.validateMultiple(selectedLinkProperty.get()) || readOnly);
+        toggleMode(!authorizationPolicy.validateMultiple(selectedLinkProperty.get()) || editingRestrictions.hasRestrictions(selectedLinkProperty.get(), typeId) || readOnly);
         controlAdministrativeClassesOnToggle(selectedLinkProperty);
       });
 

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -3,6 +3,8 @@
   var poistaSelected = false;
   var authorizationPolicy;
   var pointAssetToSave = false;
+  var typeId = 10;
+  var editingRestrictions = new EditingRestrictions();
 
   var rootElement = $("#feature-attributes");
 
@@ -390,9 +392,15 @@
 
         var limitedRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen. Voit muokata kohteita vain oman kuntasi alueelta.';
         var noRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen.';
+        var stateRoadEditingRestricted = 'Kohteiden muokkaus on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.';
+        var municipalityRoadEditingRestricted = 'Kunnan kohteiden muokkaus on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.';
         var message = '';
 
-        if (!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !authorizationPolicy.hasRightsInMunicipality(selectedMassTransitStopModel.getMunicipalityCode())) {
+        if (editingRestrictions.pointAssetHasRestriction(selectedMassTransitStopModel.getMunicipalityCode(), selectedMassTransitStopModel.getAdministrativeClass(), typeId)) {
+          message = stateRoadEditingRestricted;
+        } else if(editingRestrictions.pointAssetHasRestriction(selectedMassTransitStopModel.getMunicipalityCode(), selectedMassTransitStopModel.getAdministrativeClass(), typeId)) {
+          message = municipalityRoadEditingRestricted;
+        } else if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !authorizationPolicy.hasRightsInMunicipality(selectedMassTransitStopModel.getMunicipalityCode())) {
           message = limitedRights;
         } else if (!authorizationPolicy.assetSpecificAccess())
           message = noRights;

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -20,6 +20,9 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   };
   var clusterView;
 
+  var editingRestrictions = new EditingRestrictions();
+  var typeId = 10;
+
   var showOrHideServicePointLayer = function (showOrHide) {
     servicePointLayer.setVisible(showOrHide);
   };
@@ -523,6 +526,21 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
       }
       eventbus.trigger('busStop:selected', stopTypes[0]);
       selectedAsset = createAsset(data);
+      var administrativeClass = selectedMassTransitStopModel.getAdministrativeClass();
+      var municipalityCode = selectedMassTransitStopModel.getMunicipalityCode();
+
+      if (administrativeClass === 'State' && editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
+        me.displayAssetCreationRestricted('Kohteiden lisääminen on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.');
+        selectedMassTransitStopModel.cancel();
+        return;
+      }
+
+      if (administrativeClass === 'Municipality' && editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
+        me.displayAssetCreationRestricted('Kunnan kohteiden lisääminen on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.');
+        selectedMassTransitStopModel.cancel();
+        return;
+      }
+
       var feature = selectedAsset.massTransitStop.getMarkerFeature();
       selectControl.addSelectionFeatures([feature], false, false);
       applyBlockingOverlays();

--- a/UI/src/view/point_asset/pointAssetForm.js
+++ b/UI/src/view/point_asset/pointAssetForm.js
@@ -9,6 +9,8 @@ root.PointAssetForm = function() {
   me.saveCondition= null;
   me.feedbackCollection= null;
 
+  var editingRestrictions = new EditingRestrictions();
+
   this.initialize = function(parameters) {
     me.pointAsset = parameters.pointAsset;
     me.roadCollection = parameters.roadCollection;
@@ -39,14 +41,14 @@ root.PointAssetForm = function() {
 
     eventbus.on('application:readOnly', function(readOnly) {
       if(me.applicationModel.getSelectedLayer() === layerName && (!_.isEmpty(me.roadCollection.getAll()) && !_.isNull(selectedAsset.getId()))){
-        me.toggleMode(rootElement, !authorizationPolicy.formEditModeAccess(selectedAsset, me.roadCollection) || readOnly);
+        me.toggleMode(rootElement, !authorizationPolicy.formEditModeAccess(selectedAsset, me.roadCollection) || editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), selectedAsset.getAdministrativeClass(), me.pointAsset.typeId) || readOnly);
       }
     });
 
     eventbus.on(layerName + ':selected ' + layerName + ':cancelled roadLinks:fetched', function() {
       if (!_.isEmpty(me.roadCollection.getAll()) && !_.isNull(selectedAsset.getId())) {
         me.renderForm(rootElement, selectedAsset, localizedTexts, authorizationPolicy, me.roadCollection, collection);
-        me.toggleMode(rootElement, !authorizationPolicy.formEditModeAccess(selectedAsset, me.roadCollection) || me.applicationModel.isReadOnly());
+        me.toggleMode(rootElement, !authorizationPolicy.formEditModeAccess(selectedAsset, me.roadCollection) || editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), selectedAsset.getAdministrativeClass(), me.pointAsset.typeId) || me.applicationModel.isReadOnly());
         rootElement.find('.form-controls button').prop('disabled', !(selectedAsset.isDirty() && me.saveCondition(selectedAsset, authorizationPolicy)));
         rootElement.find('button#cancel-button').prop('disabled', false);
       }
@@ -171,11 +173,19 @@ root.PointAssetForm = function() {
   };
 
   this.userInformationLog = function(authorizationPolicy, asset) {
+    var adminClass = asset.getAdministrativeClass();
+
     var limitedRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen. Voit muokata kohteita vain oman kuntasi alueelta.';
     var noRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen.';
+    var stateRoadEditingRestricted = 'Kohteiden muokkaus on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.';
+    var municipalityRoadEditingRestricted = 'Kunnan kohteiden muokkaus on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.';
     var message = '';
 
-    if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !authorizationPolicy.hasRightsInMunicipality(asset.getMunicipalityCode())) {
+    if (adminClass === 'State' && editingRestrictions.pointAssetHasRestriction(asset.getMunicipalityCode(), adminClass, me.pointAsset.typeId)) {
+      message = stateRoadEditingRestricted;
+    } else if (adminClass === 'Municipality' && editingRestrictions.pointAssetHasRestriction(asset.getMunicipalityCode(), adminClass, me.pointAsset.typeId)) {
+      message = municipalityRoadEditingRestricted;
+    } else if(!authorizationPolicy.isOperator() && (authorizationPolicy.isMunicipalityMaintainer() || authorizationPolicy.isElyMaintainer()) && !authorizationPolicy.hasRightsInMunicipality(asset.getMunicipalityCode())) {
       message = limitedRights;
     } else if(!authorizationPolicy.formEditModeAccess(asset, me.roadCollection))
       message = noRights;

--- a/UI/src/view/point_asset/pointAssetLayer.js
+++ b/UI/src/view/point_asset/pointAssetLayer.js
@@ -9,6 +9,7 @@
       selectedAsset = params.selectedAsset,
       mapOverlay = params.mapOverlay,
       layerName = params.layerName,
+      typeId = params.typeId,
       newAsset = params.newAsset,
       roadAddressInfoPopup = params.roadAddressInfoPopup,
       assetLabel = params.assetLabel,
@@ -38,6 +39,8 @@
     me.vectorLayer.setOpacity(1);
     me.vectorLayer.setVisible(true);
     map.addLayer(me.vectorLayer);
+
+    var editingRestrictions = new EditingRestrictions();
 
     var selectControl = new SelectToolControl(application, me.vectorLayer, map, false,{
         style : function (feature) {
@@ -282,6 +285,10 @@
       return selectedAsset.getConstructionType(asset.linkId);
     }
 
+    function obtainMunicipalityCode(asset) {
+      return selectedAsset.getMunicipalityCodeByLinkId(asset.linkId);
+    }
+
     this.removeLayerFeatures = function() {
       me.vectorLayer.getSource().clear();
     };
@@ -404,6 +411,17 @@
         var bearing = geometrycalculator.getLineDirectionDegAngle(nearestLine);
         var administrativeClass = obtainAdministrativeClass(nearestLine);
         var constructionType = obtainConstructionType(nearestLine);
+        var municipalityCode = obtainMunicipalityCode(nearestLine);
+
+        if (administrativeClass === 'State' && editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
+          me.displayAssetCreationRestricted('Kohteiden lisääminen on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.');
+          return;
+        }
+
+        if (administrativeClass === 'Municipality' && editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
+          me.displayAssetCreationRestricted('Kunnan kohteiden lisääminen on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.');
+          return;
+        }
 
         var asset = me.createAssetWithPosition(selectedLat, selectedLon, nearestLine, projectionOnNearestLine, bearing,
             administrativeClass, constructionType);

--- a/UI/src/view/providers/layer.js
+++ b/UI/src/view/providers/layer.js
@@ -44,6 +44,7 @@
       }
     };
     this.displayConfirmMessage = function() { new Confirm(); };
+    this.displayAssetCreationRestricted = function (message) { new AssetCreationRestrictedPopup(message); };
     this.handleMapMoved = function(state) {
       if (state.selectedLayer === layerName && state.zoom >= me.minZoomForContent ) {
         if (!me.isStarted()) {

--- a/UI/tmpl/index.html
+++ b/UI/tmpl/index.html
@@ -116,6 +116,7 @@
 <script type="text/javascript" src="src/authorizationpolicies/cyclingAndWalkingAuthorizationPolicy.js"></script>
 <script type="text/javascript" src="src/authorizationpolicies/linearStateRoadExcludeOperatorAuthorizationPolicy.js"></script>
 <script type="text/javascript" src="src/authorizationpolicies/pointStateRoadExcludeOperatorAuthorizationPolicy.js"></script>
+<script type="text/javascript" src="src/authorizationpolicies/editingRestrictions.js"></script>
 <script type="text/javascript" src="src/view/tileMapCollection.js"></script>
 <script type="text/javascript" src="src/view/providers/layer.js"></script>
 <script type="text/javascript" src="src/view/providers/roadLayer.js"></script>
@@ -236,6 +237,7 @@
 <script type="text/javascript" src="src/model/locationSearch.js"></script>
 <script type="text/javascript" src="src/model/selectedLinearAssetFactory.js"></script>
 <script type="text/javascript" src="src/view/confirm.js"></script>
+<script type="text/javascript" src="src/view/assetCreationRestrictedPopup.js"></script>
 <script type="text/javascript" src="src/view/genericConfirmPopup.js"></script>
 <script type="text/javascript" src="src/view/initialPopupView.js"></script>
 <script type="text/javascript" src="src/view/userNotificationPopup.js"></script>

--- a/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
+++ b/digiroad2-api-common/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Context.scala
@@ -524,6 +524,10 @@ object Digiroad2Context {
     new AssetsOnExpiredLinksService()
   }
 
+  lazy val editingRestrictionsService: EditingRestrictionsService = {
+    new EditingRestrictionsService()
+  }
+
   lazy val roadLinkReplacementWorkListService: RoadLinkReplacementWorkListService = {
     new RoadLinkReplacementWorkListService()
   }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -4,7 +4,7 @@ import java.security.InvalidParameterException
 import java.time.LocalDate
 import fi.liikennevirasto.digiroad2.Digiroad2Context.municipalityProvider
 import fi.liikennevirasto.digiroad2.asset.DateParser._
-import fi.liikennevirasto.digiroad2.asset.{PointAssetValue, HeightLimit => HeightLimitInfo, WidthLimit => WidthLimitInfo, _}
+import fi.liikennevirasto.digiroad2.asset.{PointAssetValue, HeightLimit => HeightLimitInfo, WidthLimit => WidthLimitInfo, RoadLinkProperties => RoadLinkPropertiesAsset, _}
 import fi.liikennevirasto.digiroad2.authentication.{JWTAuthentication, UnauthenticatedException, UserNotFoundException}
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.{IncomingServicePoint, ServicePoint}
@@ -875,7 +875,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   put("/linkproperties") {
     val properties = parsedBody.extract[Seq[LinkProperties]]
     val user = userProvider.getCurrentUser()
-    def municipalityValidation(municipalityCode: Int, administrativeClass: AdministrativeClass) = validateUserAccess(user, 460)(municipalityCode, administrativeClass)
+    def municipalityValidation(municipalityCode: Int, administrativeClass: AdministrativeClass) = validateUserAccess(user, RoadLinkPropertiesAsset.typeId)(municipalityCode, administrativeClass)
     properties.map { prop =>
       roadLinkService.updateLinkProperties(prop, Option(user.username), municipalityValidation, user.isOperator()).map { roadLink =>
         Map("linkId" -> roadLink.linkId,

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -90,7 +90,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
                    val laneWorkListService: LaneWorkListService = Digiroad2Context.laneWorkListService,
                    val autoProcessedLanesWorkListService: AutoProcessedLanesWorkListService = Digiroad2Context.autoProcessedLanesWorkListService,
                    val assetsOnExpiredLinksService: AssetsOnExpiredLinksService = Digiroad2Context.assetsOnExpiredLinksService,
-                   val roadLinkMissingReplacementService: RoadLinkReplacementWorkListService = Digiroad2Context.roadLinkReplacementWorkListService)
+                   val roadLinkMissingReplacementService: RoadLinkReplacementWorkListService = Digiroad2Context.roadLinkReplacementWorkListService,
+                   val editingRestrictionsService: EditingRestrictionsService = Digiroad2Context.editingRestrictionsService)
 
   extends ScalatraServlet
     with JacksonJsonSupport
@@ -574,7 +575,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       case None =>
         halt(Conflict(s"Can not find nearby road link for given municipalities " + user.configuration.authorizedMunicipalities))
       case Some(link) =>
-        validateUserAccess(user, Some(ServicePoints.typeId))(link.municipalityCode, link.administrativeClass)
+        validateUserAccess(user, ServicePoints.typeId)(link.municipalityCode, link.administrativeClass)
         try {
           servicePointStopService.update(id, Point(lon, lat), properties, user.username, link.municipalityCode)
         } catch {
@@ -629,7 +630,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     val bearing = positionParameters._4.get
     val properties = (parsedBody \ "properties").extract[Seq[SimplePointAssetProperty]]
     val roadLink = roadLinkService.getRoadLinkAndComplementaryByLinkId(linkId).getOrElse(throw new NoSuchElementException)
-    validateUserAccess(userProvider.getCurrentUser())(roadLink.municipalityCode, roadLink.administrativeClass)
+    validateUserAccess(userProvider.getCurrentUser(), MassTransitStopAsset.typeId)(roadLink.municipalityCode, roadLink.administrativeClass)
     validateElyMaintainerUser(properties)
     validateCreationProperties(properties)
     validatePropertiesMaxSize(properties)
@@ -874,7 +875,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   put("/linkproperties") {
     val properties = parsedBody.extract[Seq[LinkProperties]]
     val user = userProvider.getCurrentUser()
-    def municipalityValidation(municipalityCode: Int, administrativeClass: AdministrativeClass) = validateUserAccess(user)(municipalityCode, administrativeClass)
+    def municipalityValidation(municipalityCode: Int, administrativeClass: AdministrativeClass) = validateUserAccess(user, 460)(municipalityCode, administrativeClass)
     properties.map { prop =>
       roadLinkService.updateLinkProperties(prop, Option(user.username), municipalityValidation, user.isOperator()).map { roadLink =>
         Map("linkId" -> roadLink.linkId,
@@ -1280,7 +1281,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     val usedService = getLinearAssetService(typeId)
     val linkIds = usedService.getPersistedAssetsByIds(typeId, ids).map(_.linkId)
     roadLinkService.fetchRoadlinksByIds(linkIds.toSet)
-      .foreach(a => validateUserAccess(user, Some(typeId))(a.municipalityCode, a.administrativeClass))
+      .foreach(a => validateUserAccess(user, typeId)(a.municipalityCode, a.administrativeClass))
 
     usedService.updateVerifiedInfo(ids, user.username, typeId)
   }
@@ -1323,7 +1324,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       extractLinearAssetValue(parsedBody \ "existingValue"),
       extractLinearAssetValue(parsedBody \ "createdValue"),
       user.username,
-      validateUserAccess(user, Some(typeId)))
+      validateUserAccess(user, typeId))
   }
 
   post("/linearassets/:id/separate") {
@@ -1334,7 +1335,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       extractLinearAssetValue(parsedBody \ "valueTowardsDigitization"),
       extractLinearAssetValue(parsedBody \ "valueAgainstDigitization"),
       user.username,
-      validateUserAccess(user, Some(typeId)))
+      validateUserAccess(user, typeId))
   }
 
   get("/speedlimit/sid/") {
@@ -1696,8 +1697,8 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     optionalValue match {
       case Some(values) =>
       val idsSavedOrUpdated = speedLimitService.createOrUpdateSpeedLimit(newLimits, values, user.username,ids,
-          validateUserAccess(user, Some(SpeedLimitAsset.typeId)),
-          validateUserAccess(user, Some(SpeedLimitAsset.typeId)) _)
+          validateUserAccess(user, SpeedLimitAsset.typeId),
+          validateUserAccess(user, SpeedLimitAsset.typeId) _)
         speedLimitService.getSpeedLimitAssetsByIds(idsSavedOrUpdated.toSet)
       case _ => BadRequest("Speed limit value not provided")
     }
@@ -1710,7 +1711,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       (parsedBody \ "existingValue").extract[Int],
       (parsedBody \ "createdValue").extract[Int],
       user.username,
-      validateUserAccess(user, Some(SpeedLimitAsset.typeId)) _)
+      validateUserAccess(user, SpeedLimitAsset.typeId) _)
   }
   
   post("/speedlimits/:speedLimitId/separate") {
@@ -1719,7 +1720,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       (parsedBody \ "valueTowardsDigitization").extract[SpeedLimitValue],
       (parsedBody \ "valueAgainstDigitization").extract[SpeedLimitValue],
       user.username,
-      validateUserAccess(user, Some(SpeedLimitAsset.typeId)))
+      validateUserAccess(user, SpeedLimitAsset.typeId))
   }
   
   post("/speedlimits") {
@@ -1734,27 +1735,33 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       (parsedBody \ "value").extract[SpeedLimitValue],
       user.username,
       Seq.empty[Long],
-      validateUserAccess(user, Some(SpeedLimitAsset.typeId)) _,
-      validateUserAccess(user, Some(SpeedLimitAsset.typeId)) _
+      validateUserAccess(user, SpeedLimitAsset.typeId) _,
+      validateUserAccess(user, SpeedLimitAsset.typeId) _
     ).headOption match {
       case Some(id) => speedLimitService.getSpeedLimitById(id)
       case _ => BadRequest("Speed limit creation failed")
     }
   }
 
-  private def validateUserAccess(user: User, typeId: Option[Int] = None)(municipality: Int, administrativeClass: AdministrativeClass) : Unit = {
-    typeId match {
-      case Some(assetType) => validateAdministrativeClass(assetType, user, municipality)(administrativeClass)
-      case _ =>
-    }
-    if (!user.isAuthorizedToWrite(municipality, administrativeClass)) {
-      halt(Unauthorized("User not authorized"))
+
+  private def validateServicePointAccess(municipality: Int): Unit = {
+    if (editingRestrictionsService.isEditingRestricted(ServicePoints.typeId, municipality, Municipality, true)
+      || editingRestrictionsService.isEditingRestricted(ServicePoints.typeId, municipality, State, true)) {
+      halt(Unauthorized("Editing this asset type is generally restricted in this municipality."))
     }
   }
 
-  private def validateUserRightsForOldTrafficCodes(user: User, isOldCodeBeingUsed: Boolean, municipalityCode: Int) : Unit = {
-    if (isOldCodeBeingUsed) {
-      validateUserMunicipalityAccessByMunicipality(user)(municipalityCode)
+  private def validateAssetTypeAccess(assetTypeId: Int, municipality: Int, administrativeClass: AdministrativeClass): Unit = {
+    if (editingRestrictionsService.isEditingRestricted(assetTypeId, municipality, administrativeClass, true)) {
+      halt(Unauthorized("Editing this asset type is generally restricted in this municipality."))
+    }
+  }
+
+  private def validateUserAccess(user: User, typeId: Int)(municipality: Int, administrativeClass: AdministrativeClass) : Unit = {
+        validateAssetTypeAccess(typeId, municipality, administrativeClass)
+        validateAdministrativeClass(typeId, user, municipality)(administrativeClass)
+    if (!user.isAuthorizedToWrite(municipality, administrativeClass)) {
+      halt(Unauthorized("User not authorized"))
     }
   }
 
@@ -1801,7 +1808,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             halt(Unauthorized("User not authorized"))
         }
     } else {
-      roadLinks.foreach(a => validateUserAccess(user, Some(typeId))(a.municipalityCode, a.administrativeClass))
+      roadLinks.foreach(a => validateUserAccess(user, typeId)(a.municipalityCode, a.administrativeClass))
     }
   }
 
@@ -1811,7 +1818,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     }
 
     val roadLinks = roadLinkService.fetchRoadlinksAndComplementaries(linkIds)
-    roadLinks.foreach(a => validateUserAccess(user)(a.municipalityCode, a.administrativeClass))
+    roadLinks.foreach(a => validateUserAccess(user, Lanes.typeId)(a.municipalityCode, a.administrativeClass))
   }
 
   private def validateUserRightsForRoadAddress(laneRoadAddressInfo: LaneRoadAddressInfo, user: User) : Unit = {
@@ -1879,7 +1886,10 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       val linkIds = manoeuvres.flatMap(_.linkIds)
       val roadLinks = roadLinkService.getRoadLinksByLinkIds(linkIds.toSet)
 
-      roadLinks.foreach{rl => validateUserMunicipalityAccessByMunicipality(user)(rl.municipalityCode)}
+      roadLinks.foreach{rl =>
+        validateAssetTypeAccess(Manoeuvres.typeId, rl.municipalityCode, rl.administrativeClass)
+        validateUserMunicipalityAccessByMunicipality(user)(rl.municipalityCode)
+      }
 
       try {
         manoeuvreService.createManoeuvre(user.username, manoeuvre, roadLinks)
@@ -2174,7 +2184,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
     roadLinkService.getRoadLinkAndComplementaryByLinkId(updatedAsset.linkId) match {
       case None => halt(NotFound(s"RoadLink with mml id ${updatedAsset.linkId} does not exist"))
       case Some(link) =>
-        validateUserAccess(user, Some(service.typeId))(link.municipalityCode, link.administrativeClass)
+        validateUserAccess(user, service.typeId)(link.municipalityCode, link.administrativeClass)
         service match {
           case trafficSignService: TrafficSignService => {
             if (!trafficSignService.verifyDatesOnTemporarySigns(updatedAsset.asInstanceOf[IncomingTrafficSign])) halt(BadRequest("Incorrect parameters on date values"))
@@ -2191,7 +2201,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
 
     roadLinkService.getRoadLinkAndComplementaryByLinkId(asset.linkId).map{
       link =>
-       validateUserAccess(user, Some(service.typeId))(link.municipalityCode, link.administrativeClass)
+       validateUserAccess(user, service.typeId)(link.municipalityCode, link.administrativeClass)
         service match {
           case trafficSignService: TrafficSignService => {
             if (!trafficSignService.verifyDatesOnTemporarySigns(asset.asInstanceOf[IncomingTrafficSign])) halt(BadRequest("Incorrect parameters on date values"))
@@ -2248,7 +2258,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       case None =>
         halt(Conflict(s"Can not find nearby road link for given municipalities " + user.configuration.authorizedMunicipalities))
       case Some(link) =>
-        validateUserAccess(user, Some(ServicePoints.typeId))(link.municipalityCode, link.administrativeClass)
+        validateServicePointAccess(link.municipalityCode)
         try {
           servicePointService.create(asset, link.municipalityCode, user.username)
         } catch {
@@ -2265,7 +2275,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
       case None =>
         halt(Conflict(s"Can not find nearby road link for given municipalities " + user.configuration.authorizedMunicipalities))
       case Some(link) =>
-        validateUserAccess(user, Some(ServicePoints.typeId))(link.municipalityCode, link.administrativeClass)
+        validateServicePointAccess(link.municipalityCode)
         try {
           servicePointService.update(id, updatedAsset, link.municipalityCode, user.username)
         } catch {
@@ -2284,7 +2294,7 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
             case None =>
               halt(Conflict(s"Can not find nearby road link for given municipalities " + user.configuration.authorizedMunicipalities))
             case Some(link) =>
-              validateUserAccess(user, Some(ServicePoints.typeId))(link.municipalityCode, link.administrativeClass)
+              validateUserAccess(user, ServicePoints.typeId)(link.municipalityCode, link.administrativeClass)
           }
         case _ => halt(Conflict(s"Can not find nearby road link for given municipalities " + user.configuration.authorizedMunicipalities))
       }

--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/dataimport/ImportDataApi.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/dataimport/ImportDataApi.scala
@@ -51,18 +51,6 @@ class ImportDataApi(roadLinkService: RoadLinkService, val userProvider: UserProv
     importAssets(fileParams("csv-file"), assetType)
   }
 
-  post("/lanes") {
-    val updateOnlyStartDates = params.get("updateStartDates") match {
-      case Some(param) => UpdateOnlyStartDates(param.toBoolean)
-      case _ => UpdateOnlyStartDates(false)
-    }
-    if(!userProvider.getCurrentUser().isOperator())
-      halt(Forbidden("Vain operaattori voi suorittaa Excel-ajon"))
-    else
-      validateOperation()
-    importLanes(fileParams("csv-file"), updateOnlyStartDates)
-  }
-
   post("/maintenanceRoads") {
     if (!userProvider.getCurrentUser().isOperator()) {
       halt(Forbidden("Vain operaattori voi suorittaa Excel-ajon"))
@@ -135,19 +123,6 @@ class ImportDataApi(roadLinkService: RoadLinkService, val userProvider: UserProv
       val user = userProvider.getCurrentUser()
       val newLogId = createNewLog(user.username, fileName, s"import_${TrafficSigns.layerName}")
       eventBus.publish("importCSVData", CsvDataImporterInfo(TrafficSigns.layerName, fileName, userProvider.getCurrentUser(), csvFileInputStream, newLogId, municipalitiesToExpire.map(NumericValues)))
-      getLogById(newLogId)
-    }
-  }
-
-  def importLanes(csvFileItem: FileItem, updateStartDates: UpdateOnlyStartDates): Option[ImportStatusInfo] = {
-    val fileName = csvFileItem.getName
-    val csvFileInputStream = csvFileItem.getInputStream
-    if(csvFileInputStream.available() == 0)
-      halt(BadRequest("Ei valittua CSV-tiedostoa. Valitse tiedosto ja yritä uudestaan."))
-    else {
-      val user = userProvider.getCurrentUser()
-      val newLogId = createNewLog(user.username, fileName, "import_lanes")
-      eventBus.publish("importCSVData", CsvDataImporterInfo(Lanes.layerName, fileName, userProvider.getCurrentUser(), csvFileInputStream, newLogId, Set(updateStartDates)))
       getLogById(newLogId)
     }
   }

--- a/digiroad2-oracle/src/main/resources/clear-db.sql
+++ b/digiroad2-oracle/src/main/resources/clear-db.sql
@@ -13,6 +13,7 @@ drop table if exists date_period_value cascade;
 drop table if exists date_period_value_history cascade;
 drop table if exists date_property_value cascade;
 drop table if exists date_property_value_history cascade;
+drop table if exists editing_restrictions cascade;
 drop table if exists ely cascade;
 drop table if exists enumerated_value cascade;
 drop table if exists export_lock cascade;

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_53__create_editing_restrictions_table.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_53__create_editing_restrictions_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE editing_restrictions (
+    id INT PRIMARY KEY DEFAULT nextval('primary_key_seq'),
+    municipality_id INT NOT NULL,
+    state_road_restricted_asset_types VARCHAR(1000),
+    municipality_road_restricted_asset_types VARCHAR(1000),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_53__create_editing_restrictions_table.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_53__create_editing_restrictions_table.sql
@@ -1,8 +1,12 @@
 CREATE TABLE editing_restrictions (
-    id INT PRIMARY KEY DEFAULT nextval('primary_key_seq'),
+    id INT PRIMARY KEY,
     municipality_id INT UNIQUE NOT NULL,
     state_road_restricted_asset_types VARCHAR(1000),
     municipality_road_restricted_asset_types VARCHAR(1000),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_municipality_restriction
+    FOREIGN KEY (municipality_id)
+    REFERENCES municipality(id)
+    ON DELETE CASCADE
 );

--- a/digiroad2-oracle/src/main/resources/db/migration/V1_53__create_editing_restrictions_table.sql
+++ b/digiroad2-oracle/src/main/resources/db/migration/V1_53__create_editing_restrictions_table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE editing_restrictions (
     id INT PRIMARY KEY DEFAULT nextval('primary_key_seq'),
-    municipality_id INT NOT NULL,
+    municipality_id INT UNIQUE NOT NULL,
     state_road_restricted_asset_types VARCHAR(1000),
     municipality_road_restricted_asset_types VARCHAR(1000),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
@@ -6,7 +6,7 @@ import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingObstacle, ObstacleService}
 import fi.liikennevirasto.digiroad2.user.User
-import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, NotImportedData, Point}
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 
 class ObstaclesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends PointAssetCsvImporter {
   override def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/ObstaclesCsvImporter.scala
@@ -1,12 +1,12 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
-import fi.liikennevirasto.digiroad2.asset.{PropertyValue, SimplePointAssetProperty, State}
+import fi.liikennevirasto.digiroad2.asset.{Obstacles, PedestrianCrossings, PropertyValue, SimplePointAssetProperty}
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingObstacle, ObstacleService}
 import fi.liikennevirasto.digiroad2.user.User
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, NotImportedData, Point}
 
 class ObstaclesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: DigiroadEventBus) extends PointAssetCsvImporter {
   override def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
@@ -21,6 +21,28 @@ class ObstaclesCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl: D
   lazy val obstaclesService: ObstacleService = new ObstacleService(roadLinkService)
 
   private val allowedTypeValues: Seq[Int] = Seq(1, 2, 3, 99)
+
+
+  override def verifyData(parsedRow: ParsedProperties, user: User): ParsedCsv = {
+    val optLon = getPropertyValueOption(parsedRow, "lon").asInstanceOf[Option[BigDecimal]]
+    val optLat = getPropertyValueOption(parsedRow, "lat").asInstanceOf[Option[BigDecimal]]
+
+    (optLon, optLat) match {
+      case (Some(lon), Some(lat)) =>
+        val roadLinks = roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong))
+        roadLinks.isEmpty match {
+          case true => (List(s"No Rights for Municipality or nonexistent road links near asset position"), Seq())
+          case false =>
+            if (assetHasEditingRestrictions(Obstacles.typeId, roadLinks)) {
+              (List("Asset type editing is restricted within municipality or admininistrative class."), Seq())
+            } else {
+              (List(), Seq(CsvAssetRowAndRoadLink(parsedRow, roadLinks)))
+            }
+        }
+      case _ =>
+        (Nil, Nil)
+    }
+  }
 
   override def createAsset(pointAssetAttributes: Seq[CsvAssetRowAndRoadLink], user: User, result: ImportResultPointAsset): ImportResultPointAsset = {
     val notImportedObstacle = pointAssetAttributes.flatMap { obstacleAttribute =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PedestrianCrossingCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PedestrianCrossingCsvImporter.scala
@@ -1,9 +1,9 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
-import fi.liikennevirasto.digiroad2.asset.State
+import fi.liikennevirasto.digiroad2.asset.{PedestrianCrossings, State}
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils}
+import fi.liikennevirasto.digiroad2.{DigiroadEventBus, GeometryUtils, Point}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingPedestrianCrossing, PedestrianCrossingService}
 import fi.liikennevirasto.digiroad2.user.User
@@ -19,6 +19,27 @@ class PedestrianCrossingCsvImporter(roadLinkServiceImpl: RoadLinkService, eventB
   override val mandatoryFieldsMapping: Map[String, String] = coordinateMappings
 
   lazy val pedestrianCrossingService: PedestrianCrossingService = new PedestrianCrossingService(roadLinkService, eventBusImpl)
+
+  override def verifyData(parsedRow: ParsedProperties, user: User): ParsedCsv = {
+    val optLon = getPropertyValueOption(parsedRow, "lon").asInstanceOf[Option[BigDecimal]]
+    val optLat = getPropertyValueOption(parsedRow, "lat").asInstanceOf[Option[BigDecimal]]
+
+    (optLon, optLat) match {
+      case (Some(lon), Some(lat)) =>
+        val roadLinks = roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong))
+        roadLinks.isEmpty match {
+          case true => (List(s"No Rights for Municipality or nonexistent road links near asset position"), Seq())
+          case false =>
+            if (assetHasEditingRestrictions(PedestrianCrossings.typeId, roadLinks)) {
+              (List("Asset type editing is restricted within municipality or admininistrative class."), Seq())
+            } else {
+              (List(), Seq(CsvAssetRowAndRoadLink(parsedRow, roadLinks)))
+            }
+        }
+      case _ =>
+        (Nil, Nil)
+    }
+  }
 
   override def createAsset(pointAssetAttributes: Seq[CsvAssetRowAndRoadLink], user: User, result: ImportResultPointAsset): ImportResultPointAsset = {
     pointAssetAttributes.foreach { pedestrianCrossingAttribute =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficLightsCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficLightsCsvImporter.scala
@@ -5,7 +5,7 @@ import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.TrafficLight
 import fi.liikennevirasto.digiroad2.lane.LaneType
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import fi.liikennevirasto.digiroad2.{AssetProperty, DigiroadEventBus, GeometryUtils, NotImportedData, Point, TrafficLightPushButton, TrafficLightRelativePosition, TrafficLightSoundSignal, TrafficLightType, TrafficLightVehicleDetection}
+import fi.liikennevirasto.digiroad2.{AssetProperty, DigiroadEventBus, GeometryUtils, Point, TrafficLightPushButton, TrafficLightRelativePosition, TrafficLightSoundSignal, TrafficLightType, TrafficLightVehicleDetection}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingTrafficLight, TrafficLightService}
 import fi.liikennevirasto.digiroad2.user.User

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficLightsCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficLightsCsvImporter.scala
@@ -1,11 +1,11 @@
 package fi.liikennevirasto.digiroad2.csvDataImporter
 
-import fi.liikennevirasto.digiroad2.asset.{PointAssetState, PointAssetStructure, SimplePointAssetProperty, State}
+import fi.liikennevirasto.digiroad2.asset.{PointAssetState, PointAssetStructure, SimplePointAssetProperty, State, TrafficLights}
 import fi.liikennevirasto.digiroad2.client.RoadLinkClient
 import fi.liikennevirasto.digiroad2.dao.pointasset.TrafficLight
 import fi.liikennevirasto.digiroad2.lane.LaneType
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
-import fi.liikennevirasto.digiroad2.{AssetProperty, DigiroadEventBus, GeometryUtils, Point, TrafficLightPushButton, TrafficLightRelativePosition, TrafficLightSoundSignal, TrafficLightType, TrafficLightVehicleDetection}
+import fi.liikennevirasto.digiroad2.{AssetProperty, DigiroadEventBus, GeometryUtils, NotImportedData, Point, TrafficLightPushButton, TrafficLightRelativePosition, TrafficLightSoundSignal, TrafficLightType, TrafficLightVehicleDetection}
 import fi.liikennevirasto.digiroad2.service.RoadLinkService
 import fi.liikennevirasto.digiroad2.service.pointasset.{IncomingTrafficLight, TrafficLightService}
 import fi.liikennevirasto.digiroad2.user.User
@@ -96,6 +96,8 @@ class TrafficLightsCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImp
         val roadLinks = roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong), forCarTraffic = false)
         if (roadLinks.isEmpty) {
           (List(s"No Rights for Municipality or nonexistent road links near asset position"), Seq())
+        } else if (assetHasEditingRestrictions(TrafficLights.typeId, roadLinks)) {
+          (List("Asset type editing is restricted within municipality or admininistrative class."), Seq())
         } else {
           (List(), Seq(CsvAssetRowAndRoadLink(parsedRow, roadLinks)))
         }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -414,8 +414,8 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
           case (Some(lon), Some(lat)) =>
             val roadLinks = optTrafficSignType match {
               case Some(signType) if TrafficSignType.applyAdditionalGroup(TrafficSignTypeGroup.CycleAndWalkwaySigns).contains(signType) =>
-                roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong), forCarTraffic = false).filter(_.administrativeClass != State).filter(rl => !editingRestrictionsService.isEditingRestricted(TrafficSigns.typeId, rl.municipalityCode, rl.administrativeClass))
-              case _ => roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong)).filter(_.administrativeClass != State).filter(rl => !editingRestrictionsService.isEditingRestricted(TrafficSigns.typeId, rl.municipalityCode, rl.administrativeClass))
+                roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong), forCarTraffic = false)
+              case _ => roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong))
             }
 
             if (roadLinks.isEmpty) {

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -414,12 +414,14 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
           case (Some(lon), Some(lat)) =>
             val roadLinks = optTrafficSignType match {
               case Some(signType) if TrafficSignType.applyAdditionalGroup(TrafficSignTypeGroup.CycleAndWalkwaySigns).contains(signType) =>
-                roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong), forCarTraffic = false).filter(_.administrativeClass != State)
-              case _ => roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong)).filter(_.administrativeClass != State)
+                roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong), forCarTraffic = false).filter(_.administrativeClass != State).filter(rl => !editingRestrictionsService.isEditingRestricted(TrafficSigns.typeId, rl.municipalityCode, rl.administrativeClass))
+              case _ => roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong)).filter(_.administrativeClass != State).filter(rl => !editingRestrictionsService.isEditingRestricted(TrafficSigns.typeId, rl.municipalityCode, rl.administrativeClass))
             }
 
             if (roadLinks.isEmpty) {
               (List(s"No Rights for Municipality or nonexistent road links near asset position"), Seq())
+            } else if (assetHasEditingRestrictions(TrafficSigns.typeId, roadLinks)) {
+              (List("Asset type editing is restricted within municipality or admininistrative class."), Seq())
             } else {
               (List(), Seq(CsvAssetRowAndRoadLink(parsedRow, roadLinks)))
             }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/EditingRestrictionsDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/EditingRestrictionsDAO.scala
@@ -21,6 +21,13 @@ class EditingRestrictionsDAO {
     }
   }
 
+  def fetchAllRestrictions(): Seq[EditingRestrictions] = {
+    sql"""
+    SELECT id, municipality_id, state_road_restricted_asset_types, municipality_road_restricted_asset_types, created_at, modified_at
+    FROM editing_restrictions
+  """.as[EditingRestrictions].list
+  }
+
   def fetchRestrictionsByMunicipality(municipality: Int): Option[EditingRestrictions] = {
     sql"""
     SELECT id, municipality_id, state_road_restricted_asset_types, municipality_road_restricted_asset_types, created_at, modified_at

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/EditingRestrictionsDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/EditingRestrictionsDAO.scala
@@ -1,0 +1,32 @@
+package fi.liikennevirasto.digiroad2.dao
+
+import org.joda.time.DateTime
+import slick.jdbc.{GetResult, PositionedResult}
+import slick.jdbc.StaticQuery.interpolation
+import slick.driver.JdbcDriver.backend.Database.dynamicSession
+
+case class EditingRestrictions(id: Int, municipalityId: Int, stateRoadRestrictedAssetTypes: Seq[Int], municipalityRoadRestrictedAssetTypes: Seq[Int], createdAt: Option[DateTime] = None, modifiedAt: Option[DateTime] = None)
+class EditingRestrictionsDAO {
+
+  implicit val getRestrictedAssetTypes: GetResult[EditingRestrictions] = new GetResult[EditingRestrictions] {
+    def apply(r: PositionedResult): EditingRestrictions = {
+      val id = r.nextInt()
+      val municipalityId = r.nextInt()
+      val stateRoadRestrictedAssetTypes = r.nextString().split(",").toSeq.map(_.toInt)
+      val municipalityRoadRestrictedAssetTypes = r.nextString().split(",").toSeq.map(_.toInt)
+      val createdAt = Option(r.nextTimestamp()).map(new DateTime(_))
+      val modifiedAt = Option(r.nextTimestamp()).map(new DateTime(_))
+
+      EditingRestrictions(id, municipalityId, stateRoadRestrictedAssetTypes, municipalityRoadRestrictedAssetTypes, createdAt, modifiedAt)
+    }
+  }
+
+  def fetchRestrictionsByMunicipality(municipality: Int): Option[EditingRestrictions] = {
+    sql"""
+    SELECT id, municipality_id, state_road_restricted_asset_types, municipality_road_restricted_asset_types, created_at, modified_at
+    FROM editing_restrictions
+    WHERE municipality_id = $municipality
+  """.as[EditingRestrictions].firstOption
+  }
+
+}

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/EditingRestrictionsDAO.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/dao/EditingRestrictionsDAO.scala
@@ -12,8 +12,8 @@ class EditingRestrictionsDAO {
     def apply(r: PositionedResult): EditingRestrictions = {
       val id = r.nextInt()
       val municipalityId = r.nextInt()
-      val stateRoadRestrictedAssetTypes = r.nextString().split(",").toSeq.map(_.toInt)
-      val municipalityRoadRestrictedAssetTypes = r.nextString().split(",").toSeq.map(_.toInt)
+      val stateRoadRestrictedAssetTypes = Option(r.nextString()).filter(_.nonEmpty).map(_.split(",").toSeq.map(_.toInt)).getOrElse(Seq.empty)
+      val municipalityRoadRestrictedAssetTypes = Option(r.nextString()).filter(_.nonEmpty).map(_.split(",").toSeq.map(_.toInt)).getOrElse(Seq.empty)
       val createdAt = Option(r.nextTimestamp()).map(new DateTime(_))
       val modifiedAt = Option(r.nextTimestamp()).map(new DateTime(_))
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/DataImportManager.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/middleware/DataImportManager.scala
@@ -43,7 +43,7 @@ class DataImportManager(roadLinkClient: RoadLinkClient, roadLinkService: RoadLin
       case TrafficSigns.layerName =>
         trafficSignCsvImporter.importAssets(importedInfo.inputStream, importedInfo.fileName, importedInfo.user, importedInfo.logId, importedInfo.additionalImportInfo.map(_.asInstanceOf[NumericValues].values))
       case MaintenanceRoadAsset.layerName =>
-        maintenanceRoadCsvImporter.importAssets(importedInfo.inputStream, importedInfo.fileName, importedInfo.user.username, importedInfo.logId)
+        maintenanceRoadCsvImporter.importAssets(importedInfo.inputStream, importedInfo.fileName, importedInfo.user, importedInfo.logId)
       case "roadLinks" =>
         roadLinkCsvImporter.importAssets(importedInfo.inputStream, importedInfo.fileName, importedInfo.user.username, importedInfo.logId)
       case MassTransitStopAsset.layerName =>

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/EditingRestrictionsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/EditingRestrictionsService.scala
@@ -1,7 +1,7 @@
 package fi.liikennevirasto.digiroad2.service
 
 import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, Municipality, State}
-import fi.liikennevirasto.digiroad2.dao.EditingRestrictionsDAO
+import fi.liikennevirasto.digiroad2.dao.{EditingRestrictions, EditingRestrictionsDAO}
 import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
 
 class EditingRestrictionsService {
@@ -9,6 +9,10 @@ class EditingRestrictionsService {
   def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
 
   protected def dao : EditingRestrictionsDAO = new EditingRestrictionsDAO
+
+  def fetchRestrictions(): Seq[EditingRestrictions] = {
+    withDynTransaction(dao.fetchAllRestrictions())
+  }
 
   def isEditingRestricted(assetTypeId: Int, municipality: Int, adminClass: AdministrativeClass, newTransaction: Boolean = false): Boolean = {
     val restrictions = if (newTransaction) withDynTransaction(dao.fetchRestrictionsByMunicipality(municipality)) else dao.fetchRestrictionsByMunicipality(municipality)

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/EditingRestrictionsService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/EditingRestrictionsService.scala
@@ -1,0 +1,29 @@
+package fi.liikennevirasto.digiroad2.service
+
+import fi.liikennevirasto.digiroad2.asset.{AdministrativeClass, Municipality, State}
+import fi.liikennevirasto.digiroad2.dao.EditingRestrictionsDAO
+import fi.liikennevirasto.digiroad2.postgis.PostGISDatabase
+
+class EditingRestrictionsService {
+
+  def withDynTransaction[T](f: => T): T = PostGISDatabase.withDynTransaction(f)
+
+  protected def dao : EditingRestrictionsDAO = new EditingRestrictionsDAO
+
+  def isEditingRestricted(assetTypeId: Int, municipality: Int, adminClass: AdministrativeClass, newTransaction: Boolean = false): Boolean = {
+    val restrictions = if (newTransaction) withDynTransaction(dao.fetchRestrictionsByMunicipality(municipality)) else dao.fetchRestrictionsByMunicipality(municipality)
+    restrictions match {
+      case Some(restriction) =>
+        if (adminClass == Municipality && restriction.municipalityRoadRestrictedAssetTypes.contains(assetTypeId)) {
+          return true
+        }
+        if (adminClass == State && restriction.stateRoadRestrictedAssetTypes.contains(assetTypeId)) {
+          return true
+        }
+        return false
+      case _ => return false
+    }
+    false
+  }
+
+}

--- a/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/EditingRestrictionsServiceSpec.scala
+++ b/digiroad2-oracle/src/test/scala/fi/liikennevirasto/digiroad2/service/EditingRestrictionsServiceSpec.scala
@@ -1,0 +1,57 @@
+import fi.liikennevirasto.digiroad2.asset.{Municipality, State}
+import fi.liikennevirasto.digiroad2.dao.{EditingRestrictions, EditingRestrictionsDAO}
+import fi.liikennevirasto.digiroad2.service.EditingRestrictionsService
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{FunSuite, Matchers}
+
+class EditingRestrictionsServiceTest extends FunSuite with Matchers {
+
+  val mockDAO: EditingRestrictionsDAO = MockitoSugar.mock[EditingRestrictionsDAO]
+  val service = new EditingRestrictionsService {
+    override protected def dao: EditingRestrictionsDAO = mockDAO
+  }
+
+  test("isEditingRestricted returns true when asset type id is found in municipality restrictions") {
+
+    val assetTypeId = 60
+    val municipality = 1
+    val adminClasses = Municipality
+    val mockRestrictions = Some(EditingRestrictions(0, 1, Seq(), Seq(assetTypeId), None, None))
+
+    when(mockDAO.fetchRestrictionsByMunicipality(municipality)).thenReturn(mockRestrictions)
+
+    val result = service.isEditingRestricted(assetTypeId, municipality, adminClasses)
+
+    result shouldBe true
+  }
+
+  test("isEditingRestricted returns true when asset type ID is found in state restrictions") {
+
+    val assetTypeId = 70
+    val municipality = 2
+    val adminClasses = State
+    val mockRestrictions = Some(EditingRestrictions(0, 3, Seq(assetTypeId), Seq(), None, None))
+
+    when(mockDAO.fetchRestrictionsByMunicipality(municipality)).thenReturn(mockRestrictions)
+
+    val result = service.isEditingRestricted(assetTypeId, municipality, adminClasses)
+
+    result shouldBe true
+  }
+
+  test("isEditingRestricted returns false when asset type ID is not found") {
+
+    val assetTypeId = 80
+    val municipality = 3
+    val adminClasses = Municipality
+    val mockRestrictions = Some(EditingRestrictions(0, 4, Seq(60), Seq(70), None, None))
+
+    when(mockDAO.fetchRestrictionsByMunicipality(municipality)).thenReturn(mockRestrictions)
+
+    val result = service.isEditingRestricted(assetTypeId, municipality, adminClasses)
+
+    result shouldBe false
+  }
+}
+


### PR DESCRIPTION
4337: Lisätty taulu, johon kuntakohtaisesti voi lisätä assetTypeId:tä, joiden muokkaaminen/lisääminen on kyseisen kunnan alueella estetty kunnan ja/tai valtion linkeillä. Tarkistukset apin tallentaviin endpointeihin ja csv_importiin. Poistettu LanesCsvImporter.

4339: Tehty ui-rajoitukset. Katsotaan samassa kohdassa kuin vaikka kuntakäyttäjien rajoitukset muihin kuin omiin kuntiin. Asset jää readOnly tilaan, jos oikeuksia ei ole. Lisättävistä pistemäisistä tulee popup-ilmoitus, jos oikeuksia ei ole. Tämä oli helpompi toteuttaa kuin tyhjä asset, jota ei saa muokata, ja mielestäni yhtä selkeä.