### PR TITLE
DROTH-4399 refactor linearAssetPartitioner

### DIFF
--- a/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
+++ b/digiroad2-geo/src/main/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitioner.scala
@@ -5,42 +5,6 @@ import fi.liikennevirasto.digiroad2.asset.SideCode
 object LinearAssetPartitioner extends GraphPartitioner {
 
   /**
-   * Partitions a sequence of linear assets by enriching them with road link address data
-   * and delegating to a partitioning logic. It enriches each asset temporarily with additional
-   * attributes such as road number and road name if a corresponding RoadLink
-   * exists. After enrichment, it calls a secondary partitioning method on the enriched assets.
-   *
-   * @tparam T The specific subtype of PieceWiseLinearAsset.
-   * @param assetLinks              A sequence of linear assets to enrichAndPartition.
-   * @param roadAddressForPartition A map from link IDs to RoadLink objects,
-   *                                used to enrich each asset with road-specific address data.
-   * @return A sequence of partitions, where each enrichAndPartition is a sequence of assets of type T.
-   */
-  def enrichAndPartition[T <: PieceWiseLinearAsset](assetLinks: Seq[T], roadAddressForPartition: Map[String, RoadLink]): Seq[Seq[T]] = {
-
-    val enrichedLinks: Seq[PieceWiseLinearAsset] = assetLinks.map {
-      case pwla: PieceWiseLinearAsset =>
-        val roadLinkOption = roadAddressForPartition.get(pwla.linkId)
-        val additionalAttributes: Map[String, Any] = roadLinkOption match {
-          case Some(roadLink) =>
-            val attrs = roadLink.attributes
-            Map(
-              "ROADNUMBER" -> attrs.get("ROADNUMBER"),
-              "ROADNAME_FI" -> attrs.get("ROADNAME_FI"),
-              "ROADNAME_SE" -> attrs.get("ROADNAME_SE"),
-              "ROADPARTNUMBER" -> attrs.get("ROADPARTNUMBER")
-            ).collect { case (key, Some(value)) => key -> Some(value) }
-          case None => Map.empty
-        }
-
-        val mergedAttributes = pwla.attributes ++ additionalAttributes
-
-        pwla.copy(attributes = mergedAttributes)
-    }
-    partition(enrichedLinks).asInstanceOf[Seq[Seq[T]]]
-  }
-
-  /**
    * Partitions a sequence of linear assets into clusters based on shared road-related attributes.
    * Partitioned groups are activated together on the map when a link in the group is clicked.
    *

--- a/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitionerSpec.scala
+++ b/digiroad2-geo/src/test/scala/fi/liikennevirasto/digiroad2/linearasset/LinearAssetPartitionerSpec.scala
@@ -36,15 +36,11 @@ class LinearAssetPartitionerSpec extends FunSuite with Matchers {
     val prohibitionAssets = Seq(
       linearAsset(1, linkId1,
         Some(Prohibitions(Seq(ProhibitionValue(1, Set(ValidityPeriod(1, 2, ValidityPeriodDayOfWeek.Weekday, 0, 0)), Set.empty)))),
-        Seq(Point(0, 0), Point(10, 0)), 190),
+        Seq(Point(0, 0), Point(10, 0)), 190, Map("ROADNUMBER" -> Some(1L))),
       linearAsset(2, linkId2,
         Some(Prohibitions(Seq(ProhibitionValue(1, Set(ValidityPeriod(1, 3, ValidityPeriodDayOfWeek.Weekday, 0, 0)), Set.empty)))),
-        Seq(Point(10, 0), Point(20, 0)), 190))
-
-    val links = Map(
-      linkId1 -> roadLinkForAsset(Left(1)),
-      linkId2 -> roadLinkForAsset(Left(1)))
-    val groupedLinks = LinearAssetPartitioner.enrichAndPartition(prohibitionAssets, links)
+        Seq(Point(10, 0), Point(20, 0)), 190, Map("ROADNUMBER" -> Some(1L))))
+    val groupedLinks = LinearAssetPartitioner.partition(prohibitionAssets)
     groupedLinks should have size 2
     groupedLinks(0) should have size 1
     groupedLinks(1) should have size 1
@@ -52,12 +48,9 @@ class LinearAssetPartitionerSpec extends FunSuite with Matchers {
 
   test("groups assets with equal prohibition validity periods") {
     val prohibitionAssets = Seq(
-      linearAsset(1, linkId1, Some(Prohibitions(Seq(ProhibitionValue(1, Set(ValidityPeriod(1, 3, ValidityPeriodDayOfWeek.Weekday, 0, 0)), Set.empty)))), Seq(Point(1.0, 0.0), Point(2.0, 0.0)),190, Map(), AdministrativeClass.apply("State")),
-      linearAsset(2, linkId2, Some(Prohibitions(Seq(ProhibitionValue(1, Set(ValidityPeriod(1, 3, ValidityPeriodDayOfWeek.Weekday, 0, 0)), Set.empty)))), Seq(Point(2.0, 0.0), Point(3.0, 0.0)),190, Map(), AdministrativeClass.apply("State")))
-    val links = Map(
-      linkId1 -> roadLinkForAsset(Left(1)),
-      linkId2 -> roadLinkForAsset(Left(1)))
-    val groupedLinks = LinearAssetPartitioner.enrichAndPartition(prohibitionAssets, links)
+      linearAsset(1, linkId1, Some(Prohibitions(Seq(ProhibitionValue(1, Set(ValidityPeriod(1, 3, ValidityPeriodDayOfWeek.Weekday, 0, 0)), Set.empty)))), Seq(Point(1.0, 0.0), Point(2.0, 0.0)),190, Map("ROADNUMBER" -> Some(1L)), AdministrativeClass.apply("State")),
+      linearAsset(2, linkId2, Some(Prohibitions(Seq(ProhibitionValue(1, Set(ValidityPeriod(1, 3, ValidityPeriodDayOfWeek.Weekday, 0, 0)), Set.empty)))), Seq(Point(2.0, 0.0), Point(3.0, 0.0)),190, Map("ROADNUMBER" -> Some(1L)), AdministrativeClass.apply("State")))
+    val groupedLinks = LinearAssetPartitioner.partition(prohibitionAssets)
     groupedLinks should have size 1
     groupedLinks(0) should have size 2
   }

--- a/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
+++ b/digiroad2-oracle/src/main/scala/fi/liikennevirasto/digiroad2/service/linearasset/SpeedLimitService.scala
@@ -129,7 +129,7 @@ class SpeedLimitService(eventbus: DigiroadEventBus, roadLinkService: RoadLinkSer
   def getHistory(bounds: BoundingRectangle, municipalities: Set[Int]): Seq[Seq[PieceWiseLinearAsset]] = {
     val roadLinks = roadLinkService.getRoadLinksHistory(bounds, municipalities)
     val filledTopology = getByRoadLinks(SpeedLimitAsset.typeId, roadLinks, true, true, {roadLinkFilter: RoadLink => roadLinkFilter.isCarTrafficRoad})
-    LinearAssetPartitioner.enrichAndPartition(filledTopology, roadLinks.groupBy(_.linkId).mapValues(_.head))
+    LinearAssetPartitioner.partition(filledTopology)
   }
 
   /**


### PR DESCRIPTION
Refaktoroidaan partitioneriin tulevien assettien rikastaminen osoitetiedoilla olemassa olevalla enrichLinearAssetAttributes funktiolla, partitionerfunktiossa rikastamisen sijaan.