### PR TITLE
Droth 3780

### DIFF
--- a/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
+++ b/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
@@ -26,19 +26,25 @@
     };
 
     /** Rules:
-    * Municipality maintainer: can update bus stops and other asset types inside own municipalities on admin class 2(municipality) and 3(private)
+    * Municipality maintainer: can update bus stops and other asset types inside own municipalities on admin class 1(state, only virtual stops) 2(municipality) and 3(private)
     * Ely maintainer: can update bus stops and other asset types inside own ELY-area on admin class 1(state) and 2(municipality) and 3(private)
     * Operator: no restrictions
     * */
 
     this.assetSpecificAccess = function(){
       var municipalityCode = selectedMassTransitStopModel.getMunicipalityCode();
+      var isAdminClassState = selectedMassTransitStopModel.isAdminClassState();
+      var isOnlyVirtualStop = selectedMassTransitStopModel.isOnlyVirtualStop();
 
       var isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() && me.hasRightsInMunicipality(municipalityCode);
       var isElyyAndHaveRights = me.isElyMaintainer() && me.hasRightsInMunicipality(municipalityCode);
 
-      return me.isStateExclusions(selectedMassTransitStopModel) || ( isMunicipalityAndHaveRights || isElyyAndHaveRights || me.isOperator() );
+      return me.isStateExclusions(selectedMassTransitStopModel) ||
+          ((isMunicipalityAndHaveRights && (!isAdminClassState || (isAdminClassState && isOnlyVirtualStop))) ||
+              isElyyAndHaveRights ||
+              me.isOperator());
     };
+
 
 
     this.formEditModeAccess = function () {

--- a/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
+++ b/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
@@ -36,13 +36,12 @@
       var isAdminClassState = selectedMassTransitStopModel.isAdminClassState();
       var isOnlyVirtualStop = selectedMassTransitStopModel.isOnlyVirtualStop();
 
-      var isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() && me.hasRightsInMunicipality(municipalityCode);
+      var isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() &&
+          me.hasRightsInMunicipality(municipalityCode) &&
+          (!isAdminClassState || (isAdminClassState && isOnlyVirtualStop));
       var isElyyAndHaveRights = me.isElyMaintainer() && me.hasRightsInMunicipality(municipalityCode);
 
-      return me.isStateExclusions(selectedMassTransitStopModel) ||
-          ((isMunicipalityAndHaveRights && (!isAdminClassState || (isAdminClassState && isOnlyVirtualStop))) ||
-              isElyyAndHaveRights ||
-              me.isOperator());
+      return me.isStateExclusions(selectedMassTransitStopModel) || (isMunicipalityAndHaveRights || isElyyAndHaveRights || me.isOperator());
     };
 
 

--- a/UI/src/enumerations.js
+++ b/UI/src/enumerations.js
@@ -175,5 +175,14 @@
       {value: 99, title: 'Tuntematon'}
     ];
 
