### PR TITLE
Droth 4318 update ecr lifecycle policy

### DIFF
--- a/aws/cloud-formation/cicd/dev/cicd-github.yaml
+++ b/aws/cloud-formation/cicd/dev/cicd-github.yaml
@@ -391,9 +391,9 @@ Resources:
                   },
                   {
                       "rulePriority": 2,
-                      "description": "Retain 3 latest untagged images",
+                      "description": "Retain 3 latest images",
                       "selection": {
-                          "tagStatus": "untagged",
+                          "tagStatus": "any",
                           "countType": "imageCountMoreThan",
                           "countNumber": 3
                       },

--- a/aws/cloud-formation/cicd/dev/cicd-github.yaml
+++ b/aws/cloud-formation/cicd/dev/cicd-github.yaml
@@ -417,12 +417,11 @@ Resources:
                   },
                   {
                       "rulePriority": 4,
-                      "description": "Expire images not tagged with qa or prod after 90 days",
+                      "description": "Retain 3 latest untagged images",
                       "selection": {
-                          "tagStatus": "any",
-                          "countType": "sinceImagePushed",
-                          "countUnit": "days",
-                          "countNumber": 90
+                          "tagStatus": "untagged",
+                          "countType": "imageCountMoreThan",
+                          "countNumber": 3
                       },
                       "action": {
                           "type": "expire"

--- a/aws/cloud-formation/cicd/dev/cicd-github.yaml
+++ b/aws/cloud-formation/cicd/dev/cicd-github.yaml
@@ -378,32 +378,6 @@ Resources:
               "rules": [
                   {
                       "rulePriority": 1,
-                      "description": "Retain images tagged with prod",
-                      "selection": {
-                          "tagStatus": "tagged",
-                          "tagPrefixList": ["prod"],
-                          "countType": "imageCountMoreThan",
-                          "countNumber": 999999
-                      },
-                      "action": {
-                          "type": "expire"
-                      }
-                  },
-                  {
-                      "rulePriority": 2,
-                      "description": "Retain images tagged with qa",
-                      "selection": {
-                          "tagStatus": "tagged",
-                          "tagPrefixList": ["qa"],
-                          "countType": "imageCountMoreThan",
-                          "countNumber": 999999
-                      },
-                      "action": {
-                          "type": "expire"
-                      }
-                  },
-                  {
-                      "rulePriority": 3,
                       "description": "Retain images tagged with latest",
                       "selection": {
                           "tagStatus": "tagged",
@@ -416,7 +390,7 @@ Resources:
                       }
                   },
                   {
-                      "rulePriority": 4,
+                      "rulePriority": 2,
                       "description": "Retain 3 latest untagged images",
                       "selection": {
                           "tagStatus": "untagged",

--- a/aws/cloud-formation/cicd/qa/cicd-qa.yaml
+++ b/aws/cloud-formation/cicd/qa/cicd-qa.yaml
@@ -354,7 +354,7 @@ Resources:
                   },
                   {
                       "rulePriority": 2,
-                      "description": "Retain images tagged with qa",
+                      "description": "Retain images tagged with test",
                       "selection": {
                           "tagStatus": "tagged",
                           "tagPrefixList": ["test"],
@@ -364,22 +364,9 @@ Resources:
                       "action": {
                           "type": "expire"
                       }
-                  },
+                  }
                   {
                       "rulePriority": 3,
-                      "description": "Retain images tagged with latest",
-                      "selection": {
-                          "tagStatus": "tagged",
-                          "tagPrefixList": ["latest"],
-                          "countType": "imageCountMoreThan",
-                          "countNumber": 999999
-                      },
-                      "action": {
-                          "type": "expire"
-                      }
-                  },
-                  {
-                      "rulePriority": 4,
                       "description": "Retain 3 latest untagged images",
                       "selection": {
                           "tagStatus": "untagged",

--- a/aws/cloud-formation/cicd/qa/cicd-qa.yaml
+++ b/aws/cloud-formation/cicd/qa/cicd-qa.yaml
@@ -369,7 +369,7 @@ Resources:
                       "rulePriority": 3,
                       "description": "Retain 3 latest untagged images",
                       "selection": {
-                          "tagStatus": "untagged",
+                          "tagStatus": "any",
                           "countType": "imageCountMoreThan",
                           "countNumber": 3
                       },

--- a/aws/cloud-formation/cicd/qa/cicd-qa.yaml
+++ b/aws/cloud-formation/cicd/qa/cicd-qa.yaml
@@ -364,7 +364,7 @@ Resources:
                       "action": {
                           "type": "expire"
                       }
-                  }
+                  },
                   {
                       "rulePriority": 3,
                       "description": "Retain 3 latest untagged images",

--- a/aws/cloud-formation/cicd/qa/cicd-qa.yaml
+++ b/aws/cloud-formation/cicd/qa/cicd-qa.yaml
@@ -380,12 +380,11 @@ Resources:
                   },
                   {
                       "rulePriority": 4,
-                      "description": "Expire images not tagged with qa or prod after 90 days",
+                      "description": "Retain 3 latest untagged images",
                       "selection": {
-                          "tagStatus": "any",
-                          "countType": "sinceImagePushed",
-                          "countUnit": "days",
-                          "countNumber": 90
+                          "tagStatus": "untagged",
+                          "countType": "imageCountMoreThan",
+                          "countNumber": 3
                       },
                       "action": {
                           "type": "expire"

--- a/aws/cloud-formation/ecr/PROD-ECR.yaml
+++ b/aws/cloud-formation/ecr/PROD-ECR.yaml
@@ -36,11 +36,11 @@ Resources:
             "rules": [
               {
                 "rulePriority": 1,
-                "description": "Retain 10 latest images",
+                "description": "Retain 3 latest images",
                 "selection": {
                   "tagStatus": "any",
                   "countType": "imageCountMoreThan",
-                  "countNumber": 10
+                  "countNumber": 3
                 },
                 "action": {
                   "type": "expire"


### PR DESCRIPTION
Päivitetty ECR LifeCyclePolicyja: Lyhennetty vanhojen imagejen säilytyksen ikkunaa. Säilytetään korkeintaan vain 3:a tägäämätöntä imagea (devillä ja qalla säilytettävä tägi siirtyy automaattisesti uusimmalle, jolloin aiemmin tägätty jää tyhjäksi).

Lisäksi poistettu turhia sääntöjä:
   - devillä ei tarvetta säilyttää qa- ja prod-tägejä
   - qa:lla ei tarvetta säilyttää latest-tägiä