### PR TITLE
DROTH-4276 Prevent municipality user from trying to create terminal o…

### DIFF
--- a/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
+++ b/UI/src/authorizationpolicies/massTransitStopAuthorizationPolicy.js
@@ -10,8 +10,13 @@
       return (me.isElyMaintainer() && me.hasRightsInMunicipality(municipalityCode)) || me.isOperator();
     };
 
-    this.filterRoadLinks = function(roadLink){
-      var isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() && me.hasRightsInMunicipality(roadLink.municipalityCode);
+    this.filterRoadLinks = function(roadLink, allowStateRoadLinksForMunicipality){
+      var isMunicipalityAndHaveRights;
+      if (allowStateRoadLinksForMunicipality) {
+        isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() && me.hasRightsInMunicipality(roadLink.municipalityCode);
+      } else {
+        isMunicipalityAndHaveRights = me.isMunicipalityMaintainer() && roadLink.administrativeClass !== 'State' && me.hasRightsInMunicipality(roadLink.municipalityCode);
+      }
       var isElyAndHaveRights = me.isElyMaintainer() && me.hasRightsInMunicipality(roadLink.municipalityCode);
 
       return me.isStateExclusions(roadLink) || isMunicipalityAndHaveRights || isElyAndHaveRights || me.isOperator();

--- a/UI/src/model/selectedMassTransitStop.js
+++ b/UI/src/model/selectedMassTransitStop.js
@@ -37,6 +37,14 @@
       return _.includes(['Add', 'AddTerminal', 'AddPointAsset'], optionTool);
     }
 
+    function isAddTerminalTool(optionTool){
+      return _.includes(['AddTerminal'], optionTool);
+    }
+
+    function isAddServicePointTool(optionTool){
+      return _.includes(['AddPointAsset'], optionTool);
+    }
+
     var close = function() {
       assetHasBeenModified = false;
       currentAsset = {};
@@ -740,6 +748,8 @@
       setAdditionalProperty: setAdditionalProperty,
       isSuggested: isSuggested,
       isAnAddToolOption: isAnAddToolOption,
+      isAddTerminalTool: isAddTerminalTool,
+      isAddServicePointTool: isAddServicePointTool,
       isTerminalType: isTerminalType,
       isServicePointType: isServicePointType,
       getServicePointPropertyOrdering: getServicePointPropertyOrdering,

--- a/UI/src/view/point_asset/massTransitStopLayer.js
+++ b/UI/src/view/point_asset/massTransitStopLayer.js
@@ -219,7 +219,8 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
     style : function(feature) {
       return massTransitStopLayerStyles.default.getStyle(feature, {zoomLevel: zoomlevels.isInRoadLinkZoomLevel(zoomlevels.getViewZoom(map))});
     },
-    walkingCycling : false
+    walkingCycling : false,
+    excludeStateRoadLinks: false
   });
 
   roadLayer.setLayerSpecificStyleProvider('massTransitStop', function() {
@@ -490,7 +491,7 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
 
     var default_asset_direction = {BothDirections: 2, TowardsDigitizing: 2, AgainstDigitizing: 3};
     var roadLinks = getCorrectRoadLinks();
-    var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks), coordinate.x, coordinate.y);
+    var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks, selectedControl), coordinate.x, coordinate.y);
     var lon, lat;
 
     if(nearestLine.end && nearestLine.start){
@@ -774,8 +775,16 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
 
     if (selectedMassTransitStopModel.isAnAddToolOption(selectedControl) && zoomlevels.isInRoadLinkZoomLevel(zoomlevels.getViewZoom(map)))
     {
-      if ( selectedControl !== 'AddPointAsset')
+      if ( selectedControl === 'Add') {
         pointTool.activate();
+        pointTool.includeStateRoadLinks();
+      }
+
+      if ( selectedControl === 'AddTerminal') {
+        pointTool.activate();
+        if (authorizationPolicy.isMunicipalityMaintainer()) pointTool.excludeStateRoadLinks();
+        else pointTool.includeStateRoadLinks();
+      }
     }
   };
 
@@ -834,21 +843,22 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
       selectControl.deactivate();
       var stopType = [];
       var roadLinks = getCorrectRoadLinks();
-      var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks), coordinates.x, coordinates.y);
+      var nearestLine = geometrycalculator.findNearestLine(excludeRoadByAdminClass(roadLinks, selectedControl), coordinates.x, coordinates.y);
       var roadLink = roadCollection.getRoadLinkByLinkId(nearestLine.linkId);
