### PR TITLE
Droth 4336 fix bugs

### DIFF
--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -247,7 +247,7 @@
         poistaSelected = false;
         pointAssetToSave = false;
 
-        readOnly = authorizationPolicy.formEditModeAccess();
+        readOnly = authorizationPolicy.formEditModeAccess() || editingRestrictions.pointAssetHasRestriction(selectedMassTransitStopModel.getMunicipalityCode(), selectedMassTransitStopModel.getAdministrativeClass(), typeId);
         var wrapper;
         if(readOnly){
           wrapper = $('<div />').addClass('wrapper read-only');

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -613,8 +613,11 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
       return null;
     }), null);
 
-    if(!authorizationPolicy.formEditModeAccess() && !applicationModel.isReadOnly())
-        dragControl.activate();
+    if(!authorizationPolicy.formEditModeAccess() && !applicationModel.isReadOnly() && !editingRestrictions.pointAssetHasRestriction(selectedMassTransitStopModel.getMunicipalityCode(), selectedMassTransitStopModel.getAdministrativeClass(), typeId)) {
+      dragControl.activate();
+    } else {
+      dragControl.deactivate();
+    }
 
     selectedAsset.massTransitStop.getMarkerFeature().setStyle(selectedAsset.massTransitStop.getMarkerSelectionStyles());
     terminalSource.clear();
@@ -897,7 +900,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   function toggleMode(readOnly) {
     if(applicationModel.isReadOnly() || readOnly){
       dragControl.deactivate();
-    } else if(selectedMassTransitStopModel.exists() && !authorizationPolicy.formEditModeAccess()) {
+    } else if(selectedMassTransitStopModel.exists() && !authorizationPolicy.formEditModeAccess() && !editingRestrictions.pointAssetHasRestriction(selectedMassTransitStopModel.getMunicipalityCode(), selectedMassTransitStopModel.getAdministrativeClass(), typeId)) {
       dragControl.activate();
     }
   }

--- a/UI/src/view/point_asset/pointAssetLayer.js
+++ b/UI/src/view/point_asset/pointAssetLayer.js
@@ -61,10 +61,16 @@
       if(feature.selected.length > 0 && feature.deselected.length === 0){
           var properties = feature.selected[0].getProperties();
           var administrativeClass = obtainAdministrativeClass(properties);
+          var municipalityCode = obtainMunicipalityCode(properties);
           var asset = _.merge({}, properties, {administrativeClass: administrativeClass});
           selectedAsset.open(asset);
-          if(authorizationPolicy.formEditModeAccess(selectedAsset, roadCollection) && !applicationModel.isReadOnly())
-            dragControl.activate();
+          if (authorizationPolicy.formEditModeAccess(selectedAsset, roadCollection) && !applicationModel.isReadOnly()) {
+            if (typeId === 250 && !(editingRestrictions.pointAssetHasRestriction(selectedAsset.get().municipalityCode, 'State', typeId) || editingRestrictions.pointAssetHasRestriction(selectedAsset.get().municipalityCode, 'Municipality', typeId))) {
+              dragControl.activate();
+            } else if (typeId !== 250 && !editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
+              dragControl.activate();
+            }
+          }
       }
       else {
         if(feature.deselected.length > 0 && !selectedAsset.isDirty()) {
@@ -322,7 +328,11 @@
       if(readOnly){
         dragControl.deactivate();
       } else if(selectedAsset.exists() && authorizationPolicy.formEditModeAccess(selectedAsset, roadCollection)) {
-        dragControl.activate();
+        if (typeId === 250 && !(editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), 'State', typeId) || editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), 'Municipality', typeId))) {
+          dragControl.activate();
+        } else if (typeId !== 250 && !editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), selectedAsset.getAdministrativeClass(), typeId)) {
+          dragControl.activate();
+        }
       }
     }
 

--- a/UI/src/view/point_asset/pointAssetLayer.js
+++ b/UI/src/view/point_asset/pointAssetLayer.js
@@ -41,6 +41,7 @@
     map.addLayer(me.vectorLayer);
 
     var editingRestrictions = new EditingRestrictions();