+    this.massTransitStopTypes = {
+      Tram:              { value: 1,  text: 'Raitiovaunu' },
+      Bus:               { value: 2,  text: 'Bussi' },
+      Virtual:           { value: 5,  text: 'Virtuaalipysäkki' },
+      Terminal:          { value: 6,  text: 'Terminaali' },
+      ServicePoint:      { value: 7,  text: 'Palvelupiste' },
+      Unknown:           { value: 99, text: 'Tuntematon' }
+    };
+
   };
 })(this);

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -578,9 +578,17 @@
     }
 
     function isAdminClassState(properties) {
+      if (!properties) properties = getProperties();
       var adminClass = getAdministrativeClass(properties);
 
       return adminClass === '1' || adminClass === 'State';
+    }
+
+    function isAdminClassMunicipality(properties) {
+      if (!properties) properties = getProperties();
+      var adminClass = getAdministrativeClass(properties);
+
+      return adminClass === '2' || adminClass === 'Municipality';
     }
 
     function isAdministratorHSL(properties){
@@ -711,6 +719,7 @@
       getRoadLink: getRoadLink,
       getAdministrativeClass: getAdministrativeClass,
       isAdminClassState: isAdminClassState,
+      isAdminClassMunicipality: isAdminClassMunicipality,
       isAdministratorELY: isAdministratorELY,
       isAdministratorHSL: isAdministratorHSL,
       validateDirectionsForSave : validateDirectionsForSave,

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -132,10 +132,7 @@
       assetHasBeenModified = true;
       // If stopType is 6 (Terminal) or 7 (ServicePoint), pass coordinates to backend.
       // Backend includes liitetyt_pysakit property in response for these types
-      var assetPosition = (asset.stopTypes && (asset.stopTypes.includes('6') || asset.stopTypes.includes('7')))
-          ? { lon: asset.lon, lat: asset.lat }
-          : undefined;
-
+      var assetPosition = (asset.stopTypes && (asset.stopTypes.includes('6') || asset.stopTypes.includes('7'))) ? { lon: asset.lon, lat: asset.lat } : undefined;
       backend.getAssetTypeProperties(assetPosition, function(properties) {
         _.find(properties, function (property) {
           return property.publicId === 'vaikutussuunta';

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -143,6 +143,19 @@
         if(!_.isEmpty(currentAsset.stopTypes) && currentAsset.stopTypes[0] == '7')
           properties =  _.filter(properties, function(prop) { return _.includes(servicePointPropertyOrdering, prop.publicId);});
 
+        if (!_.isEmpty(currentAsset.stopTypes) && currentAsset.stopTypes[0] == '5') {
+          var stopTypeProperty = _.find(properties, { publicId: 'pysakin_tyyppi' });
+          if (stopTypeProperty) {
+            stopTypeProperty.values = [
+              {
+                propertyValue: "5",
+                propertyDisplayValue: "Virtuaalipysäkki",
+                checked: false
+              }
+            ];
+          }
+        }
+
         currentAsset.propertyMetadata = properties;
         currentAsset.payload = _.merge({}, _.pick(currentAsset, usedKeysFromFetchedAsset), transformPropertyData(properties));
         changedProps = extractPublicIds(currentAsset.payload.properties);

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -130,7 +130,12 @@
       currentAsset = asset;
       currentAsset.payload = {};
       assetHasBeenModified = true;
-      var assetPosition = asset.stopTypes && asset.stopTypes.length > 0 ? { lon: asset.lon, lat: asset.lat } : undefined;
+      // If stopType is 6 (Terminal) or 7 (ServicePoint), pass coordinates to backend.
+      // Backend includes liitetyt_pysakit property in response for these types
+      var assetPosition = (asset.stopTypes && (asset.stopTypes.includes('6') || asset.stopTypes.includes('7')))
+          ? { lon: asset.lon, lat: asset.lat }
+          : undefined;
+
       backend.getAssetTypeProperties(assetPosition, function(properties) {
         _.find(properties, function (property) {
           return property.publicId === 'vaikutussuunta';

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -761,11 +761,10 @@
         return createWrapper(property).append(createMultiChoiceElement(readOnly, property, choices).append(choiceValidation.element));
       };
 
-      var allowOnlyVirtualStopChoice = function(propertyValue) {
+      var allowOnlyVirtualStopChoice = function() {
         var isStateAdminClass = selectedMassTransitStopModel.getAdministrativeClass() == 1 || selectedMassTransitStopModel.getAdministrativeClass() === 'State';
 
-        return authorizationPolicy.isMunicipalityMaintainer() && isStateAdminClass &&
-            selectedMassTransitStopModel.isOnlyVirtualStop() && (propertyValue === "1" || propertyValue === "2");
+        return authorizationPolicy.isMunicipalityMaintainer() && isStateAdminClass && selectedMassTransitStopModel.isOnlyVirtualStop();
       };
 
       var createMultiChoiceElement = function(readOnly, property, choices) {
@@ -795,7 +794,7 @@
 
           var shouldDisable = false;
           if (property.publicId === "pysakin_tyyppi") {
-            shouldDisable = allowOnlyVirtualStopChoice(value.propertyValue);
+            shouldDisable = allowOnlyVirtualStopChoice();
           }
 
           if (readOnly) {

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -172,7 +172,7 @@
     }
 
     var updateStatus = function () {
-      var isStateAdminClass = selectedMassTransitStopModel.getAdministrativeClass() == 1 || selectedMassTransitStopModel.getAdministrativeClass() === 'State';
+      var isStateAdminClass = selectedMassTransitStopModel.isAdminClassState;
 
       if (pointAssetToSave && !isValidServicePoint()) {
         element.prop('disabled', true);
@@ -407,8 +407,8 @@
         var municipalityRoadEditingRestricted = 'Kunnan kohteiden muokkaus on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.';
         var message = '';
 
-        var stateAdminClassLink = selectedMassTransitStopModel.getAdministrativeClass() == 1 || selectedMassTransitStopModel.getAdministrativeClass() === 'State';
-        var municipalityAdminClassLink = selectedMassTransitStopModel.getAdministrativeClass() == 2 || selectedMassTransitStopModel.getAdministrativeClass() === 'Municipality';
+        var stateAdminClassLink = selectedMassTransitStopModel.isAdminClassState();
+        var municipalityAdminClassLink = selectedMassTransitStopModel.isAdminClassMunicipality();
 
         if (stateAdminClassLink && editingRestrictions.pointAssetHasRestriction(selectedMassTransitStopModel.getMunicipalityCode(), selectedMassTransitStopModel.getAdministrativeClass(), typeId)) {
           message = stateRoadEditingRestricted;
@@ -758,7 +758,7 @@
       };
 
       var allowOnlyVirtualStopChoice = function() {
-        var isStateAdminClass = selectedMassTransitStopModel.getAdministrativeClass() == 1 || selectedMassTransitStopModel.getAdministrativeClass() === 'State';
+        var isStateAdminClass = selectedMassTransitStopModel.isAdminClassState();
 
         return authorizationPolicy.isMunicipalityMaintainer() && isStateAdminClass && selectedMassTransitStopModel.isOnlyVirtualStop();
       };

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -405,7 +405,6 @@
         var noRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen.';
         var stateRoadEditingRestricted = 'Kohteiden muokkaus on estetty, koska kohteita ylläpidetään Tievelho-tietojärjestelmässä.';
         var municipalityRoadEditingRestricted = 'Kunnan kohteiden muokkaus on estetty, koska kohteita ylläpidetään kunnan omassa tietojärjestelmässä.';
-        var municipalityUserStateRoadRights = 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen. Kuntaylläpitäjänä voit muokata valtion teillä vain virtuaalipysäkkejä.';
         var message = '';
 
         var stateAdminClassLink = selectedMassTransitStopModel.getAdministrativeClass() == 1 || selectedMassTransitStopModel.getAdministrativeClass() === 'State';
@@ -419,10 +418,7 @@
           message = limitedRights;
         } else if (!authorizationPolicy.assetSpecificAccess()) {
           message = noRights;
-        } else if (authorizationPolicy.isMunicipalityMaintainer() && stateAdminClassLink && !selectedMassTransitStopModel.isOnlyVirtualStop()) {
-          message = municipalityUserStateRoadRights;
         }
-
 
         if(message) {
           return '' +
@@ -1099,9 +1095,6 @@
         if (property.publicId === 'tietojen_yllapitaja' && (_.find(property.values, function (value) {return value.propertyValue != '2';}))) {
           isTRMassTransitStop = false;
           property.propertyType = "single_choice";
-          renderAssetForm();
-        }
-        if (property.publicId === 'pysakin_tyyppi') {
           renderAssetForm();
         }
         // Prevent getAssetForm() branching to 'Ei toteutettu'

--- a/UI/src/view/point_asset/massTransitStopForm.js
+++ b/UI/src/view/point_asset/massTransitStopForm.js
@@ -172,7 +172,7 @@
     }
 
     var updateStatus = function () {
-      var isStateAdminClass = selectedMassTransitStopModel.isAdminClassState;
+      var isStateAdminClass = selectedMassTransitStopModel.isAdminClassState();
 
       if (pointAssetToSave && !isValidServicePoint()) {
         element.prop('disabled', true);

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -21,6 +21,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
   var clusterView;
 
   var editingRestrictions = new EditingRestrictions();
+  var enumerations = new Enumerations();
   var typeId = 10;
 
   var showOrHideServicePointLayer = function (showOrHide) {
@@ -683,7 +684,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     var properties = feature.getProperties();
 
     var distance;
-    if(properties.data.stopTypes[0] != 7) {
+    if(properties.data.stopTypes[0] != enumerations.massTransitStopTypes.ServicePoint.value) {
       distance = Math.sqrt(geometrycalculator.getSquaredDistanceBetweenPoints(coordinates, originalCoordinates));
     }else{
       distance = Math.sqrt(geometrycalculator.getSquaredDistanceBetweenPoints({ x: event.coordinate[0], y: event.coordinate[1]}, originalCoordinates));
@@ -729,7 +730,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     var feature = event.features.getArray()[0];
     var properties = feature.getProperties();
 
-    if (properties.data.stopTypes[0] != 7) {
+    if (properties.data.stopTypes[0] != enumerations.massTransitStopTypes.ServicePoint.value) {
 
     properties.data.bearing = angle;
     properties.data.roadDirection = angle;
@@ -836,14 +837,14 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
       var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks), coordinates.x, coordinates.y);
       var roadLink = roadCollection.getRoadLinkByLinkId(nearestLine.linkId);
       var administrativeClass = roadLink.getData().administrativeClass;
+      var isStateAdminClass = administrativeClass == enumerations.administrativeClasses.State.value || administrativeClass === enumerations.administrativeClasses.State.stringValue;
 
-      if ( selectedControl === 'AddTerminal' ) {
-        stopType = ['6'];
-      } else if ( selectedControl === 'AddPointAsset' ) {
-        stopType = ['7'];
-      } else if (selectedControl === 'Add' && (administrativeClass == 1 || administrativeClass === 'State') &&
-          authorizationPolicy.isMunicipalityMaintainer()) {
-        stopType = ['5'];
+      if (selectedControl === 'AddTerminal') {
+        stopType = [enumerations.massTransitStopTypes.Terminal.value];
+      } else if (selectedControl === 'AddPointAsset') {
+        stopType = [enumerations.massTransitStopTypes.ServicePoint.value];
+      } else if (selectedControl === 'Add' && isStateAdminClass && authorizationPolicy.isMunicipalityMaintainer()) {
+        stopType = [enumerations.massTransitStopTypes.Virtual.value];
       }
 
       createNewAsset(coordinates, false, stopType );

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -832,11 +832,18 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
 
       selectControl.deactivate();
       var stopType = [];
+      var roadLinks = getCorrectRoadLinks();
+      var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks), coordinates.x, coordinates.y);
+      var roadLink = roadCollection.getRoadLinkByLinkId(nearestLine.linkId);
+      var administrativeClass = roadLink.getData().administrativeClass;
 
       if ( selectedControl === 'AddTerminal' ) {
         stopType = ['6'];
       } else if ( selectedControl === 'AddPointAsset' ) {
         stopType = ['7'];
+      } else if (selectedControl === 'Add' && (administrativeClass == 1 || administrativeClass === 'State') &&
+          authorizationPolicy.isMunicipalityMaintainer()) {
+        stopType = ['5'];
       }
 
       createNewAsset(coordinates, false, stopType );


### PR DESCRIPTION
Korjattu joukkoliikenteenpysäkkien UI:lta bugeja ja puutteita toiminnassa liittyen DROTH-3780 muutokseen, jossa kuntakäyttäjille sallittiin virtuaalipysäkkien ylläpito valtion teillä omassa kunnassaan. 

Muutettu formin toimintaa siten, että jos vain virtuaalipysäkki on sallittu tyyppi pysäkille, niin muita tyyppejä ei voi valita, vaan ne on disabloitu. Lisätessä uutta pysäkkiä kuntakäyttäjänä valtion tielle, on nyt virtuaalipysäkki valittuna jo oletuksena. Muutoksen takia virheviesti 'Käyttöoikeudet eivät riitä kohteen muokkaamiseen. Kuntaylläpitäjänä voit muokata valtion teillä vain virtuaalipysäkkejä.' jäi turhaksi ja poistettu.

