### PR TITLE
DROTH-4276 Add info text for obstacle types on obstacleForm.js

### DIFF
--- a/UI/src/view/point_asset/obstacleForm.js
+++ b/UI/src/view/point_asset/obstacleForm.js
@@ -39,7 +39,15 @@
         '      </select>' +
         '    </div>' +
         '</div>' +
-          components;
+          components +
+          '      <div class="obstacle-info-text" style="margin-top:12px;">' +
+          '        <ul style="margin-bottom:0;">' +
+          '          <li><strong>Kiinteä esterakennelma</strong> tarkoittaa, että estettä ei voi avata eikä lihasvoimin poistaa, kuten betoniporsas, pollari tai kivi.</li>' +
+          '          <li><strong>Avattava esterakennelma</strong> on este, jonka saa auki tarvittaessa (voi olla lukittu tai lukitsematon). Avattava puomi kattaa myös portit, ketjut sekä kävelyn ja pyöräilyn väylien sulkuportit.</li>' +
+          '          <li><strong>Kaivanne</strong> tarkoittaa tien poikki kaivettua uraa, joka estää tiellä kulkemisen.</li>' +
+          '          <li><strong>Ei tiedossa</strong> tarkoittaa, että esterakennelman tarkempi tyyppi ei ole tiedossa.</li>' +
+          '        </ul>' +
+          '      </div>';
     };
 
     this.boxEvents = function(rootElement, selectedAsset, localizedTexts, authorizationPolicy, roadCollection, collection) {


### PR DESCRIPTION
Lisätty puuttuva teksti obstacle formille kuvailemaan esterakennelmien tyypit
<img width="894" height="918" alt="image" src="https://github.com/user-attachments/assets/e3a4ac07-55d0-433c-beb7-c12317a087a4" />