+    var servicePointTypeId = 250;
 
     var selectControl = new SelectToolControl(application, me.vectorLayer, map, false,{
         style : function (feature) {
@@ -65,9 +66,9 @@
           var asset = _.merge({}, properties, {administrativeClass: administrativeClass});
           selectedAsset.open(asset);
           if (authorizationPolicy.formEditModeAccess(selectedAsset, roadCollection) && !applicationModel.isReadOnly()) {
-            if (typeId === 250 && !(editingRestrictions.pointAssetHasRestriction(selectedAsset.get().municipalityCode, 'State', typeId) || editingRestrictions.pointAssetHasRestriction(selectedAsset.get().municipalityCode, 'Municipality', typeId))) {
+            if (typeId === servicePointTypeId && !(editingRestrictions.pointAssetHasRestriction(selectedAsset.get().municipalityCode, 'State', typeId) || editingRestrictions.pointAssetHasRestriction(selectedAsset.get().municipalityCode, 'Municipality', typeId))) {
               dragControl.activate();
-            } else if (typeId !== 250 && !editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
+            } else if (typeId !== servicePointTypeId && !editingRestrictions.pointAssetHasRestriction(municipalityCode, administrativeClass, typeId)) {
               dragControl.activate();
             }
           }
@@ -328,9 +329,9 @@
       if(readOnly){
         dragControl.deactivate();
       } else if(selectedAsset.exists() && authorizationPolicy.formEditModeAccess(selectedAsset, roadCollection)) {
-        if (typeId === 250 && !(editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), 'State', typeId) || editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), 'Municipality', typeId))) {
+        if (typeId === servicePointTypeId && !(editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), 'State', typeId) || editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), 'Municipality', typeId))) {
           dragControl.activate();
-        } else if (typeId !== 250 && !editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), selectedAsset.getAdministrativeClass(), typeId)) {
+        } else if (typeId !== servicePointTypeId && !editingRestrictions.pointAssetHasRestriction(selectedAsset.getMunicipalityCode(), selectedAsset.getAdministrativeClass(), typeId)) {
           dragControl.activate();
         }
       }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PedestrianCrossingCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/PedestrianCrossingCsvImporter.scala
@@ -26,9 +26,9 @@ class PedestrianCrossingCsvImporter(roadLinkServiceImpl: RoadLinkService, eventB
 
     (optLon, optLat) match {
       case (Some(lon), Some(lat)) =>
-        val roadLinks = roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong))
+        val roadLinks = roadLinkService.getClosestRoadlinkForCarTraffic(user, Point(lon.toLong, lat.toLong)).filter(_.administrativeClass != State)
         roadLinks.isEmpty match {
-          case true => (List(s"No Rights for Municipality or nonexistent road links near asset position"), Seq())
+          case true => (List(s"No Rights for Municipality or nonexistent non-state road links near asset position"), Seq())
           case false =>
             if (assetHasEditingRestrictions(PedestrianCrossings.typeId, roadLinks)) {
               (List("Asset type editing is restricted within municipality or admininistrative class."), Seq())
@@ -48,7 +48,7 @@ class PedestrianCrossingCsvImporter(roadLinkServiceImpl: RoadLinkService, eventB
 
       val position = getCoordinatesFromProperties(csvProperties)
 
-      val nearestRoadLink = nearbyLinks.filter(_.administrativeClass != State).minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
+      val nearestRoadLink = nearbyLinks.minBy(r => GeometryUtils.minimumDistance(position, r.geometry))
 
       val floating = checkMinimumDistanceFromRoadLink(position, nearestRoadLink.geometry)
 


### PR DESCRIPTION
* korjattu bussien lomake, jonka disablointi puuttui, kun rajoitettu
* estetty pistemäisten siirtäminen, kun rajoitettu
* siirretty state road filtteri eri kohtaan suojateiden csv-importissa (vanhan koodin bugi, joka kaataa koko importin, jos alunperin löytyy lähistöltä vain valtion linkki) 