### PR TITLE
Droth 4276 change default obstacle type to empty

### DIFF
--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -1138,7 +1138,7 @@
         title: 'Esterakennelma',
         allowComplementaryLinks: true,
         newAsset: { propertyData: [
-            {'name': 'Esterakennelma', 'propertyType': 'single_choice', 'publicId': "esterakennelma", values: [ {propertyValue: 1, propertyDisplayValue: ""} ] },
+            {'name': 'Esterakennelma', 'propertyType': 'single_choice', 'publicId': "esterakennelma", values: [ {propertyValue: "", propertyDisplayValue: ""} ] },
             {'name': "Vihjetieto", 'propertyType': 'checkbox', 'publicId': "suggest_box", values: [ {propertyValue: 0} ]}
         ]},
         legendValues: [

--- a/UI/src/assetTypeConfiguration.js
+++ b/UI/src/assetTypeConfiguration.js
@@ -1142,8 +1142,8 @@
             {'name': "Vihjetieto", 'propertyType': 'checkbox', 'publicId': "suggest_box", values: [ {propertyValue: 0} ]}
         ]},
         legendValues: [
-          {symbolUrl: 'images/point-assets/point_blue.svg', label: 'Muu pysyvä esterakennelma'},
-          {symbolUrl: 'images/point-assets/point_green.svg', label: 'Avattava puomi'},
+          {symbolUrl: 'images/point-assets/point_blue.svg', label: 'Kiinteä esterakennelma'},
+          {symbolUrl: 'images/point-assets/point_green.svg', label: 'Avattava esterakennelma'},
           {symbolUrl: 'images/point-assets/point_yellow.svg', label: 'Kaivanne'},
           {symbolUrl: 'images/point-assets/point_grey.svg', label: 'Ei tiedossa'},
           {symbolUrl: 'images/point-assets/point_red.svg', label: 'Geometrian ulkopuolella'}

--- a/UI/src/view/point_asset/obstacleForm.js
+++ b/UI/src/view/point_asset/obstacleForm.js
@@ -15,8 +15,8 @@
     };
 
     var obstacleTypes = {
-      1: 'Muu pysyvä esterakenne',
-      2: 'Avattava puomi',
+      1: 'Kiinteä esterakennelma',
+      2: 'Avattava esterakennelma',
       3: 'Kaivanne',
       99: 'Ei tiedossa'
     };
@@ -32,8 +32,8 @@
         '      <p class="form-control-static">' + obstacleTypes[me.selectedAsset.getByProperty('esterakennelma')] + '</p>' +
         '        <select id="esterakennelma-select" class="form-control" style="display:none">' +
         '         <option value="" ' + (me.selectedAsset.getByProperty('esterakennelma') === null ? 'selected' : '') + '></option>' +
-        '         <option value="1" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 1 ? 'selected' : '') +'>Muu pysyvä esterakennelma</option>' +
-        '         <option value="2" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 2 ? 'selected' : '') +'>Avattava puomi</option>' +
+        '         <option value="1" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 1 ? 'selected' : '') +'>Kiinteä esterakennelma</option>' +
+        '         <option value="2" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 2 ? 'selected' : '') +'>Avattava esterakennelma</option>' +
         '         <option value="3" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 3 ? 'selected' : '') +'>Kaivanne</option>' +
         '         <option value="99" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 99 ? 'selected' : '') +'>Ei tiedossa</option>' +
         '      </select>' +

--- a/UI/src/view/point_asset/obstacleForm.js
+++ b/UI/src/view/point_asset/obstacleForm.js
@@ -28,7 +28,7 @@
       return '' +
         '<div class="edit-mode"> '+
         '    <div class="form-group editable form-obstacle">' +
-        '      <label class="control-label required" for="esterakennelma">Esterakennelma</label>' +
+        '      <label class="control-label required">Esterakennelma</label>' +
         '      <p class="form-control-static">' + obstacleTypes[me.selectedAsset.getByProperty('esterakennelma')] + '</p>' +
         '        <select id="esterakennelma-select" class="form-control" style="display:none">' +
         '         <option value="" ' + (me.selectedAsset.getByProperty('esterakennelma') === null ? 'selected' : '') + '></option>' +

