### PR TITLE
DROTH-4191 Fix bug on speedLimitLayer. Wrong parameter was given to f…

### DIFF
--- a/UI/src/view/linear_asset/speedLimitLayer.js
+++ b/UI/src/view/linear_asset/speedLimitLayer.js
@@ -158,7 +158,8 @@ window.SpeedLimitLayer = function(params) {
       if (!closestSpeedLimitLink) {
         return;
       }
-      if (authorizationPolicy.formEditModeAccess(closestSpeedLimitLink)) {
+      var nearestSpeedLimitAsset = closestSpeedLimitLink.feature.getProperties();
+      if (authorizationPolicy.formEditModeAccess(nearestSpeedLimitAsset)) {
         if (isWithinCutThreshold(closestSpeedLimitLink.distance)) {
           moveTo(closestSpeedLimitLink.point[0], closestSpeedLimitLink.point[1]);
         } else {


### PR DESCRIPTION
Korjattu bugi, jossa katkaisutyökalun kursori ei piirtynyt tielinkille kuntakäyttäjillä. formEditModeAccess metodille ollaan annettu väärässä muodossa asset, jolloin kuntakäyttäjän oikeuksien tarkistus epäonnistui aina, eikä kursoria siten piirretty lähimmälle sallitulle linkille.