### PR TITLE
DROTH-4344 remove hard coded api key

### DIFF
--- a/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
+++ b/digiroad2-api-oth/src/main/scala/fi/liikennevirasto/digiroad2/Digiroad2Api.scala
@@ -281,16 +281,16 @@ class Digiroad2Api(val roadLinkService: RoadLinkService,
   }
 
   get("/masstransitstopgapiurl"){
-    val lat =params.get("latitude").getOrElse(halt(BadRequest("Bad coordinates")))
-    val lon =params.get("longitude").getOrElse(halt(BadRequest("Bad coordinates")))
-    val heading =params.get("heading").getOrElse(halt(BadRequest("Bad coordinates")))
-    val oldapikeyurl=s"//maps.googleapis.com/maps/api/streetview?key=AIzaSyBh5EvtzXZ1vVLLyJ4kxKhVRhNAq-_eobY&size=360x180&location=$lat,$lon&fov=110&heading=$heading&pitch=-10&sensor=false'"
+    val lat = params.get("latitude").getOrElse(halt(BadRequest("Bad coordinates")))
+    val lon = params.get("longitude").getOrElse(halt(BadRequest("Bad coordinates")))
+    val heading = params.get("heading").getOrElse(halt(BadRequest("Bad coordinates")))
     try {
       val urlsigner = new GMapUrlSigner()
       Map("gmapiurl" -> urlsigner.signRequest(lat,lon,heading))
     } catch
       {
-        case e: Exception => Map("gmapiurl" -> oldapikeyurl)
+        case illegalArgument: IllegalArgumentException => logger.error(illegalArgument.getMessage)
+        case e: Exception => logger.error("Url signature failed." + e.getMessage)
       }
   }
 


### PR DESCRIPTION
Poistetaan apikey koodista. IllegalArgument tulee, jos signaturen muodostamisessa ei ole ollenkaan id:tä tai cryptokeytä.