-      var administrativeClass = roadLink.getData().administrativeClass;
-      var isStateAdminClass = administrativeClass == enumerations.administrativeClasses.State.value || administrativeClass === enumerations.administrativeClasses.State.stringValue;
+      if (roadLink) {
+        var administrativeClass = roadLink.getData().administrativeClass;
+        var isStateAdminClass = administrativeClass == enumerations.administrativeClasses.State.value || administrativeClass === enumerations.administrativeClasses.State.stringValue;
 
-      if (selectedControl === 'AddTerminal') {
-        stopType = [enumerations.massTransitStopTypes.Terminal.value];
-      } else if (selectedControl === 'AddPointAsset') {
-        stopType = [enumerations.massTransitStopTypes.ServicePoint.value];
-      } else if (selectedControl === 'Add' && isStateAdminClass && authorizationPolicy.isMunicipalityMaintainer()) {
-        stopType = [enumerations.massTransitStopTypes.Virtual.value];
+        if (selectedControl === 'AddTerminal') {
+          stopType = [enumerations.massTransitStopTypes.Terminal.value];
+        } else if (selectedControl === 'AddPointAsset') {
+          stopType = [enumerations.massTransitStopTypes.ServicePoint.value];
+        } else if (selectedControl === 'Add' && isStateAdminClass && authorizationPolicy.isMunicipalityMaintainer()) {
+          stopType = [enumerations.massTransitStopTypes.Virtual.value];
+        }
+
+        createNewAsset(coordinates, false, stopType);
       }
-
-      createNewAsset(coordinates, false, stopType );
-
     } else {
 
       if (selectedMassTransitStopModel.isDirty()) {
@@ -1069,9 +1079,14 @@ window.MassTransitStopLayer = function(map, roadCollection, mapOverlay, assetGro
       clusterFeatureSource.clear();
   };
 
-  function excludeRoadByAdminClass(roadCollection) {
+  function excludeRoadByAdminClass(roadCollection, selectedControl) {
+    var allowStateRoadLinksForMunicipality;
+    if (selectedMassTransitStopModel.isAddTerminalTool(selectedControl) || selectedMassTransitStopModel.isAddServicePointTool(selectedControl)) {
+      allowStateRoadLinksForMunicipality = false;
+    } else allowStateRoadLinksForMunicipality = true;
+
     return _.filter(roadCollection, function (road) {
-      return authorizationPolicy.filterRoadLinks(road);
+      return authorizationPolicy.filterRoadLinks(road, allowStateRoadLinksForMunicipality);
     });
   }
 

--- a/UI/src/view/point_asset/pointsCursorTool.js
+++ b/UI/src/view/point_asset/pointsCursorTool.js
@@ -36,24 +36,47 @@
       settings.walkingCycling = !settings.walkingCycling;
     };
 
+    var excludeStateRoadLinks = function () {
+      settings.excludeStateRoadLinks = true;
+    };
+
+    var includeStateRoadLinks = function () {
+      settings.excludeStateRoadLinks = false;
+    };
+
     var updateByPosition = function (mousePoint) {
-      var nearestLine;
+      var roadLinks;
       if (settings.walkingCycling === true) {
-        nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForCarPedestrianCycling(), mousePoint[0], mousePoint[1]);
+        roadLinks = roadCollection.getRoadsForCarPedestrianCycling();
       } else {
-        nearestLine = geometrycalculator.findNearestLine(roadCollection.getRoadsForPointAssets(), mousePoint[0], mousePoint[1]);
+        roadLinks = roadCollection.getRoadsForPointAssets();
       }
-      var projectionOnNearestLine = geometrycalculator.nearestPointOnLine(nearestLine, {
-        x: mousePoint[0],
-        y: mousePoint[1]
-      });
-      moveTo(projectionOnNearestLine.x, projectionOnNearestLine.y);
+
+      var filteredRoadLinks;
+      if( settings.excludeStateRoadLinks === true) {
+        filteredRoadLinks = _.filter(roadLinks, function(link) {
+          return link.administrativeClass !== "State";
+        });
+      } else {
+        filteredRoadLinks = roadLinks;
+      }
+
+      if (filteredRoadLinks && filteredRoadLinks.length !== 0) {
+        var nearestLine = geometrycalculator.findNearestLine(filteredRoadLinks, mousePoint[0], mousePoint[1]);
+        var projectionOnNearestLine = geometrycalculator.nearestPointOnLine(nearestLine, {
+          x: mousePoint[0],
+          y: mousePoint[1]
+        });
+        moveTo(projectionOnNearestLine.x, projectionOnNearestLine.y);
+      }
     };
 
     return {
       activate: activate,
       deactivate: deactivate,
-      toggleWalkingCycling: toggleWalkingCycling
+      toggleWalkingCycling: toggleWalkingCycling,
+      excludeStateRoadLinks: excludeStateRoadLinks,
+      includeStateRoadLinks: includeStateRoadLinks
     };
   };
 })(this);


### PR DESCRIPTION
Aikaisemmat muutokset mahdollistivat kuntakäyttäjän yrittää luoda Terminaalia tai palvelupistettä valtion tielinkille. Formi aukesi tällöin readonly tilassa, kun kuntakäyttäjä loi assetin, koska kuntakäyttäjällä ei oikeutta muokata valtion teillä terminaaleja ja palvelupisteitä. Formia ei siten myöskään saanut suljettua tästä syystä. 

Filtteröidään nyt sopivat tielinkit luodessa assettia UI:lla. Korjattu samalla pointsCursorTool (Kursori, joka piirtyy lähimmälle tielinkille joukkoliikenteen pysäkkiä luodessa) näkymään vain sallituilla tielinkeillä.