### PR TITLE
Droth 4291 traffic sign csv import bug

### DIFF
--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -465,7 +465,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
     }
   }
 
-  test("Validation for traffic sign import with additional panel sign type", Tag("db")) {
+  test("Validation for traffic sign import when importing additional panel as main sign", Tag("db")) {
     val assetFields = Map("koordinaatti x" -> 1, "koordinaatti y" -> 1, "liikennemerkin tyyppi" -> "H22.2", "suuntima" -> "40",
       "arvo" -> "", "kunnan id" -> "408")
 

--- a/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
+++ b/digiroad2-api-oth/src/test/scala/fi/liikennevirasto/digiroad2/dataimport/CsvDataImporterSpec.scala
@@ -483,7 +483,7 @@ class CsvDataImporterSpec extends AuthenticatedApiSpec with BeforeAndAfter {
       result.notImportedData.size should be(1)
       result.createdData.size should be(0)
 
-      result.notImportedData.head.reason should equal("Not a valid sign")
+      result.notImportedData.head.reason should equal("Invalid trafficSignType for main sign")
     }
   }
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -324,7 +324,7 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
     val optTrafficSignType = getPropertyValueOption(parsedRow, "trafficSignType").asInstanceOf[Option[String]]
     val (trafficSign, isValidMainSign) = validateMainSignType(optTrafficSignType)
 
-    //Validate if we get a valida sign
+    //Validate if we get a valid sign
     if (!isValidMainSign)
       return (List("Not a valid main sign"), Seq() )
 

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/csvDataImporter/TrafficSignCsvImporter.scala
@@ -305,28 +305,21 @@ class TrafficSignCsvImporter(roadLinkServiceImpl: RoadLinkService, eventBusImpl:
         case _: Throwable => (false, List("Invalid dates formats"))
       }
     }
-    def validateMainSignType(trafficSignType: Option[String]) = {
-      def isValidMainSignType(signType: TrafficSignType) = {
-        signType match {
-          case _: AdditionalPanelsType | TrafficSignType.Unknown =>
-            false
-          case _ => true
-        }
-      }
-      trafficSignType match {
-        case Some(signType) =>
-          val sign = TrafficSignType.applyNewLawCode(signType)
-          (sign, isValidMainSignType(sign))
-        case _ => (TrafficSignType.Unknown, false)
+
+    def validateMainSignType(signType: TrafficSignType) = {
+      signType match {
+        case _: AdditionalPanelsType | TrafficSignType.Unknown =>
+          false
+        case _ => true
       }
     }
 
     val optTrafficSignType = getPropertyValueOption(parsedRow, "trafficSignType").asInstanceOf[Option[String]]
-    val (trafficSign, isValidMainSign) = validateMainSignType(optTrafficSignType)
+    val trafficSign = optTrafficSignType.map(TrafficSignType.applyNewLawCode).getOrElse(TrafficSignType.Unknown)
+    val isValidMainSign = validateMainSignType(trafficSign)
 
-    //Validate if we get a valid sign
     if (!isValidMainSign)
-      return (List("Not a valid main sign"), Seq() )
+      return (List("Invalid trafficSignType for main sign"), Seq() )
 
     /* start date validations */
     val temporaryDevices = Seq(4,5)


### PR DESCRIPTION
Muutettu CSV importing verifyData-metodissa suoritettavaa liikennemerkkien tarkastusta niin, ettei lisäkilpiä (H-alkuinen trafficSignType) voi lisätä päämerkkinä. 

verifyData-päämetodin rakenteeseen ei tämän tiketin osalta koskettu kummemin, mutta se liian on pitkä ja rönsyilevä ja kaipaisi laajempaa remonttia. Lisäksi virheilmoitusten kuvaukset ovat jostain syystä englanniksi. Operaattori on tietoinen tilanteesta ja asiasta on tehty parannusehdotus.