--- a/UI/src/view/point_asset/obstacleForm.js
+++ b/UI/src/view/point_asset/obstacleForm.js
@@ -26,16 +26,19 @@
     this.renderValueElement = function(asset, collection, authorizationPolicy) {
       var components = me.renderComponents(asset.propertyData, propertyOrdering, authorizationPolicy);
       return '' +
+        '<div class="edit-mode"> '+
         '    <div class="form-group editable form-obstacle">' +
-        '      <label class="control-label">Esterakennelma</label>' +
+        '      <label class="control-label required" for="esterakennelma">Esterakennelma</label>' +
         '      <p class="form-control-static">' + obstacleTypes[me.selectedAsset.getByProperty('esterakennelma')] + '</p>' +
-        '      <select class="form-control" style="display:none">  ' +
-        '        <option value="1" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 1 ? 'selected' : '') +'>Muu pysyvä esterakennelma</option>' +
-        '        <option value="2" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 2 ? 'selected' : '') +'>Avattava puomi</option>' +
-        '        <option value="3" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 3 ? 'selected' : '') +'>Kaivanne</option>' +
-        '        <option value="99" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 99 ? 'selected' : '') +'>Ei tiedossa</option>' +
+        '        <select id="esterakennelma-select" class="form-control" style="display:none">' +
+        '         <option value="" ' + (me.selectedAsset.getByProperty('esterakennelma') === null ? 'selected' : '') + '></option>' +
+        '         <option value="1" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 1 ? 'selected' : '') +'>Muu pysyvä esterakennelma</option>' +
+        '         <option value="2" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 2 ? 'selected' : '') +'>Avattava puomi</option>' +
+        '         <option value="3" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 3 ? 'selected' : '') +'>Kaivanne</option>' +
+        '         <option value="99" '+ (parseInt(me.selectedAsset.getByProperty('esterakennelma')) === 99 ? 'selected' : '') +'>Ei tiedossa</option>' +
         '      </select>' +
         '    </div>' +
+        '</div>' +
           components;
     };
 

--- a/UI/src/view/point_asset/pointAssetForm.js
+++ b/UI/src/view/point_asset/pointAssetForm.js
@@ -52,6 +52,12 @@ root.PointAssetForm = function() {
         rootElement.find('.form-controls button').prop('disabled', !(selectedAsset.isDirty() && me.saveCondition(selectedAsset, authorizationPolicy)));
         rootElement.find('button#cancel-button').prop('disabled', false);
       }
+      if (layerName === 'obstacles') {
+        var obstacleTypeSelect = rootElement.find('#esterakennelma-select');
+        var obstacleValue = obstacleTypeSelect.val();
+        var isValid = obstacleValue !== "";
+        rootElement.find('#save-button').prop('disabled', !isValid || !(selectedAsset.isDirty() && me.saveCondition(selectedAsset, authorizationPolicy)));
+      }
     });
 
     eventbus.on(layerName + ':changed', function() {
@@ -62,6 +68,12 @@ root.PointAssetForm = function() {
         var bearingElement = rootElement.find('.form-point-asset input#bearing');
         rootElement.find('button#save-button').prop('disabled', bearingElement.prop('disabled') === false &&
             (bearingElement.val() < 0 || bearingElement.val() > 360 || _.isEmpty(bearingElement.val())));
+      }
+      if (layerName === 'obstacles') {
+        var obstacleTypeSelect = rootElement.find('#esterakennelma-select');
+        var obstacleValue = obstacleTypeSelect.val();
+        var isValid = obstacleValue !== "";
+        rootElement.find('#save-button').prop('disabled', !isValid || !(selectedAsset.isDirty() && me.saveCondition(selectedAsset, authorizationPolicy)));
       }
     });
 


### PR DESCRIPTION
Muutetaan esterakennelmien pudotuvalikko näyttämään oletuksena uuden esterakennelman tapauksessa tyhjää valintaa. Esterakennelman tallennus-painike on disabloitu jos tyypin arvo on tyhjä.

Pullarilla myös 4278-tiketin nimenmuutos käyttöliittymän esterakennelmatyyppien nimille.